### PR TITLE
refactor(NumberField): use delayed onChange

### DIFF
--- a/packages/components/src/components/NumberField/NumberField.tsx
+++ b/packages/components/src/components/NumberField/NumberField.tsx
@@ -22,7 +22,7 @@ export interface NumberFieldProps
     FlowComponentProps {}
 
 export const NumberField = flowComponent("NumberField", (props) => {
-  const { children, className, ref, ...rest } = props;
+  const { children, className, ref, onChange, ...rest } = props;
 
   const rootClassName = clsx(formFieldStyles.formField, className);
 
@@ -39,9 +39,29 @@ export const NumberField = flowComponent("NumberField", (props) => {
     },
   };
 
+  const handleOnChange = (value: number) => {
+    /**
+     * When entering numbers via keyboard, the NumberField onChange event is
+     * triggered onBlur. When clicking on another form element directly after
+     * changing an invalid NumberField from invalid to valid (via keyboard), the
+     * users click may not hit the desired target, because the removed
+     * validation message may cause a layout-shift. To circumvent this pitfall,
+     * the onChange event is delayed for a little time.
+     */
+    setTimeout(() => {
+      if (onChange) {
+        onChange(value);
+      }
+    }, 150);
+  };
+
   return (
     <ClearPropsContext>
-      <Aria.NumberField {...rest} className={rootClassName}>
+      <Aria.NumberField
+        {...rest}
+        className={rootClassName}
+        onChange={handleOnChange}
+      >
         <Aria.Group className={styles.group}>
           <Button
             slot="decrement"


### PR DESCRIPTION
When entering numbers via keyboard, the NumberField onChange event is triggered onBlur. When clicking on another form element directly after changing an invalid NumberField from invalid to valid (via keyboard), the users click may not hit the desired target, because the removed validation message may cause a layout-shift.