### PR TITLE
Fix modal accessibility

### DIFF
--- a/packages/components/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/components/src/components/ButtonGroup/ButtonGroup.tsx
@@ -1,4 +1,4 @@
-import type { ComponentProps, FC, PropsWithChildren } from "react";
+import type { ComponentProps, PropsWithChildren } from "react";
 import React from "react";
 import styles from "./ButtonGroup.module.scss";
 import type { PropsContext } from "@/lib/propsContext";
@@ -9,11 +9,14 @@ import {
   useProps,
 } from "@/lib/propsContext";
 import clsx from "clsx";
+import type { FlowComponentProps } from "@/lib/componentFactory/flowComponent";
+import { flowComponent } from "@/lib/componentFactory/flowComponent";
 
 export interface ButtonGroupProps
-  extends PropsWithChildren<ComponentProps<"div">> {}
+  extends PropsWithChildren<ComponentProps<"div">>,
+    FlowComponentProps {}
 
-export const ButtonGroup: FC<ButtonGroupProps> = (props) => {
+export const ButtonGroup = flowComponent("ButtonGroup", (props) => {
   const { children, className, ...rest } = useProps("ButtonGroup", props);
 
   const rootClassName = clsx(styles.buttonGroup, className);
@@ -35,6 +38,6 @@ export const ButtonGroup: FC<ButtonGroupProps> = (props) => {
       </div>
     </ClearPropsContext>
   );
-};
+});
 
 export default ButtonGroup;

--- a/packages/components/src/components/Modal/Modal.tsx
+++ b/packages/components/src/components/Modal/Modal.tsx
@@ -47,16 +47,15 @@ export const Modal: FC<ModalProps> = (props) => {
 
   const propsContext: PropsContext = {
     Content: {
-      tunnelId: "content",
       elementType: React.Fragment,
     },
     Heading: {
       level: 2,
-      tunnelId: "title",
       slot: "title",
     },
     ButtonGroup: {
       className: styles.buttonGroup,
+      tunnelId: "buttons",
     },
   };
 
@@ -73,11 +72,8 @@ export const Modal: FC<ModalProps> = (props) => {
           <OverlayContextProvider value={state}>
             <PropsContextProvider props={propsContext}>
               <TunnelProvider>
-                <div className={styles.content}>
-                  <TunnelExit id="title" />
-                  <TunnelExit id="content" />
-                </div>
-                {children}
+                <div className={styles.content}>{children}</div>
+                <TunnelExit id="buttons" />
               </TunnelProvider>
             </PropsContextProvider>
           </OverlayContextProvider>


### PR DESCRIPTION
Wenn sich die Modal Heading im Tunnel befindet erhält sie die Id nicht, die sie braucht um als Label für das Modal verwendet zu werden (labelled-by)