### PR TITLE
fix(Form): form should not be dirty after resetting

### DIFF
--- a/packages/components/src/integrations/react-hook-form/components/Field/Field.tsx
+++ b/packages/components/src/integrations/react-hook-form/components/Field/Field.tsx
@@ -12,6 +12,7 @@ import {
 import { useLocalizedStringFormatter } from "react-aria";
 import locales from "./locales/*.locale.json";
 import FieldErrorView from "@/views/FieldErrorView";
+import { useUpdateFormDefaultValue } from "@/integrations/react-hook-form/components/Field/hooks/useUpdateFormDefaultValue";
 
 export interface FieldProps<T extends FieldValues>
   extends Omit<ControllerProps<T>, "render">, PropsWithChildren {}
@@ -45,7 +46,10 @@ export function Field<T extends FieldValues>(props: FieldProps<T>) {
           : rest.rules?.maxLength,
     },
   });
-  const formContext = useFormContext();
+  const formContext = useFormContext<T>();
+
+  useUpdateFormDefaultValue(props, formContext.form);
+
   /**
    * We don't use controller.field.value here, because it doesn't update when
    * the form value is updated outside of this field (e.g. when setting values

--- a/packages/components/src/integrations/react-hook-form/components/Field/hooks/useUpdateFormDefaultValue.ts
+++ b/packages/components/src/integrations/react-hook-form/components/Field/hooks/useUpdateFormDefaultValue.ts
@@ -1,0 +1,21 @@
+import type { FieldProps } from "@/integrations/react-hook-form/components/Field/Field";
+import { useLayoutEffect } from "react";
+import type { FieldValues, UseFormReturn } from "react-hook-form";
+
+export const useUpdateFormDefaultValue = <T extends FieldValues>(
+  fieldProps: FieldProps<T>,
+  form: UseFormReturn<T>,
+) => {
+  const { defaultValue, name } = fieldProps;
+
+  useLayoutEffect(() => {
+    if (defaultValue !== undefined) {
+      form.resetField(name, {
+        defaultValue,
+        keepDirty: true,
+        keepError: true,
+        keepTouched: true,
+      });
+    }
+  }, [form, defaultValue, name]);
+};

--- a/packages/components/src/integrations/react-hook-form/components/Form/Form.browser.test.tsx
+++ b/packages/components/src/integrations/react-hook-form/components/Form/Form.browser.test.tsx
@@ -52,11 +52,14 @@ describe("resetting", () => {
     });
     const Field = typedField(form);
 
+    const isDirty = form.formState.isDirty;
+
     return (
       <Form form={form} onSubmit={(values) => handleSubmit(values)}>
         <Field {...props.textField} name="test">
           <TextField aria-label="test" />
         </Field>
+        {isDirty && <span data-testid="dirty">dirty</span>}
         <Button
           onPress={() => {
             if (resetValueTo) {
@@ -112,6 +115,41 @@ describe("resetting", () => {
       expect(field).toHaveDisplayValue(expected);
     },
   );
+
+  test("Form is not dirty after reset when field has default value", async () => {
+    await render(
+      <TestForm
+        textField={{
+          defaultValue: "default",
+        }}
+      />,
+    );
+
+    const field = page.getByLabelText("test");
+    const resetButton = page.getByText("Reset");
+    const isDirty = page.getByTestId("dirty");
+
+    await userEvent.type(field, "changed");
+    expect(isDirty).toBeInTheDocument();
+
+    await userEvent.click(resetButton);
+    expect(isDirty).not.toBeInTheDocument();
+  });
+
+  test("Form is not dirty after reset when form has default value", async () => {
+    initialValue = "default";
+    await render(<TestForm />);
+
+    const field = page.getByLabelText("test");
+    const resetButton = page.getByText("Reset");
+    const isDirty = page.getByTestId("dirty");
+
+    await userEvent.type(field, "changed");
+    expect(isDirty).toBeInTheDocument();
+
+    await userEvent.click(resetButton);
+    expect(isDirty).not.toBeInTheDocument();
+  });
 });
 
 describe("submission", () => {


### PR DESCRIPTION
When resetting a form that defines default values via the `defaultValue` Prop at a field, the form remains dirty.