### PR TITLE
docs: minor adjustment

### DIFF
--- a/packages/docs/src/content/03-components/overlays/modal/guidelines.mdx
+++ b/packages/docs/src/content/03-components/overlays/modal/guidelines.mdx
@@ -62,7 +62,7 @@ erfordern, da ...
 
 - manche Modals rein informativen Inhalt enthalten.
 - einige Inhalte sich unmittelbar selber speichern und zu direkten Änderungen
-  führen (z.B. Einstellungen in einem OffCanvas).
+  führen (z.B. Einstellungen in einem OffCanvas mittels [Switch](/03-components/form-controls/switch)).
 - bestimmte Eingaben sich automatisch selber validieren (z.B.
   2-FA-Authentifikation) und das Modal schließen.
 


### PR DESCRIPTION
A clarification was added stating that settings in an offcanvas only need no confirmation when made using a switch.