### PR TITLE
docs: removed "dont-box"

### DIFF
--- a/packages/docs/src/content/03-components/form-controls/text-field/guidelines.mdx
+++ b/packages/docs/src/content/03-components/form-controls/text-field/guidelines.mdx
@@ -54,16 +54,10 @@ besitzen. Ein gutes Label vermittelt alle notwendigen Informationen, um das Text
 korrekt auszufüllen. Außerdem sollte es knapp (max. 2 Wörter), präzise und weder 
 versteckt noch auspunktiert sein.
 
-<DoAndDont>
-  <Dont example="withoutLabel">
-    Das TextField darf nie ohne ein zugehöriges Label verwendet werden.
-
-  </Dont>
   <Do example="default">
     Verwende ein kurzes, präzises Label, das essentielle Eingabeanforderungen kommuniziert.
 
   </Do>
-</DoAndDont>
 
 ---
 


### PR DESCRIPTION
Removed dont box below label for further clarification that a label is no longer a necessity