### PR TITLE
security(Remote): do no allow to set tunnel provider from remote context

### DIFF
--- a/packages/components/src/components/TunnelEntry/TunnelEntry.tsx
+++ b/packages/components/src/components/TunnelEntry/TunnelEntry.tsx
@@ -4,7 +4,10 @@ import type { TunnelEntryProps } from "@mittwald/react-tunnel";
 
 export type { TunnelEntryProps } from "@mittwald/react-tunnel";
 
-/** @flr-generate all */
+/**
+ * @flr-generate all
+ * @flr-ignore-props providerId
+ */
 export const TunnelEntry: FC<TunnelEntryProps> = (props) => (
   <ReactTunnelEntry {...props} />
 );

--- a/packages/remote-elements/src/auto-generated/RemoteTunnelEntryElement.ts
+++ b/packages/remote-elements/src/auto-generated/RemoteTunnelEntryElement.ts
@@ -12,7 +12,6 @@ export class RemoteTunnelEntryElement extends FlowRemoteElement<RemoteTunnelEntr
   static override get remoteProperties() {
     return {
       id: {},
-      providerId: {},
       staticEntryId: {},
     };
   }


### PR DESCRIPTION
Only allow the default tunnel provider. This can be handled explicitly on the host site.