### PR TITLE
fix(Actions): fix exclude param on build step in publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,7 @@ jobs:
         run: git branch --track main origin/main
 
       - name: Build 🔨
-        run: yarn build --exclude @mittwald/flow-docs
+        run: yarn build --exclude @mittwald/flow-documentation
 
       - name: Version and publish 🚀
         run: |


### PR DESCRIPTION
The default package name is overwritten here https://github.com/mittwald/flow/blob/main/packages/docs/package.json#L2, so `@mittwald/flow-docs` doesn't exclude the documentation package during the build process.