### PR TITLE
fix(Remote): import flow components from flr-universal only

### DIFF
--- a/packages/components/src/index/flr-universal.ts
+++ b/packages/components/src/index/flr-universal.ts
@@ -36,3 +36,5 @@ export {
 
 export * from "@/lib/controller/public";
 export * from "@/lib/hooks/public";
+
+export { useControlledRemoteValueProps } from "@/lib/remote/useControlledRemoteValueProps";

--- a/packages/remote-react-components/src/components/RemoteRoot.tsx
+++ b/packages/remote-react-components/src/components/RemoteRoot.tsx
@@ -23,7 +23,10 @@ import {
 import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
 import { RemoteContextProvider } from "@/components/RemoteContextProvider";
 import { LoadingFallbackTrigger } from "@/components/LoadingFallbackTrigger";
-import { IntlProvider, useLanguage } from "@mittwald/flow-react-components";
+import {
+  IntlProvider,
+  useLanguage,
+} from "@mittwald/flow-react-components/flr-universal";
 import type { HostConfig } from "@mittwald/flow-core";
 import { initExtBridge } from "@mittwald/ext-bridge/browser";
 

--- a/packages/remote-react-components/src/lib/createRemoteComponent.ts
+++ b/packages/remote-react-components/src/lib/createRemoteComponent.ts
@@ -1,5 +1,5 @@
 import { version } from "@/version";
-import { useControlledRemoteValueProps } from "@mittwald/flow-react-components";
+import { useControlledRemoteValueProps } from "@mittwald/flow-react-components/flr-universal";
 import { FlowRemoteElement } from "@mittwald/flow-remote-elements";
 import { createRemoteComponent as libCreateRemoteComponent } from "@mittwald/remote-dom-react";
 import { createElement } from "react";

--- a/packages/remote-react-components/src/views/NotificationContainer.tsx
+++ b/packages/remote-react-components/src/views/NotificationContainer.tsx
@@ -1,4 +1,4 @@
-import { useNotificationController } from "@mittwald/flow-react-components";
+import { useNotificationController } from "@mittwald/flow-react-components/flr-universal";
 import { ControlledNotification } from "@mittwald/flow-react-components/internal";
 import { type FC } from "react";
 


### PR DESCRIPTION
Remote extensions rendering a flow List with items crash in deployed
builds ("Cannot read properties of undefined (reading 'itemView')"), but
work via a localhost dev URL.

The remote packages import flow from two entries at once (flr-universal +
default), which both re-export List/listContext. A production bundler then
creates two listContext instances — the provider sets one, the item
consumers read the other (default {}), so list is undefined. Dev only has
one module instance.

Fix: import everything remote-side from flr-universal (and export
useControlledRemoteValueProps there)