### PR TITLE
docs(GettingStarted): fix typos

### DIFF
--- a/packages/docs/src/content/01-get-started/installation/index.mdx
+++ b/packages/docs/src/content/01-get-started/installation/index.mdx
@@ -5,9 +5,9 @@ description: Willkommen in der Flow Dokumentation!
 <InlineAlert>
   <Heading>Hinweis zu frühem Entwicklungsstand und Stabilität</Heading>
   <Content>
-    Dieses Projekt befindet sich in einer **frühen Entwicklungsphase** weswegen
+    Dieses Projekt befindet sich in einer **frühen Entwicklungsphase**, weswegen
     wir keine Garantie zur Stabilität bieten können. Du kannst dieses Projekt
-    dennoch gerne ausprobieren, verlasse dich aber bitte nicht darauf das die
+    dennoch gerne ausprobieren, verlasse dich aber bitte nicht darauf, dass die
     aktuellen Inhalte in dieser Form bestehen bleiben. Wir freuen uns über jedes
     Feedback zum aktuellen Entwicklungsstand!
   </Content>

--- a/packages/docs/src/content/01-get-started/stylesheet/index.mdx
+++ b/packages/docs/src/content/01-get-started/stylesheet/index.mdx
@@ -33,13 +33,13 @@ import "@mittwald/flow-stylesheet/css";
 
 ## Anwendung des Stylesheets
 
-Um anfangen zu können solltest du verstehen wie die Klassennamen strukturiert
+Um anfangen zu können, solltest du verstehen, wie die Klassennamen strukturiert
 sind. Die im Stylesheet bereitgestellten Klassennamen folgen einem konsistenten,
-Komponenten basiertem und leicht zu verstehendem Schema.
+Komponentenbasierten und leicht zu verstehendem Schema.
 
 ---
 
-### Generelle Klassennamen Auszeichnungen
+### Generelle Klassennamen-Auszeichnungen
 
 Alle Klassennamen sind in Lowercase geschrieben und benutzen `-` um Wörter zu
 trennen und `--` um logische Abschnitte zu unterteilen.
@@ -94,11 +94,11 @@ Hier ein paar Beispiele um die diese Anforderung zu verdeutlichen:
 
 #### In einer Komposition verwendete Komponenten
 
-Es ist gängige Praxis größere Komponenten aus bereits bestehenden kleineren
+Es ist gängige Praxis, größere Komponenten aus bereits bestehenden kleineren
 Komponenten zusammenzusetzen. Der InlineAlert besteht beispielsweise aus einem
 Icon, einer Heading und optionalem Inhalt. Die verwendeten Komponenten müssen
 ihren Basis-Klassennamen für das grundsätzliche Styling erhalten (`flow--icon`),
-sowie den spezialisierten Klassennamen (`flow--inline-alert--status-icon`) um
+sowie den spezialisierten Klassennamen (`flow--inline-alert--status-icon`), um
 spezifische Styles des Inline Alerts zu erhalten.
 
 <LiveCodeEditor example="composition" />


### PR DESCRIPTION
closes #509 