### PR TITLE
feat(components): add deprecation warning provider

### DIFF
--- a/packages/components/src/components/Action/Action.tsx
+++ b/packages/components/src/components/Action/Action.tsx
@@ -9,6 +9,7 @@ import type { ComponentPropsContext } from "@/lib/propsContext/types";
 import { flowComponent } from "@/lib/componentFactory/flowComponent";
 import type { ActionFn } from "@/components/Action/types";
 import { useActionState } from "@/components/Action/hooks/useActionState";
+import { useWarnDeprecation } from "@/components/DeprecationWarningProvider";
 
 const actionButtonContext: ComponentPropsContext<"Button"> = {
   onPress: dynamic((props) => {
@@ -57,10 +58,15 @@ export const Action = flowComponent(
       ...actionProps
     } = props;
 
-    if ("action" in actionProps && typeof actionProps.action === "function") {
-      console.warn(
+    const warnDeprecation = useWarnDeprecation();
+    const usesDeprecatedActionProp =
+      "action" in actionProps && typeof actionProps.action === "function";
+
+    if (usesDeprecatedActionProp) {
+      warnDeprecation(
         "The 'action' prop is now deprecated. Use 'onAction' instead.",
       );
+
       if ("onAction" in actionProps === false) {
         actionProps.onAction = actionProps.action as ActionFn;
       }

--- a/packages/components/src/components/CartesianChart/CartesianChart.tsx
+++ b/packages/components/src/components/CartesianChart/CartesianChart.tsx
@@ -24,6 +24,7 @@ import { TypedChartGrid } from "@/components/CartesianChart/components/ChartGrid
 import { TypedChartLegend } from "@/components/CartesianChart/components/ChartLegend";
 import { TypedChartTooltip } from "@/components/CartesianChart/components/ChartTooltip";
 import { TypedLine } from "@/components/CartesianChart/components/Line";
+import { useWarnDeprecation } from "@/components/DeprecationWarningProvider";
 
 /** @deprecated Use a ReactNode instead */
 export interface CartesianChartEmptyViewProps {
@@ -55,6 +56,7 @@ export interface CartesianChartProps<TData = ChartDataValue>
 export const CartesianChart: FC<CartesianChartProps> = (props) => {
   const { children, data, className, height, flexGrow, emptyView, ...rest } =
     props;
+  const warnDeprecation = useWarnDeprecation();
 
   const { viewDimensions, ref: containerRef } = useChartClipRect();
 
@@ -64,6 +66,13 @@ export const CartesianChart: FC<CartesianChartProps> = (props) => {
     className,
     showEmptyView && styles.emptyView,
   );
+  const usesDeprecatedEmptyView = !!emptyView && !isValidElement(emptyView);
+
+  if (usesDeprecatedEmptyView) {
+    warnDeprecation(
+      "CartesianChart: emptyView as a non-element is deprecated and will be removed in a future release. Please provide an element as emptyView.",
+    );
+  }
 
   const emptyElement = useMemo(() => {
     if (isValidElement(emptyView)) {
@@ -74,9 +83,6 @@ export const CartesianChart: FC<CartesianChartProps> = (props) => {
       return;
     }
 
-    console.warn(
-      "CartesianChart: emptyView as a non-element is deprecated and will be removed in a future release. Please provide an element as emptyView.",
-    );
     return null;
   }, [emptyView]);
 

--- a/packages/components/src/components/CartesianChart/components/CartesianGrid/CartesianGrid.tsx
+++ b/packages/components/src/components/CartesianChart/components/CartesianGrid/CartesianGrid.tsx
@@ -1,4 +1,6 @@
 import { ChartGrid, type ChartGridProps } from "@/components/CartesianChart";
+import { useWarnDeprecation } from "@/components/DeprecationWarningProvider";
+import type { FC } from "react";
 
 /** @deprecated Use ChartGridProps */
 export type CartesianGridProps = ChartGridProps;
@@ -7,4 +9,12 @@ export type CartesianGridProps = ChartGridProps;
  * @deprecated Use ChartGrid
  * @flr-generate all
  */
-export const CartesianGrid = ChartGrid;
+export const CartesianGrid: FC<CartesianGridProps> = (props) => {
+  const warnDeprecation = useWarnDeprecation();
+
+  warnDeprecation(
+    "The 'CartesianGrid' component is deprecated and will be removed in a future release. Use 'ChartGrid' instead.",
+  );
+
+  return <ChartGrid {...props} />;
+};

--- a/packages/components/src/components/DeprecationWarningProvider/DeprecationWarningProvider.test.tsx
+++ b/packages/components/src/components/DeprecationWarningProvider/DeprecationWarningProvider.test.tsx
@@ -1,0 +1,56 @@
+/** @vitest-environment happy-dom */
+import {
+  DeprecationWarningProvider,
+  useWarnDeprecation,
+} from "@/components/DeprecationWarningProvider";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test, vi } from "vitest";
+
+const message = "This API is deprecated.";
+
+const WarningComponent = () => {
+  const warnDeprecation = useWarnDeprecation();
+
+  warnDeprecation(message);
+  warnDeprecation(message);
+
+  return null;
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test("warns through console and provider callback only once per message", async () => {
+  const consoleWarn = vi.spyOn(console, "warn");
+  const onWarning = vi.fn();
+  const container = document.createElement("div");
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(
+      <DeprecationWarningProvider onWarning={onWarning}>
+        <WarningComponent />
+      </DeprecationWarningProvider>,
+    );
+  });
+
+  expect(consoleWarn).toHaveBeenCalledTimes(1);
+  expect(consoleWarn).toHaveBeenCalledWith(message);
+  expect(onWarning).toHaveBeenCalledTimes(1);
+  expect(onWarning).toHaveBeenCalledWith(message);
+
+  await act(async () => {
+    root.render(
+      <DeprecationWarningProvider onWarning={onWarning}>
+        <WarningComponent />
+      </DeprecationWarningProvider>,
+    );
+  });
+
+  expect(consoleWarn).toHaveBeenCalledTimes(1);
+  expect(onWarning).toHaveBeenCalledTimes(1);
+
+  root.unmount();
+});

--- a/packages/components/src/components/DeprecationWarningProvider/DeprecationWarningProvider.tsx
+++ b/packages/components/src/components/DeprecationWarningProvider/DeprecationWarningProvider.tsx
@@ -1,0 +1,58 @@
+import {
+  createContext,
+  type FC,
+  type PropsWithChildren,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+} from "react";
+
+export type DeprecationWarningHandler = (message: string) => void;
+
+export interface DeprecationWarningProviderProps extends PropsWithChildren {
+  onWarning?: DeprecationWarningHandler;
+}
+
+export const DeprecationWarningContext = createContext<
+  DeprecationWarningHandler | undefined
+>(undefined);
+
+export const DeprecationWarningProvider: FC<DeprecationWarningProviderProps> = (
+  props,
+) => {
+  const { children, onWarning } = props;
+
+  return (
+    <DeprecationWarningContext.Provider value={onWarning}>
+      {children}
+    </DeprecationWarningContext.Provider>
+  );
+};
+
+export const useWarnDeprecation = () => {
+  const onWarning = useContext(DeprecationWarningContext);
+  const reportedWarnings = useRef(new Set<string>());
+  const pendingWarnings = useRef<string[]>([]);
+
+  useEffect(() => {
+    const warnings = pendingWarnings.current;
+    pendingWarnings.current = [];
+
+    for (const message of warnings) {
+      console.warn(message);
+      onWarning?.(message);
+    }
+  });
+
+  return useCallback((message: string) => {
+    if (reportedWarnings.current.has(message)) {
+      return;
+    }
+
+    reportedWarnings.current.add(message);
+    pendingWarnings.current.push(message);
+  }, []);
+};
+
+export default DeprecationWarningProvider;

--- a/packages/components/src/components/DeprecationWarningProvider/index.ts
+++ b/packages/components/src/components/DeprecationWarningProvider/index.ts
@@ -1,0 +1,9 @@
+export {
+  DeprecationWarningContext,
+  DeprecationWarningProvider,
+  type DeprecationWarningHandler,
+  type DeprecationWarningProviderProps,
+  useWarnDeprecation,
+} from "@/components/DeprecationWarningProvider/DeprecationWarningProvider";
+
+export { default } from "@/components/DeprecationWarningProvider/DeprecationWarningProvider";

--- a/packages/components/src/components/TextArea/TextArea.tsx
+++ b/packages/components/src/components/TextArea/TextArea.tsx
@@ -11,6 +11,7 @@ import { useControlledHostValueProps } from "@/lib/remote/useControlledHostValue
 import { useLocalizedStringFormatter } from "@/components/TranslationProvider/useLocalizedStringFormatter";
 import locales from "./locales/*.locale.json";
 import { FieldDescription } from "@/components/FieldDescription";
+import { useWarnDeprecation } from "@/components/DeprecationWarningProvider";
 
 export interface TextAreaProps
   extends
@@ -34,6 +35,7 @@ export interface TextAreaProps
 
 /** @flr-generate all */
 export const TextArea = flowComponent("TextArea", (props) => {
+  const warnDeprecation = useWarnDeprecation();
   const {
     children,
     placeholder,
@@ -52,6 +54,17 @@ export const TextArea = flowComponent("TextArea", (props) => {
   const [charactersCount, setCharactersCount] = useState(
     props.defaultValue?.length ?? props.value?.length ?? 0,
   );
+
+  if (allowHorizontalResize !== undefined) {
+    warnDeprecation(
+      "The 'allowHorizontalResize' prop is deprecated and will be removed in a future release. Use 'allowResize' instead.",
+    );
+  }
+  if (allowVerticalResize !== undefined) {
+    warnDeprecation(
+      "The 'allowVerticalResize' prop is deprecated and will be removed in a future release. Use 'allowResize' instead.",
+    );
+  }
 
   const {
     FieldErrorView,

--- a/packages/components/src/components/public.ts
+++ b/packages/components/src/components/public.ts
@@ -37,6 +37,7 @@ export * from "@/components/CounterBadge";
 export * from "@/components/CountryOptions";
 export * from "@/components/DatePicker";
 export * from "@/components/DateRangePicker";
+export * from "@/components/DeprecationWarningProvider";
 export * from "@/components/Div";
 export * from "@/components/DonutChart";
 export * from "@/components/FieldDescription";


### PR DESCRIPTION
Adds a `DeprecationWarningProvider` and `useWarnDeprecation()` hook so Flow components can report deprecated usage through both `console.warn` and an optional app-provided callback.

**Changes**
- Adds `DeprecationWarningProvider` with `onWarning`
- Adds `useWarnDeprecation()` for component-level deprecation logging
- Wires existing deprecation paths through the new hook:
  - `Action.action`
  - `CartesianChart.emptyView` as non-element
  - `CartesianGrid`
  - `TextArea.allowHorizontalResize`
  - `TextArea.allowVerticalResize`
- Adds a unit test for warning callback, console warning, and deduplication

**Verification**
```bash
corepack pnpm --filter @mittwald/flow-react-components test:compile
corepack pnpm --filter @mittwald/flow-react-components exec vitest run --project=unit src/components/DeprecationWarningProvider/DeprecationWarningProvider.test.tsx
```