### PR TITLE
fix(RemoteRenderer): Set HostPathname on ready

### DIFF
--- a/packages/remote-core/src/connection/types.ts
+++ b/packages/remote-core/src/connection/types.ts
@@ -26,6 +26,7 @@ export type RemoteToHostConnection = ThreadNestedIframe<
 export interface HostToRemoteConnection {
   version: Version;
   thread: ThreadIframe<RemoteExports, HostExports>;
+  updateHostPathname: (hostPathname?: string) => void;
 }
 
 export enum Version {

--- a/packages/remote-react-renderer/src/hooks/useUpdateHostPathnameOnRemote.ts
+++ b/packages/remote-react-renderer/src/hooks/useUpdateHostPathnameOnRemote.ts
@@ -1,7 +1,4 @@
-import {
-  Version,
-  type HostToRemoteConnection,
-} from "@mittwald/flow-remote-core";
+import { type HostToRemoteConnection } from "@mittwald/flow-remote-core";
 import { useLayoutEffect } from "react";
 
 /** Updates the host pathname in the remote connection. */
@@ -14,9 +11,7 @@ export const useUpdateHostPathnameOnRemote = (
       return;
     }
 
-    const { thread, version } = connection;
-    if (version >= Version.v2) {
-      thread.imports.setPathname(hostPathname);
-    }
+    const { updateHostPathname } = connection;
+    updateHostPathname(hostPathname);
   }, [hostPathname, connection]);
 };


### PR DESCRIPTION
- [x] removes render subscription after render check is done
- [x] publishes the HostPathName after first ready connection