### PR TITLE
fix: correct dark mode teaser typo

### DIFF
--- a/apps/docs/src/app/page.tsx
+++ b/apps/docs/src/app/page.tsx
@@ -88,7 +88,7 @@ const Home: FC = () => {
                 Dark-Mode entdecken<Badge color="violet">Neu</Badge>
               </Heading>
               <Text>
-                Capre Noctem - Nutze die Dunkelheit! Ab jetzt unterstützt unser
+                Carpe Noctem - Nutze die Dunkelheit! Ab jetzt unterstützt unser
                 Design System ein Light- und ein Dark-Theme.
               </Text>
               <Link href="/02-foundations/01-design/03-themes">


### PR DESCRIPTION
## Summary

Corrects the Dark Mode teaser text from "Capre Noctem" to "Carpe Noctem".

## Testing

- pnpm exec prettier --check apps/docs/src/app/page.tsx
- pnpm exec eslint apps/docs/src/app/page.tsx
- pnpm nx build docs

Fixes #2525