### PR TITLE
Expose remote package version in remote renderer handshake

### DIFF
--- a/apps/remote-dom-demo/src/app/host/layout.tsx
+++ b/apps/remote-dom-demo/src/app/host/layout.tsx
@@ -1,10 +1,19 @@
 "use client";
 import { LoadingMessage } from "@/app/_components/LoadingMessage";
 import { getHostPath, getRemotePath } from "@/app/_lib/navigation";
+import {
+  ColumnLayout,
+  IntlProvider,
+  Label,
+  LabeledValue,
+  Section,
+  Separator,
+  Text,
+} from "@mittwald/flow-react-components";
 import { RemoteRenderer } from "@mittwald/flow-remote-react-renderer";
+import type { RemoteReadyEvent } from "@mittwald/flow-remote-react-renderer";
 import { usePathname, useRouter } from "next/navigation";
 import { useRef, useState } from "react";
-import { IntlProvider } from "@mittwald/flow-react-components";
 
 export default function HostPage() {
   const router = useRouter();
@@ -12,31 +21,50 @@ export default function HostPage() {
   const remotePath = getRemotePath(hostPath);
   const srcRef = useRef(remotePath);
   const [isNavigating, setIsNavigating] = useState(false);
+  const [remoteReadyEvent, setRemoteReadyEvent] = useState<RemoteReadyEvent>();
 
   return (
     <IntlProvider locale="de-DE">
-      {isNavigating && <LoadingMessage />}
-      <RemoteRenderer
-        onNavigationStateChanged={(state) => {
-          const { pathname, isPending } = state;
-          router.replace(getHostPath(pathname));
-          setIsNavigating(isPending);
-        }}
-        hostPathname={hostPath}
-        src={srcRef.current}
-        extBridgeImplementation={{
-          getConfig: async () => ({
-            extensionId: "ext-id",
-            extensionInstanceId: "exti-id",
-            sessionId: "session-id",
-            userId: "user-id",
-            appInstallationId: "appi-id",
-            customerId: "customer-id",
-            projectId: "project-id",
-          }),
-          getSessionToken: async () => "session-token",
-        }}
-      />
+      <Section>
+        {isNavigating && <LoadingMessage />}
+        {remoteReadyEvent && (
+          <>
+            <ColumnLayout>
+              <LabeledValue>
+                <Label>Communication version</Label>
+                <Text>{remoteReadyEvent.version}</Text>
+              </LabeledValue>
+              <LabeledValue>
+                <Label>Remote package</Label>
+                <Text>{remoteReadyEvent.packageVersion ?? "unknown"}</Text>
+              </LabeledValue>
+            </ColumnLayout>
+            <Separator />
+          </>
+        )}
+        <RemoteRenderer
+          onConnected={setRemoteReadyEvent}
+          onNavigationStateChanged={(state) => {
+            const { pathname, isPending } = state;
+            router.replace(getHostPath(pathname));
+            setIsNavigating(isPending);
+          }}
+          hostPathname={hostPath}
+          src={srcRef.current}
+          extBridgeImplementation={{
+            getConfig: async () => ({
+              extensionId: "ext-id",
+              extensionInstanceId: "exti-id",
+              sessionId: "session-id",
+              userId: "user-id",
+              appInstallationId: "appi-id",
+              customerId: "customer-id",
+              projectId: "project-id",
+            }),
+            getSessionToken: async () => "session-token",
+          }}
+        />
+      </Section>
     </IntlProvider>
   );
 }

--- a/packages/remote-core/src/connection/connectHostRenderRoot.ts
+++ b/packages/remote-core/src/connection/connectHostRenderRoot.ts
@@ -12,6 +12,7 @@ import { ThreadNestedIframe } from "@quilted/threads";
 interface Options {
   root: HTMLDivElement;
   onPathnameChanged?: (pathname: string) => void;
+  packageVersion?: string;
 }
 
 const incompatibleParentFrameError = () =>
@@ -31,7 +32,7 @@ export const connectRemoteReceiver = (
 export const connectHostRenderRoot = async (
   options: Options,
 ): Promise<RemoteToHostConnection> => {
-  const { root, onPathnameChanged } = options;
+  const { root, onPathnameChanged, packageVersion } = options;
 
   const connection = new ThreadNestedIframe<HostExports, RemoteExports>({
     serialization: new FlowThreadSerialization(),
@@ -49,7 +50,10 @@ export const connectHostRenderRoot = async (
   }
 
   try {
-    await connection.imports.setIsReady(Version.v3);
+    await connection.imports.setIsReady({
+      version: Version.v4,
+      packageVersion,
+    });
 
     if (typeof mwExtBridge !== "undefined") {
       mwExtBridge.connection = connection.imports;

--- a/packages/remote-core/src/connection/connectRemoteIframe.ts
+++ b/packages/remote-core/src/connection/connectRemoteIframe.ts
@@ -2,9 +2,12 @@ import {
   Version,
   type HostExports,
   type HostToRemoteConnection,
+  type HostToRemoteConnectionReadyEvent,
   type NavigationState,
   type RemoteExports,
   type RemoteExtBridgeConnectionApi,
+  type RemoteReadyEvent,
+  type RemoteReadyEventInput,
 } from "@/connection/types";
 import { getWithMergedHostConfig } from "@/ext-bridge/getWithMergedHostConfig";
 import { emptyImplementation } from "@/ext-bridge/implementation";
@@ -17,12 +20,28 @@ interface Options {
   connection: RemoteConnection;
   iframe: HTMLIFrameElement;
   hostConfig: HostConfig;
-  onReady?: (connection: HostToRemoteConnection) => void;
+  onReady?: (event: HostToRemoteConnectionReadyEvent) => void;
   onLoadingChanged?: (isLoading: boolean) => void;
   onError?: (error: string) => void;
   onNavigationStateChanged?: (state: NavigationState) => void;
   extBridgeImplementation?: RemoteExtBridgeConnectionApi;
 }
+
+const normalizeReadyEvent = (
+  event?: RemoteReadyEventInput,
+): RemoteReadyEvent => {
+  if (typeof event === "number") {
+    return {
+      version: event,
+    };
+  }
+
+  return (
+    event ?? {
+      version: Version.v1,
+    }
+  );
+};
 
 export const connectRemoteIframe = (opts: Options): HostToRemoteConnection => {
   const {
@@ -41,14 +60,18 @@ export const connectRemoteIframe = (opts: Options): HostToRemoteConnection => {
     getConfig: getWithMergedHostConfig(extBridgeImplementationProp, hostConfig),
   };
 
-  const result = {
+  const result: HostToRemoteConnection = {
     thread: new ThreadIframe<RemoteExports, HostExports>(iframe, {
       serialization: new FlowThreadSerialization(),
       exports: {
         ...extBridgeImplementation,
-        setIsReady: async (version = Version.v1) => {
-          result.version = version;
-          onReady?.(result);
+        setIsReady: async (event) => {
+          const readyEvent = normalizeReadyEvent(event);
+          result.version = readyEvent.version;
+          onReady?.({
+            connection: result,
+            remoteReadyEvent: readyEvent,
+          });
         },
         setIsLoading: async (isLoading: boolean) => {
           onLoadingChanged?.(isLoading);

--- a/packages/remote-core/src/connection/types.ts
+++ b/packages/remote-core/src/connection/types.ts
@@ -12,6 +12,13 @@ export interface NavigationState {
   isPending: boolean;
 }
 
+export interface RemoteReadyEvent {
+  version: Version;
+  packageVersion?: string;
+}
+
+export type RemoteReadyEventInput = Version | RemoteReadyEvent;
+
 export type RemoteExtBridgeConfig = Omit<
   ExtBridgeConfigInput,
   keyof HostConfig
@@ -31,7 +38,7 @@ export interface RemoteExtBridgeConnectionApi extends Omit<
  * When addding properties, make sure to release the host before all clients.
  */
 export interface HostExports extends ExtBridgeConnectionApi {
-  setIsReady: (version?: Version) => Promise<void>;
+  setIsReady: (event?: RemoteReadyEventInput) => Promise<void>;
   setIsLoading: (isLoading: boolean) => Promise<void>;
   setError: (error: string) => Promise<void>;
   setNavigationState: (state: NavigationState) => Promise<void>;
@@ -54,9 +61,15 @@ export interface HostToRemoteConnection {
   updateHostPathname: (hostPathname?: string) => void;
 }
 
+export interface HostToRemoteConnectionReadyEvent {
+  connection: HostToRemoteConnection;
+  remoteReadyEvent: RemoteReadyEvent;
+}
+
 export enum Version {
   vUnknown = 0,
   v1 = 1,
   v2 = 2,
   v3 = 3,
+  v4 = 4,
 }

--- a/packages/remote-react-components/src/components/RemoteRoot.tsx
+++ b/packages/remote-react-components/src/components/RemoteRoot.tsx
@@ -3,6 +3,7 @@ import * as remoteComponents from "@/auto-generated";
 import * as customViewComponents from "@/views";
 import { useWatchPathname } from "@/hooks/useWatchPathname";
 import { stringifyError } from "@/lib/stringifyError";
+import { packageVersion } from "@/version";
 import { ViewComponentContextProvider } from "@mittwald/flow-react-components/internal";
 import {
   connectHostRenderRootRef,
@@ -123,6 +124,7 @@ export const RemoteRoot: FC<RemoteRootProps> = (props) => {
   const connect = connectHostRenderRootRef({
     onPathnameChanged: (pathname) =>
       startPathnameChangedTransition(() => onHostPathnameChanged?.(pathname)),
+    packageVersion,
   });
 
   /** Is wrapped in Div to resolve render awaiter in <RemoteRenderer /> */

--- a/packages/remote-react-components/src/types.d.ts
+++ b/packages/remote-react-components/src/types.d.ts
@@ -1,6 +1,8 @@
 /// <reference types="@vitest/browser/providers/playwright" />
 /// <reference types="vite/client" />
 
+declare const __FLOW_REMOTE_REACT_COMPONENTS_PACKAGE_VERSION__: string;
+
 declare module "*.module.css" {
   const classes: Record<string, string>;
   export default classes;

--- a/packages/remote-react-components/src/version.ts
+++ b/packages/remote-react-components/src/version.ts
@@ -1,3 +1,6 @@
 import { Version } from "@mittwald/flow-remote-core";
 
-export const version = Version.v3;
+export const communicationVersion = Version.v4;
+export const packageVersion = __FLOW_REMOTE_REACT_COMPONENTS_PACKAGE_VERSION__;
+
+export const version = communicationVersion;

--- a/packages/remote-react-components/vite.config.ts
+++ b/packages/remote-react-components/vite.config.ts
@@ -1,8 +1,14 @@
 import path from "path";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import packageJson from "./package.json";
 
 export default defineConfig({
+  define: {
+    __FLOW_REMOTE_REACT_COMPONENTS_PACKAGE_VERSION__: JSON.stringify(
+      packageJson.version,
+    ),
+  },
   plugins: [react()],
   optimizeDeps: {
     include: [

--- a/packages/remote-react-renderer/src/RemoteRenderer.tsx
+++ b/packages/remote-react-renderer/src/RemoteRenderer.tsx
@@ -1,7 +1,11 @@
 "use client";
 import type { RemoteRendererBrowserProps } from "@/RemoteRendererBrowser";
 import { BrowserOnly } from "@mittwald/flow-react-components";
+import type { RemoteReadyEvent } from "@mittwald/flow-remote-core";
 import React, { type FC } from "react";
+
+export type { RemoteRendererBrowserProps } from "@/RemoteRendererBrowser";
+export type { RemoteReadyEvent };
 
 const RemoteRendererBrowser = React.lazy(
   () => import("./RemoteRendererBrowser"),

--- a/packages/remote-react-renderer/src/RemoteRendererBrowser.tsx
+++ b/packages/remote-react-renderer/src/RemoteRendererBrowser.tsx
@@ -10,6 +10,7 @@ import {
   type HostToRemoteConnection,
   type NavigationState,
   type RemoteExtBridgeConnectionApi,
+  type RemoteReadyEvent,
 } from "@mittwald/flow-remote-core";
 import { refresh, usePromise } from "@mittwald/react-use-promise";
 import {
@@ -32,6 +33,7 @@ export interface RemoteRendererBrowserProps {
   src?: string;
   timeoutMs?: number;
   onNavigationStateChanged?: (state: NavigationState) => void;
+  onConnected?: (event: RemoteReadyEvent) => void;
   hostPathname?: string;
   extBridgeImplementation?: RemoteExtBridgeConnectionApi;
   /** Internal use only */
@@ -56,6 +58,7 @@ export const RemoteRendererBrowser: FC<RemoteRendererBrowserProps> = (
     src,
     extBridgeImplementation,
     onNavigationStateChanged,
+    onConnected,
     hostPathname,
     __remoteReceiver: remoteReceiverFromProps,
   } = props;
@@ -113,8 +116,9 @@ export const RemoteRendererBrowser: FC<RemoteRendererBrowserProps> = (
     connection: receiver.connection,
     extBridgeImplementation,
     hostConfig,
-    onReady: (establishedConnection) => {
+    onReady: ({ connection: establishedConnection, remoteReadyEvent }) => {
       establishedConnection.updateHostPathname(hostPathname);
+      onConnected?.(remoteReadyEvent);
       connectionPromise.resolve();
     },
     onLoadingChanged: (isLoading) => {


### PR DESCRIPTION
**⚠️ IMPORTANT: REQUIRES IMMEDIATE HOST-ENVIRONMENT UPDATE AFTER RELEASE**

## Summary
- Upgrade the remote-host handshake to version 4 and carry the remote package version through the connection
- Surface connection metadata from `RemoteRenderer` via a new `onConnected` callback
- Show the communication version and remote package version in the remote DOM demo host UI
- Wire the remote React components build to inject its package version at compile time

## Testing
- Not run (not requested)

Closes #1302 