### PR TITLE
docs: Update SearchField guidelines.mdx

### DIFF
--- a/apps/docs/src/content/03-components/form-controls/search-field/guidelines.mdx
+++ b/apps/docs/src/content/03-components/form-controls/search-field/guidelines.mdx
@@ -7,7 +7,8 @@ Ein SearchField unterstützt die effiziente Navigation und hilft dabei, große I
  Achte bei der Verwendung eines SearchFields darauf, dass...
 
 - visuelles Feedback bei Ladezuständen oder Fehlern (z. B. keine Suchergebnisse gefunden) gegeben wird.
-- die Eingabe des Users aktiv bestätigt werden muss – zum Beispiel über ein Formular ([Form (React Hook Form)](/03-components/form-controls/form-react-hook-form)) und einen [Button](/03-components/actions/button).
+- die Component selbst keine Suchlogik mitbringt und daher mit einer Logik- oder Formular-Component wie [Form (React Hook Form)](/03-components/form-controls/form-react-hook-form) kombiniert werden sollte.
+- sie leicht zugänglich und gut sichtbar positioniert ist, vorzugsweise an Stellen, an denen User eine Suche erwarten.
 
  ## Verwendung
 
@@ -15,3 +16,4 @@ Ein SearchField unterstützt die effiziente Navigation und hilft dabei, große I
 
 - große Datenmengen (z. B. in der [List](/03-components/structure/list)) gezielt und effizient zu durchsuchen.
 - Usern das schnelle Auffinden von Inhalten, Produkten oder Daten zu ermöglichen.
+- die Navigation innerhalb komplexer Anwendungen oder Websites zu unterstützen.

--- a/apps/docs/src/content/03-components/form-controls/search-field/guidelines.mdx
+++ b/apps/docs/src/content/03-components/form-controls/search-field/guidelines.mdx
@@ -6,10 +6,8 @@ Ein SearchField unterstützt die effiziente Navigation und hilft dabei, große I
 
  Achte bei der Verwendung eines SearchFields darauf, dass...
 
-- ein beschreibender Platzhaltertext verwendet wird, der den Suchkontext verdeutlicht (z. B. Suche).
 - Eingaben gezielt über die Enter-Taste abgeschickt werden.
 - visuelles Feedback bei Ladezuständen oder Fehlern (z. B. keine Suchergebnisse gefunden) gegeben wird.
-
 
  ## Verwendung
 

--- a/apps/docs/src/content/03-components/form-controls/search-field/guidelines.mdx
+++ b/apps/docs/src/content/03-components/form-controls/search-field/guidelines.mdx
@@ -6,8 +6,8 @@ Ein SearchField unterstützt die effiziente Navigation und hilft dabei, große I
 
  Achte bei der Verwendung eines SearchFields darauf, dass...
 
-- Eingaben gezielt über die Enter-Taste abgeschickt werden.
 - visuelles Feedback bei Ladezuständen oder Fehlern (z. B. keine Suchergebnisse gefunden) gegeben wird.
+- die Eingabe des Users aktiv bestätigt werden muss – zum Beispiel über ein Formular ([Form (React Hook Form)](/03-components/form-controls/form-react-hook-form)) und einen [Button](/03-components/actions/button).
 
  ## Verwendung
 


### PR DESCRIPTION
Guideline sentence deleted because there are no property placeholders.