### PR TITLE
Feature/text wrap

### DIFF
--- a/packages/components/src/components/Heading/Heading.module.scss
+++ b/packages/components/src/components/Heading/Heading.module.scss
@@ -69,6 +69,13 @@
   @include size("l");
   @include size("xl");
   @include size("xxl");
+
+  &:where(.wrap-wrap) {
+    text-wrap: wrap;
+  }
+  &:where(.wrap-balance) {
+    text-wrap: balance;
+  }
 }
 
 @media (max-width: 550px) {

--- a/packages/components/src/components/Heading/Heading.tsx
+++ b/packages/components/src/components/Heading/Heading.tsx
@@ -15,6 +15,8 @@ export interface HeadingProps extends Aria.HeadingProps, FlowComponentProps {
   size?: "xs" | "s" | "m" | "l" | "xl" | "xxl";
   /** The color of the heading. @default "primary" */
   color?: "primary" | "dark" | "light";
+  /** The text-wrap property of the text. @default undefined */
+  wrap?: "wrap" | "balance";
 }
 
 /**
@@ -27,6 +29,7 @@ export const Heading = flowComponent("Heading", (props) => {
     className,
     level = 2,
     color = "primary",
+    wrap,
     size,
     ref,
     ...rest
@@ -36,6 +39,7 @@ export const Heading = flowComponent("Heading", (props) => {
     styles.heading,
     size && styles[size],
     styles[color],
+    wrap && styles[`wrap-${wrap}`],
     className,
   );
 

--- a/packages/components/src/components/Heading/stories/Default.stories.tsx
+++ b/packages/components/src/components/Heading/stories/Default.stories.tsx
@@ -6,6 +6,7 @@ import {
   storyBackgroundDark,
   storyBackgroundLight,
 } from "@/lib/dev/storyBackgrounds";
+import { Section } from "@/components/Section";
 
 const meta: Meta<typeof Heading> = {
   title: "Content/Heading",
@@ -66,4 +67,16 @@ export const Light: Story = {
   parameters: {
     backgrounds: storyBackgroundDark,
   },
+};
+
+export const Wrap: Story = {
+  render: (props) => (
+    <Section>
+      <Heading {...props}>Personal Information of the current user</Heading>
+      <Heading {...props} wrap="balance">
+        Personal Information of the current user
+      </Heading>
+    </Section>
+  ),
+  parameters: { viewport: { defaultViewport: "mobile2" } },
 };

--- a/packages/components/src/components/Text/Text.module.scss
+++ b/packages/components/src/components/Text/Text.module.scss
@@ -42,4 +42,14 @@
   &:where(.align-end) {
     text-align: end;
   }
+
+  &:where(.wrap-wrap) {
+    text-wrap: wrap;
+  }
+  &:where(.wrap-balance) {
+    text-wrap: balance;
+  }
+  &:where(.wrap-pretty) {
+    text-wrap: pretty;
+  }
 }

--- a/packages/components/src/components/Text/Text.tsx
+++ b/packages/components/src/components/Text/Text.tsx
@@ -24,6 +24,8 @@ export interface TextProps
   color?: "light" | "dark";
   /* The alignment of the text. @default "start" */
   align?: "start" | "end" | "center";
+  /* The text-wrap property of the text. @default undefined */
+  wrap?: "wrap" | "balance" | "pretty";
 }
 
 /**
@@ -39,6 +41,7 @@ export const Text = flowComponent("Text", (props) => {
     ref,
     color,
     align = "start",
+    wrap,
     ...rest
   } = props;
 
@@ -46,6 +49,7 @@ export const Text = flowComponent("Text", (props) => {
     styles.text,
     color && styles[color],
     align && styles[`align-${align}`],
+    wrap && styles[`wrap-${wrap}`],
     className,
   );
 

--- a/packages/components/src/components/Text/stories/Default.stories.tsx
+++ b/packages/components/src/components/Text/stories/Default.stories.tsx
@@ -6,6 +6,7 @@ import {
   storyBackgroundDark,
   storyBackgroundLight,
 } from "@/lib/dev/storyBackgrounds";
+import { InlineCode } from "@/components/InlineCode";
 
 const meta: Meta<typeof Text> = {
   title: "Content/Text",
@@ -90,3 +91,28 @@ export const Light: Story = {
 };
 
 export const AlignEnd: Story = { args: { align: "end" } };
+
+export const WrapBalance: Story = {
+  render: (props) => (
+    <Section>
+      <Text>
+        <strong>
+          Without specified <InlineCode>wrap</InlineCode>:
+        </strong>
+      </Text>
+      <Text {...props} align="center">
+        This is a centered text in a small container so the text is wrapped.
+      </Text>
+      <Text>
+        <strong>
+          With <InlineCode>wrap: balance</InlineCode>:
+        </strong>
+      </Text>
+      <Text {...props} align="center" wrap="balance">
+        This is a centered text in a small container so the text is wrapped.
+      </Text>
+    </Section>
+  ),
+
+  parameters: { viewport: { defaultViewport: "mobile2" } },
+};

--- a/packages/remote-elements/src/auto-generated/RemoteFieldDescriptionElement.ts
+++ b/packages/remote-elements/src/auto-generated/RemoteFieldDescriptionElement.ts
@@ -119,6 +119,7 @@ export class RemoteFieldDescriptionElement extends FlowRemoteElement<RemoteField
       typeof: {},
       unselectable: {},
       vocab: {},
+      wrap: {},
     };
   }
 

--- a/packages/remote-elements/src/auto-generated/RemoteHeadingElement.ts
+++ b/packages/remote-elements/src/auto-generated/RemoteHeadingElement.ts
@@ -118,6 +118,7 @@ export class RemoteHeadingElement extends FlowRemoteElement<RemoteHeadingElement
       typeof: {},
       unselectable: {},
       vocab: {},
+      wrap: {},
     };
   }
 

--- a/packages/remote-elements/src/auto-generated/RemoteTextElement.ts
+++ b/packages/remote-elements/src/auto-generated/RemoteTextElement.ts
@@ -119,6 +119,7 @@ export class RemoteTextElement extends FlowRemoteElement<RemoteTextElementProps>
       typeof: {},
       unselectable: {},
       vocab: {},
+      wrap: {},
     };
   }
 


### PR DESCRIPTION
Adds support for [CSS property `text-wrap`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-wrap#values) to `Text` and `Heading` component. Use cases for this are described in the Issue https://github.com/mittwald/flow/issues/1437

The follow values are not allowed:
* `stable`: same behavior as wrap, except that when the user is editing the content. Since this scenario is not used in flow, it’s not required.
* `pretty`: allowed for `Text`, disallowed for `Heading`. This is intended for body copy by design, so not necessary for headings. 
* `nowrap`: disallowed in favour of a `Elipsis` component.