### PR TITLE
fix: require at least node version 20.11 to use icon generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "license": "MIT",
   "engines": {
-    "node": "^20.10.0"
+    "node": ">=20.11"
   },
   "scripts": {
     "all": "nx run-many --targets=\"$@\"",


### PR DESCRIPTION
closes #376 