### PR TITLE
fix(CodeBlock): auto overflow when outer content is small

### DIFF
--- a/packages/components/src/components/CodeBlock/CodeBlock.module.scss
+++ b/packages/components/src/components/CodeBlock/CodeBlock.module.scss
@@ -8,6 +8,7 @@
   font-family: FiraCode, "monospace";
   max-width: 100%;
   width: 100%;
+  overflow-y: auto;
 
   > pre {
     overflow-x: auto;


### PR DESCRIPTION
fixes https://github.com/mittwald/flow/issues/2083