### PR TITLE
fix(Modal): skip confirmation when using closeOverlay="Modal"

### DIFF
--- a/packages/components/src/components/Action/models/ActionModel.tsx
+++ b/packages/components/src/components/Action/models/ActionModel.tsx
@@ -9,6 +9,10 @@ import { ActionStateContext } from "@/components/Action/models/ActionStateContex
 import type { OverlayContext } from "@/lib/controller/overlay/context";
 import { useOverlayContext } from "@/lib/controller/overlay/context";
 import type { FlowComponentName } from "@/components/propTypes";
+import type {
+  CloseModalOptions,
+  CloseOverlayOptions,
+} from "@/lib/controller/overlay/OverlayController";
 
 interface InitObject {
   actionProps: ActionProps;
@@ -93,10 +97,18 @@ export class ActionModel {
   }
 
   public getOverlayController(
-    from: FlowComponentName | OverlayController,
+    from:
+      | FlowComponentName
+      | OverlayController
+      | CloseOverlayOptions
+      | CloseModalOptions,
   ): OverlayController | undefined {
     const getController = (
-      controller?: OverlayController | FlowComponentName,
+      controller?:
+        | OverlayController
+        | FlowComponentName
+        | CloseOverlayOptions
+        | CloseModalOptions,
     ): OverlayController | undefined => {
       if (controller === undefined) {
         return undefined;
@@ -107,6 +119,10 @@ export class ActionModel {
       if (typeof from === "string") {
         return this.overlayContext[from];
       }
+      if ("overlay" in from) {
+        return this.getOverlayController(from.overlay);
+      }
+      return this.getOverlayController("Modal");
     };
 
     return (
@@ -118,6 +134,25 @@ export class ActionModel {
       getController(this.actionProps.toggleModal ? "Modal" : undefined)
     );
   }
+
+  public static getCloseOverlayOptions = (
+    options?:
+      | OverlayController
+      | FlowComponentName
+      | CloseOverlayOptions
+      | CloseModalOptions
+      | true,
+  ) => {
+    if (
+      options === undefined ||
+      options instanceof OverlayController ||
+      typeof options === "string" ||
+      options === true
+    ) {
+      return undefined;
+    }
+    return options;
+  };
 
   public execute = (...args: unknown[]): void => {
     new ActionExecution(this).execute(...args);

--- a/packages/components/src/components/Action/models/getExecutionFunction.ts
+++ b/packages/components/src/components/Action/models/getExecutionFunction.ts
@@ -1,4 +1,4 @@
-import type { ActionModel } from "@/components/Action/models/ActionModel";
+import { ActionModel } from "@/components/Action/models/ActionModel";
 import { type ActionFn } from "@/components/Action";
 
 const voidAction = () => {
@@ -20,24 +20,35 @@ export function getExecutionFunction(action: ActionModel): ActionFn {
     toggleModal,
   } = action.actionProps;
 
-  const maybeAction = onAction
-    ? onAction
-    : openOverlay
-      ? () => action.getOverlayController(openOverlay)?.open()
-      : closeOverlay
-        ? () => action.getOverlayController(closeOverlay)?.close()
-        : toggleOverlay
-          ? () => action.getOverlayController(toggleOverlay)?.toggle()
-          : openModal
-            ? () => action.getOverlayController("Modal")?.open()
-            : toggleModal
-              ? () => action.getOverlayController("Modal")?.toggle()
-              : closeModal
-                ? () =>
-                    action
-                      .getOverlayController("Modal")
-                      ?.close(typeof closeModal === "boolean" ? {} : closeModal)
-                : voidAction;
+  if (onAction) {
+    return onAction;
+  }
 
-  return maybeAction ?? voidAction;
+  if (openOverlay) {
+    return () => action.getOverlayController(openOverlay)?.open();
+  }
+  if (closeOverlay) {
+    return () =>
+      action
+        .getOverlayController(closeOverlay)
+        ?.close(ActionModel.getCloseOverlayOptions(closeOverlay));
+  }
+  if (toggleOverlay) {
+    return () => action.getOverlayController(toggleOverlay)?.toggle();
+  }
+
+  if (openModal) {
+    return () => action.getOverlayController("Modal")?.open();
+  }
+  if (toggleModal) {
+    return () => action.getOverlayController("Modal")?.toggle();
+  }
+  if (closeModal) {
+    return () =>
+      action
+        .getOverlayController("Modal")
+        ?.close(ActionModel.getCloseOverlayOptions(closeModal));
+  }
+
+  return voidAction;
 }

--- a/packages/components/src/components/Action/types.ts
+++ b/packages/components/src/components/Action/types.ts
@@ -3,17 +3,20 @@ import type { OverlayController } from "@/lib/controller";
 import type { ActionModel } from "@/components/Action/models/ActionModel";
 import type { FlowComponentName } from "@/components/propTypes";
 import type { FlowComponentProps } from "@/lib/componentFactory/flowComponent";
-import type { CloseOverlayOptions } from "@/lib/controller/overlay/OverlayController";
+import type {
+  CloseModalOptions,
+  CloseOverlayOptions,
+} from "@/lib/controller/overlay/OverlayController";
 
 export type ActionFn = (...args: unknown[]) => unknown;
 
 export interface ActionProps extends PropsWithChildren, FlowComponentProps {
   onAction?: ActionFn;
   actionModel?: ActionModel;
-  closeOverlay?: FlowComponentName | OverlayController;
+  closeOverlay?: FlowComponentName | OverlayController | CloseOverlayOptions;
   openOverlay?: FlowComponentName | OverlayController;
   toggleOverlay?: FlowComponentName | OverlayController;
-  closeModal?: boolean | CloseOverlayOptions;
+  closeModal?: boolean | CloseModalOptions;
   openModal?: boolean;
   toggleModal?: boolean;
   break?: boolean;

--- a/packages/components/src/components/Modal/Modal.tsx
+++ b/packages/components/src/components/Modal/Modal.tsx
@@ -6,7 +6,7 @@ import {
   type PropsContext,
   PropsContextProvider,
 } from "@/lib/propsContext";
-import type { OverlayController } from "@/lib/controller/overlay";
+import { OverlayController } from "@/lib/controller/overlay";
 import type { FlowComponentProps } from "@/lib/componentFactory/flowComponent";
 import { flowComponent } from "@/lib/componentFactory/flowComponent";
 import { Overlay, type OverlayProps } from "@/components/Overlay/Overlay";
@@ -114,10 +114,34 @@ export const Modal = flowComponent("Modal", (props) => {
       spacing: "m",
       Action: {
         closeModal: dynamic((props) => {
+          if (props.closeModal === undefined) {
+            return;
+          }
           if (props.closeModal === true) {
             return { bypassConfirmation: true };
           }
-          return props.closeModal;
+          return {
+            bypassConfirmation: true,
+            ...props.closeModal,
+          };
+        }),
+        closeOverlay: dynamic((props) => {
+          if (props.closeOverlay === undefined) {
+            return;
+          }
+          if (
+            props.closeOverlay instanceof OverlayController ||
+            typeof props.closeOverlay === "string"
+          ) {
+            return {
+              bypassConfirmation: true,
+              overlay: props.closeOverlay,
+            };
+          }
+          return {
+            bypassConfirmation: true,
+            ...props.closeOverlay,
+          };
         }),
       },
     },

--- a/packages/components/src/lib/controller/overlay/OverlayController.ts
+++ b/packages/components/src/lib/controller/overlay/OverlayController.ts
@@ -3,6 +3,7 @@ import useSelector from "@/lib/mobx/useSelector";
 import { useStatic } from "@/lib/hooks/useStatic";
 import { useEffect } from "react";
 import { useCloseOverlayConfirmationController } from "@/lib/controller/overlay/useCloseOverlayConfirmationController";
+import type { FlowComponentName } from "@/components/propTypes";
 
 export type OverlayOpenHandler = () => unknown;
 export type OverlayCloseHandler = () => unknown;
@@ -15,8 +16,13 @@ type AnyOverlayOpenStateHandler =
 type DisposerFn = () => void;
 
 export interface CloseOverlayOptions {
+  overlay: FlowComponentName | OverlayController;
   bypassConfirmation?: boolean;
 }
+
+export type CloseModalOptions = Omit<CloseOverlayOptions, "overlay">;
+
+type CloseOptions = CloseOverlayOptions | CloseModalOptions;
 
 export interface OverlayControllerOptions {
   isDefaultOpen?: boolean;
@@ -129,7 +135,7 @@ export class OverlayController {
     this.setOpen(true);
   }
 
-  public close(options?: CloseOverlayOptions): void {
+  public close(options?: CloseOptions): void {
     this.setOpen(false, options);
   }
 
@@ -137,7 +143,7 @@ export class OverlayController {
     this.setOpen(!this.isOpen);
   }
 
-  public setOpen(toOpen: boolean, options: CloseOverlayOptions = {}): void {
+  public setOpen(toOpen: boolean, options: CloseOptions = {}): void {
     if (this.isOpen === toOpen) {
       return;
     }


### PR DESCRIPTION
This fix allows to close Modals without confirmation by using an Action with `<Action closeOverlay="Modal">` in the Modals Action Group.

Until now it was only possible by using `<Action closeModal>`