### PR TITLE
fix(Notification): onClose handler in ControlledNotification

### DIFF
--- a/packages/components/src/components/NotificationProvider/ControlledNotification.tsx
+++ b/packages/components/src/components/NotificationProvider/ControlledNotification.tsx
@@ -22,6 +22,7 @@ export const ControlledNotification: FC<Props> = (props) => {
     },
     onClose: () => {
       controller.remove(notification.meta.id);
+      notification.element.props.onClose?.();
     },
     onFocus: () => {
       notification.meta.autoCloseTimer.pause();


### PR DESCRIPTION
Without this change the onClose handler from the Notification Component it self never gets called if the Notification comes from the NotificationProvider because the NotificationProvider "wraps" the Notification in an ControlledNotification Component which overwrites the onClose functionality of the "raw" Notification Component