### PR TITLE
fix(Popover): fix Modal closing issue on double clicks

### DIFF
--- a/packages/components/src/components/Popover/Popover.module.scss
+++ b/packages/components/src/components/Popover/Popover.module.scss
@@ -85,6 +85,7 @@
   &[data-exiting] {
     animation: popover-slide var(--transition--duration--default) reverse
       ease-in;
+    pointer-events: none;
   }
 
   &:has(:global(.flow--options):empty) {


### PR DESCRIPTION
When Popover inside a Modal is clicked during exit-animation, the Modal closes as well. Popovers are used for example in Select, DatePicket or ComboBox.