### PR TITLE
Generate VirtualFileIds for i18n plugin test

### DIFF
--- a/packages/components/dev/viteI18nPlugin.test.ts
+++ b/packages/components/dev/viteI18nPlugin.test.ts
@@ -10,7 +10,11 @@ import { HmrContext, ViteDevServer } from "vite";
 import crypt from "crypto";
 
 const generateVirtualFileId = (filePath: string): string => {
-  return crypt.createHash("md5").update(path.resolve(filePath)).digest("hex");
+  const virtualFileId = crypt
+    .createHash("md5")
+    .update(path.resolve(filePath))
+    .digest("hex");
+  return `${moduleId}${virtualFileId}`;
 };
 
 describe("vite i18n plugin", () => {
@@ -31,7 +35,7 @@ describe("vite i18n plugin", () => {
       expect(resolve).toBeDefined();
       expect(typeof resolve).toBe("object");
       expect(resolve.id).toMatch(
-        `${moduleId}${generateVirtualFileId("./locales/*.locale.json")}`,
+        generateVirtualFileId("./locales/*.locale.json"),
       );
     }
   });
@@ -173,13 +177,13 @@ describe("vite i18n plugin", () => {
       plugin.handleHotUpdate.apply(this, [hmrContext]);
       expect(hmrContext.server.moduleGraph.getModuleById).toBeCalledTimes(3);
       expect(hmrContext.server.moduleGraph.getModuleById).toBeCalledWith(
-        `${moduleId}${generateVirtualFileId("./dev/test/locales/*.locale.json")}`,
+        generateVirtualFileId("./dev/test/locales/*.locale.json"),
       );
       expect(hmrContext.server.moduleGraph.getModuleById).toBeCalledWith(
-        `${moduleId}${generateVirtualFileId("./dev/test/locales/foo.locale.json")}`,
+        generateVirtualFileId("./dev/test/locales/foo.locale.json"),
       );
       expect(hmrContext.server.moduleGraph.getModuleById).toBeCalledWith(
-        `${moduleId}${generateVirtualFileId("./dev/test/locales/bar.locale.json")}`,
+        generateVirtualFileId("./dev/test/locales/bar.locale.json"),
       );
 
       expect(hmrContext.server.reloadModule).toBeCalledTimes(3);

--- a/packages/components/dev/viteI18nPlugin.test.ts
+++ b/packages/components/dev/viteI18nPlugin.test.ts
@@ -7,9 +7,11 @@ import type {
 } from "rollup";
 import path from "path";
 import { HmrContext, ViteDevServer } from "vite";
-import { URL } from "url";
+import crypt from "crypto";
 
-const __dirname = new URL(".", import.meta.url).pathname;
+const generateVirtualFileId = (filePath: string): string => {
+  return crypt.createHash("md5").update(path.resolve(filePath)).digest("hex");
+};
 
 describe("vite i18n plugin", () => {
   test("resolve will return correct id", async () => {
@@ -19,7 +21,7 @@ describe("vite i18n plugin", () => {
     if (plugin.resolveId && typeof plugin.resolveId === "function") {
       const resolve = (await plugin.resolveId.apply({} as PluginContext, [
         "./locales/*.locale.json",
-        "./foo/foo.ts",
+        "./foo.ts",
         {
           isEntry: false,
           attributes: {},
@@ -28,10 +30,9 @@ describe("vite i18n plugin", () => {
 
       expect(resolve).toBeDefined();
       expect(typeof resolve).toBe("object");
-      expect(resolve.id.startsWith("\x00.locale.json@")).toBeTruthy();
-      expect(
-        resolve.id.endsWith("1a1e1818b63c26ce9b92f94ec4c972dd"),
-      ).toBeTruthy();
+      expect(resolve.id).toMatch(
+        `${moduleId}${generateVirtualFileId("./locales/*.locale.json")}`,
+      );
     }
   });
 
@@ -172,13 +173,13 @@ describe("vite i18n plugin", () => {
       plugin.handleHotUpdate.apply(this, [hmrContext]);
       expect(hmrContext.server.moduleGraph.getModuleById).toBeCalledTimes(3);
       expect(hmrContext.server.moduleGraph.getModuleById).toBeCalledWith(
-        `${moduleId}b20c85a80a5c361dbb4a0afdb0674ef1`,
+        `${moduleId}${generateVirtualFileId("./dev/test/locales/*.locale.json")}`,
       );
       expect(hmrContext.server.moduleGraph.getModuleById).toBeCalledWith(
-        `${moduleId}8548eb70fa2e0577ba1853e18a3a8d29`,
+        `${moduleId}${generateVirtualFileId("./dev/test/locales/foo.locale.json")}`,
       );
       expect(hmrContext.server.moduleGraph.getModuleById).toBeCalledWith(
-        `${moduleId}c792203dcbe4dbc5e33cf1ca0446134d`,
+        `${moduleId}${generateVirtualFileId("./dev/test/locales/bar.locale.json")}`,
       );
 
       expect(hmrContext.server.reloadModule).toBeCalledTimes(3);

--- a/packages/components/dev/viteI18nPlugin.test.ts
+++ b/packages/components/dev/viteI18nPlugin.test.ts
@@ -1,4 +1,4 @@
-import plugin, { moduleId } from "./viteI18nPlugin";
+import plugin, { generateVirtualFileId, moduleId } from "./viteI18nPlugin";
 import { test, describe, expect, vi } from "vitest";
 import type {
   PartialResolvedId,
@@ -7,15 +7,6 @@ import type {
 } from "rollup";
 import path from "path";
 import { HmrContext, ViteDevServer } from "vite";
-import crypt from "crypto";
-
-const generateVirtualFileId = (filePath: string): string => {
-  const virtualFileId = crypt
-    .createHash("md5")
-    .update(path.resolve(filePath))
-    .digest("hex");
-  return `${moduleId}${virtualFileId}`;
-};
 
 describe("vite i18n plugin", () => {
   test("resolve will return correct id", async () => {

--- a/packages/components/dev/viteI18nPlugin.test.ts
+++ b/packages/components/dev/viteI18nPlugin.test.ts
@@ -11,7 +11,7 @@ import { URL } from "url";
 
 const __dirname = new URL(".", import.meta.url).pathname;
 
-describe.skip("vite i18n plugin", () => {
+describe("vite i18n plugin", () => {
   test("resolve will return correct id", async () => {
     expect(plugin.resolveId).toBeDefined();
     expect(typeof plugin.resolveId).toBe("function");

--- a/packages/components/dev/viteI18nPlugin.ts
+++ b/packages/components/dev/viteI18nPlugin.ts
@@ -70,7 +70,6 @@ export default {
 
       return {
         id: generateVirtualFileId(resolvedTranslationPath),
-        shouldTransformCachedModule: true,
         meta: {
           id,
           importer,

--- a/packages/components/dev/viteI18nPlugin.ts
+++ b/packages/components/dev/viteI18nPlugin.ts
@@ -11,6 +11,14 @@ const importPathInfosRegEx = new RegExp(
   `^(.+/${localeDirectory})/((.+)${moduleSuffix.replaceAll(".", "\\.")})$`,
 );
 
+export const generateVirtualFileId = (filePath: string): string => {
+  const virtualFileId = crypt
+    .createHash("md5")
+    .update(path.resolve(filePath))
+    .digest("hex");
+  return `${moduleId}${virtualFileId}`;
+};
+
 const generateComponentIntlContent = (
   filePath: string,
   languageKey: string,
@@ -45,12 +53,9 @@ export default {
         .concat([`*${moduleSuffix}`])
         .forEach((file: string) => {
           const filePath = path.join(localDirectory, file);
-          const virtualFileId = crypt
-            .createHash("md5")
-            .update(filePath)
-            .digest("hex");
-          const id = `${moduleId}${virtualFileId}`;
-          const module = server.moduleGraph.getModuleById(id);
+          const module = server.moduleGraph.getModuleById(
+            generateVirtualFileId(filePath),
+          );
           if (module) {
             server.reloadModule(module);
           }
@@ -62,13 +67,9 @@ export default {
     if (match && importer) {
       const importerDirectory = path.dirname(importer);
       const resolvedTranslationPath = path.resolve(importerDirectory, id);
-      const virtualFileId = crypt
-        .createHash("md5")
-        .update(resolvedTranslationPath)
-        .digest("hex");
 
       return {
-        id: moduleId + virtualFileId,
+        id: generateVirtualFileId(resolvedTranslationPath),
         shouldTransformCachedModule: true,
         meta: {
           id,


### PR DESCRIPTION
- enables the prev skipped test for the i18n plugin
- generates virtual files ids for the test
- don't transform translation files again on cache hit