### PR TITLE
refactor: unify "outline" naming

### DIFF
--- a/packages/components/src/components/Accordion/Accordion.tsx
+++ b/packages/components/src/components/Accordion/Accordion.tsx
@@ -12,7 +12,7 @@ import { Activity } from "@/components/Activity";
 export interface AccordionProps
   extends PropsWithChildren<ComponentProps<"div">> {
   defaultExpanded?: boolean;
-  variant?: "default" | "outlined";
+  variant?: "default" | "outline";
 }
 
 export const Accordion: FC<AccordionProps> = (props) => {
@@ -29,7 +29,7 @@ export const Accordion: FC<AccordionProps> = (props) => {
     styles.accordion,
     expanded && styles.expanded,
     className,
-    variant === "outlined" && styles.outline,
+    variant === "outline" && styles.outline,
   );
 
   const headerId = useId();

--- a/packages/components/src/components/Accordion/stories/Default.stories.tsx
+++ b/packages/components/src/components/Accordion/stories/Default.stories.tsx
@@ -29,7 +29,7 @@ export const DefaultExpanded: Story = {
 };
 
 export const OutlineVariant: Story = {
-  args: { variant: "outlined" },
+  args: { variant: "outline" },
 };
 
 export const WithLabel: Story = {

--- a/packages/docs/src/content/03-components/structure/accordion/examples/outline.tsx
+++ b/packages/docs/src/content/03-components/structure/accordion/examples/outline.tsx
@@ -2,7 +2,7 @@ import Accordion from "@mittwald/flow-react-components/Accordion";
 import Content from "@mittwald/flow-react-components/Content";
 import Heading from "@mittwald/flow-react-components/Heading";
 
-<Accordion variant="outlined">
+<Accordion variant="outline">
   <Heading>Accordion Titel</Heading>
   <Content>Inhalt des Accordions</Content>
 </Accordion>;

--- a/packages/docs/src/content/03-components/structure/accordion/overview.mdx
+++ b/packages/docs/src/content/03-components/structure/accordion/overview.mdx
@@ -12,7 +12,7 @@
 
 # Outline Variant
 
-<LiveCodeEditor example="outlined" />
+<LiveCodeEditor example="outline" />
 
 ---
 


### PR DESCRIPTION
On some occasions we called the "outline" variant "outlined", other times we stuck with "outline".
This PR unifies the naming to "outline".