### PR TITLE
docs(List): Improve checkbox example

### DIFF
--- a/apps/docs/src/content/03-components/structure/list/examples/checkbox.tsx
+++ b/apps/docs/src/content/03-components/structure/list/examples/checkbox.tsx
@@ -10,17 +10,52 @@ import {
   type Domain,
   domains,
 } from "@/content/03-components/structure/list/examples/domainApi";
+import { useState } from "react";
 
 export default () => {
   const List = typedList<Domain>();
 
+  const [selectedDomains, setSelectedDomains] = useState<
+    Domain[]
+  >([]);
+
+  const onSelected = (
+    domain: Domain,
+    selected: boolean,
+  ) => {
+    if (selected) {
+      setSelectedDomains((prev) => [...prev, domain]);
+    } else {
+      setSelectedDomains((prev) =>
+        prev.filter((d) => d.id !== domain.id),
+      );
+    }
+  };
+
+  const isSelected = (domain: Domain) => {
+    return (
+      selectedDomains.find((d) => d.id === domain.id) !==
+      undefined
+    );
+  };
+
   return (
-    <List.List batchSize={4} aria-label="Domains">
+    <List.List
+      batchSize={4}
+      aria-label="Domains"
+      onAction={(domain) => {
+        onSelected(domain, !isSelected(domain));
+      }}
+    >
       <List.StaticData data={domains} />
       <List.Item showTiles>
         {(domain) => (
           <List.ItemView>
             <Checkbox
+              isSelected={isSelected(domain)}
+              onChange={(value) =>
+                onSelected(domain, value)
+              }
               aria-label={`${domain.hostname} auswählen`}
             />
             <Avatar>
@@ -35,7 +70,12 @@ export default () => {
       <List.Table>
         <List.TableHeader>
           <List.TableColumn>
-            <Checkbox aria-label="Alle auswählen" />
+            <Checkbox
+              aria-label="Alle auswählen"
+              onChange={(v) =>
+                setSelectedDomains(v ? domains : [])
+              }
+            />
           </List.TableColumn>
           <List.TableColumn>Domain</List.TableColumn>
         </List.TableHeader>
@@ -44,6 +84,10 @@ export default () => {
             <List.TableCell>
               {(domain) => (
                 <Checkbox
+                  isSelected={isSelected(domain)}
+                  onChange={(value) =>
+                    onSelected(domain, value)
+                  }
                   aria-label={`${domain.hostname} auswählen`}
                 />
               )}

--- a/apps/docs/src/content/03-components/structure/list/overview.mdx
+++ b/apps/docs/src/content/03-components/structure/list/overview.mdx
@@ -97,9 +97,11 @@ angepasst werden.
 
 ## Mit Checkboxen
 
-Checkboxen die in einem ListItem platziert werden, werden automatisch vorne
+Checkboxen, die in einem ListItem platziert werden, werden automatisch vorne
 angeordnet. Die Funktionalität der Checkbox wird nicht von der Liste gesteuert
-und kann individuell implementiert werden.
+und muss individuell implementiert werden. Achte bei der Implementierung jedoch
+darauf, dass die gesamte Zeile genutzt werden kann, um das Element zu markieren.
+Nutze dafür `onAction` der List.
 
 <LiveCodeEditor example="checkbox" editorCollapsed />
 


### PR DESCRIPTION
UX-wise the complete row of a list item should be the click action for the checkbox in a list. Improve the example to make this clear and show how this could be implemented.