### PR TITLE
docs: add agent guides (AGENTS.md), CONTRIBUTE.md and /review-flow command

### DIFF
--- a/.claude/commands/review-flow.md
+++ b/.claude/commands/review-flow.md
@@ -1,0 +1,53 @@
+---
+description: Review changes against the Flow patterns and CI gates (AGENTS.md)
+argument-hint: [base ref — defaults to uncommitted changes, else merge-base with main]
+---
+
+Review the current changes against this repository's documented patterns.
+
+## Scope
+
+Determine the diff to review:
+
+- If `$ARGUMENTS` names a base (branch, commit, PR ref), diff against that.
+- Otherwise: review uncommitted changes if any exist, else the current
+  branch's diff against its merge-base with `main`.
+
+## Method
+
+1. Read the rules — they are the single source of truth; do not invent
+   criteria beyond them:
+   - `AGENTS.md` (root): generated code, Definition of Done, hard rules,
+     workflow
+   - `packages/components/AGENTS.md` when components are touched: patterns
+     (flowComponent, PropsContext, views, styling, testing bar, i18n, public
+     API surfaces)
+   - the nearest `packages/*/AGENTS.md` / `apps/*/AGENTS.md` for every other
+     touched package
+2. Check the diff against those sections. Pay special attention to:
+   - **Generated code:** were `@flr-generate` component props, icons, or prop
+     JSDoc changed without regenerating and committing the artifacts? CI
+     enforces `git diff --exit-code`.
+   - **Backwards compatibility:** are props of `@flr-generate` /
+     `flr-universal` components changed in a breaking way? Renames/removals
+     need a `useWarnDeprecation` path instead.
+   - **Definition of Done** for component work: story, docs page, tests along
+     the testing bar, locales (both `de-DE` and `en-US`), `public.ts` export,
+     remote demo page — list what is missing.
+   - **Patterns:** flowComponent usage, PropsContext rules (remote-capable
+     components only), views for internal composition in flr-universal
+     components, token-based styling (no hard-coded values).
+3. Verify each finding against the actual code before reporting — read the
+   file; never report from the diff hunk alone.
+
+## Report
+
+Group findings by severity:
+
+- **Blocking** — would fail CI or break the extension contract
+- **Should fix** — violates a documented pattern or DoD item
+- **Nit** — style/polish
+
+For each finding: `file:line`, what is wrong, and which AGENTS.md section it
+violates. If everything holds, say so explicitly. For component work, end
+with the Definition-of-Done checklist status.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,211 @@
+# mittwald Flow — Agent Guide
+
+Canonical guidance for AI coding agents (and a good primer for humans) working
+in this repository. Package-specific deep dives live next to the code — see
+[Where to look next](#where-to-look-next).
+
+## What this project is
+
+mittwald **Flow** is the design system of [mittwald](https://www.mittwald.de):
+a React component library plus a remote-DOM rendering system that lets
+[mStudio](https://developer.mittwald.de) extensions render sandboxed UI inside
+the mittwald backoffice using real Flow components.
+
+- User documentation: <https://flow.mittwald.de>
+- Storybook: <https://storybook.flow-components.de>
+- Remote rendering is based on a fork of
+  [Shopify remote-dom](https://github.com/Shopify/remote-dom)
+
+## The three systems
+
+### 1. Design system core
+
+React components in `packages/components` (most wrap
+[react-aria-components](https://react-spectrum.adobe.com/react-aria/components.html)
+for accessibility), styled with SCSS modules and design-token CSS variables.
+Icon sets, a standalone stylesheet package, and the docs site build on top of
+it. Patterns are documented in
+[packages/components/AGENTS.md](packages/components/AGENTS.md).
+
+### 2. Remote DOM ("flr" = **Fl**ow **R**emote)
+
+mStudio extensions run in a hidden iframe and render UI that the host
+materializes with real Flow components:
+
+```
+extension (iframe)                          host (mStudio)
+RemoteRoot + remote React components  ───►  RemoteRenderer + RemoteReceiver
+   │  @quilted/threads connection              │
+   └─ hidden remote DOM (flr-* elements) ───►  maps flr-* to Flow components
+```
+
+- `remote-core` owns connection + serialization (`@quilted/threads`). The
+  protocol is **versioned** — the host negotiates with different remote
+  versions at connection time. Keep this layer backwards compatible.
+- Components tagged `/** @flr-generate all */` get generated artifacts: a
+  `view.ts` next to the component, view components in
+  `packages/components/src/views/`, and files under `src/auto-generated/` in
+  `remote-elements`, `remote-react-components` and `remote-react-renderer`.
+- **Props of `@flr-generate` components are a contract with extension
+  developers.** Avoid breaking changes. When an API must change, keep the old
+  path working and log usage with `useWarnDeprecation` (from
+  `DeprecationWarningProvider`) so extension developers can be informed about
+  deprecation paths they still use.
+- Inside components that are part of the `flr-universal` export surface,
+  compose other Flow components through their **views** (`@/views/*`) — views
+  automatically switch to the remote counterpart in a remote context.
+
+### 3. Token pipeline
+
+`design-tokens` YAML files are defined together with UX — **design
+authority**. Base tokens (colors, font, sizes, …) are taboo — never invent
+or modify them. Adding **component tokens** for a new component is fine:
+model them on existing components and ask when unsure.
+[style-dictionary](https://styledictionary.com/) compiles YAML →
+`dist/css` (CSS variables) and `dist/json`.
+
+## Repository map
+
+nx + pnpm workspace monorepo. Node `>=20.19`, pnpm pinned via
+`packageManager` (use corepack). Several packages ship their own `AGENTS.md`
+— **always read the nearest `AGENTS.md` before working in a package.**
+
+| Path | Package | Role |
+| --- | --- | --- |
+| `packages/components` | `@mittwald/flow-react-components` | The heart: all React components. |
+| `packages/design-tokens` | `@mittwald/flow-design-tokens` | Token source (YAML, design authority) → CSS vars + JSON via style-dictionary. |
+| `packages/icons-base` | private | Icon source of truth (`src/icons.yaml`) + shared generator tooling. |
+| `packages/icons`, `packages/icons-pro` | `@mittwald/flow-icons(-pro)` | Published icon sets, **fully generated** from `icons-base` (Tabler / FontAwesome). |
+| `packages/stylesheet` | `@mittwald/flow-stylesheet` | Publishes the components' `all.css` as a standalone CSS package. |
+| `packages/core` | private | Shared utilities: remote host config contract, shared Vitest browser config. |
+| `packages/remote-core` | `@mittwald/flow-remote-core` | Connection + serialization layer (versioned protocol). |
+| `packages/remote-elements` | `@mittwald/flow-remote-elements` | Custom elements (`flr-*`) for the remote side; largely auto-generated. |
+| `packages/remote-react-components` | `@mittwald/flow-remote-react-components` | React API used *inside* remote apps (extensions); largely auto-generated. |
+| `packages/remote-react-renderer` | `@mittwald/flow-remote-react-renderer` | Host-side renderer mapping `flr-*` elements to Flow components; map auto-generated. |
+| `packages/ext-bridge` | `@mittwald/ext-bridge` | mStudio extension bridge (node/browser/react/i18next entries). |
+| `packages/react-tunnel` | `@mittwald/react-tunnel` | Generic "portal for components" utility (MobX-based). |
+| `packages/mstudio-ext-react-components` | `@mittwald/mstudio-ext-react-components` | Helpers for extension developers (mStudio page header customization). |
+| `packages/codemods` | private | jscodeshift migrations for consumers. |
+| `packages/typescript-config` | private | Shared tsconfig presets (`base`, `library`, `web-library`, `react-library`, `nextjs`). |
+| `apps/docs` | private | User documentation site (Next.js); content in `src/content`, deployed to flow.mittwald.de. |
+| `apps/remote-dom-demo` | private | Demo app for remote rendering. Remote-capable components should have a demo here. |
+
+## Technology stack
+
+- [nx](https://nx.dev/) — task orchestration (`affected`, caching, target deps)
+- [pnpm](https://pnpm.io/) — workspace package manager
+- [lerna-lite](https://github.com/lerna-lite/lerna-lite) — only used for publishing (versioning + changelogs from conventional commits)
+- [Vite](https://vite.dev/) — component build; [vitest](https://vitest.dev/) incl. [browser mode](https://vitest.dev/guide/browser/) (Playwright-backed)
+- [Storybook](https://storybook.js.org/) — component dev environment
+- [react-aria-components](https://react-spectrum.adobe.com/react-aria/components.html) — accessibility foundation
+- [style-dictionary](https://styledictionary.com/) — design token compilation
+- [SCSS modules](https://github.com/css-modules/css-modules) — component styling
+- [jscodeshift](https://github.com/facebook/jscodeshift) — consumer codemods
+
+## Commands
+
+```shell
+corepack enable && pnpm install            # setup
+pnpm nx dev components                     # component dev env (Storybook, :6006)
+pnpm build                                 # build everything (runs all generators)
+
+pnpm test                                  # all unit + compile tests
+pnpm affected:test                         # only affected vs. main (what CI runs)
+pnpm nx test:unit components               # unit tests for one package
+pnpm nx test:compile components            # tsc --noEmit for one package
+
+pnpm test:browser:prepare                  # install Playwright browsers (once)
+pnpm nx test:browser components --browser.name=webkit
+pnpm affected:test:browser --parallel=1 --browser.name=webkit   # what CI runs
+pnpm nx test:visual:update remote-react-components              # update visual snapshots
+
+pnpm lint                                  # eslint + stylelint (pre-commit hook runs this)
+pnpm format                                # prettier --write
+```
+
+## Generated code — must be committed
+
+CI enforces `git diff --exit-code` after building: **generated files are
+committed, and hand-editing them is futile** (headers say "auto-generated").
+
+| Generated artifact | Generator |
+| --- | --- |
+| `packages/components/src/components/**/view.ts` + `src/views/*` | `pnpm nx build:remote-components components` |
+| `packages/remote-{elements,react-components,react-renderer}/src/auto-generated/**` | same as above |
+| `packages/components/src/components/Icon/components/icons/*` | `pnpm nx build:icons components` |
+| `packages/icons/src/components/*`, `packages/icons-pro/src/components/*` | `pnpm nx build:icons icons` / `icons-pro` |
+| `packages/components/dist/assets/doc-properties.json` (from prop JSDoc) | `pnpm nx build:docs-properties components` |
+
+Changed props on an `@flr-generate` component, added an icon, or edited prop
+JSDoc? Regenerate (or simply `pnpm build`) and commit the results.
+
+## Development workflow
+
+- **Conventional Commits** with component/package scope — `fix(Button): …`,
+  `feat(components): …`. Releases and changelogs are generated from them.
+- Merged PRs trigger the publish workflow (lerna-lite, fixed versioning across
+  packages).
+- **Maintain the nx wiring for scripts.** Every package script that nx
+  orchestrates needs correct target metadata: `dependsOn` (ordering),
+  `inputs`/`outputs` (caching, affected detection) in the package's
+  `project.json` or in `nx.json` targetDefaults. When adding a script or a
+  new generated artifact, wire these up — otherwise caching serves stale
+  results and `nx affected` misses work.
+- **Git hooks** (simple-git-hooks): `post-checkout` and `post-merge` run
+  `pnpm install && pnpm clean` — expect installs after switching branches.
+  `pre-commit` runs `pnpm lint`.
+- **New dependencies:** pnpm enforces a `minimumReleaseAge` of one week
+  (exempt: `@mittwald/*`) — brand-new versions won't resolve.
+- **Breaking changes for consumers** ship with a `MIGRATION.md` entry and,
+  ideally, a codemod in `packages/codemods` (tedious by hand — a great agent
+  task).
+- `patches/` contains intentional pnpm dependency patches — leave them alone.
+- **Browser support:** all three engines (Chromium, Firefox, WebKit). CI
+  running WebKit only is a pragmatic choice, not a support statement.
+
+## Definition of Done — component work
+
+A new or substantially changed component comes with:
+
+1. Implementation following the patterns in
+   [packages/components/AGENTS.md](packages/components/AGENTS.md)
+2. Stories: `stories/Default.stories.tsx` with realistic args and meaningful
+   variants
+3. A docs page in `apps/docs/src/content/04-components/<category>/…`
+4. Tests along the testing bar: unit tests for lib functions, browser tests
+   for behavior (see the components AGENTS.md testing section)
+5. UI text in `locales/de-DE.locale.json` **and** `locales/en-US.locale.json`
+   (import pattern: i18n section of
+   [packages/components/AGENTS.md](packages/components/AGENTS.md))
+6. Public components exported from `src/components/public.ts`
+   (`flr-universal.ts` additionally, only when remote-capable)
+7. Remote-capable (`@flr-generate`): generated code regenerated + committed,
+   and a demo page in `apps/remote-dom-demo`
+8. Intentional visual changes: snapshots updated (`test:visual:update` or the
+   `update-screenshots` PR label)
+
+## Hard rules
+
+- **Never hand-edit generated files** — regenerate and commit instead.
+- **Base design tokens are taboo; visual design comes from UX** — compose
+  existing tokens and patterns. Adding component tokens for a new component
+  is fine (model them on existing components); when extending tokens, ask
+  instead of inventing.
+- **No breaking changes to `@flr-generate` component props** — deprecate with
+  `useWarnDeprecation` instead.
+- **Use views (`@/views/*`) for internal composition** in `flr-universal`
+  components.
+- **Only remote-capable components in a `PropsContext`** (see the
+  PropsContext section of
+  [packages/components/AGENTS.md](packages/components/AGENTS.md)).
+
+## Where to look next
+
+| Topic | Read |
+| --- | --- |
+| Component patterns, styling, testing, i18n | [packages/components/AGENTS.md](packages/components/AGENTS.md) |
+| Remote connection & serialization | [packages/remote-core/AGENTS.md](packages/remote-core/AGENTS.md) |
+| Remote elements / React API / host renderer | `packages/remote-{elements,react-components,react-renderer}/AGENTS.md` |
+| Icon pipeline | [packages/icons-base/AGENTS.md](packages/icons-base/AGENTS.md) |
+| Design tokens | [packages/design-tokens/AGENTS.md](packages/design-tokens/AGENTS.md) |
+| Remote demo app | [apps/remote-dom-demo/AGENTS.md](apps/remote-dom-demo/AGENTS.md) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -1,0 +1,642 @@
+# Contributing to Flow
+
+First off — thank you for taking the time to contribute! 🎉
+
+**Flow** is [mittwald's design system](https://flow.mittwald.de/). This
+repository is a monorepo containing the React component library, design
+tokens, icon sets, the remote-rendering stack, and the documentation site.
+
+This guide is for people who want to **work on Flow itself**. If you only
+want to _use_ Flow in your own project, you're in the wrong place — head to
+[flow.mittwald.de](https://flow.mittwald.de/) instead. For deep dives beyond
+this guide, every package ships an `AGENTS.md` next to its code — written
+for AI coding agents, but great reference docs for humans too.
+
+## Table of contents
+
+- [Prerequisites](#prerequisites)
+- [Getting started](#getting-started)
+- [Repository overview](#repository-overview)
+- [The ground rules](#the-ground-rules)
+- [Development workflow](#development-workflow)
+- [Anatomy of a component](#anatomy-of-a-component)
+- [Adding or changing a component](#adding-or-changing-a-component)
+- [Design tokens & icons](#design-tokens--icons)
+- [Testing](#testing)
+- [Code style](#code-style)
+- [Commit conventions](#commit-conventions)
+- [Opening a pull request](#opening-a-pull-request)
+- [Releases](#releases)
+- [Getting help](#getting-help)
+
+## Prerequisites
+
+| Tool        | Version                                                         |
+| ----------- | --------------------------------------------------------------- |
+| **Node.js** | `>=20.19` (CI runs on Node 24 — any recent 20.19+ LTS works)    |
+| **pnpm**    | `10.28.2` — pinned via the `packageManager` field, use Corepack |
+| **Git**     | any recent version                                              |
+
+We use [pnpm](https://pnpm.io/) as the package manager. The easiest way to
+get the exact pinned version is
+[Corepack](https://nodejs.org/api/corepack.html), which ships with Node.js:
+
+```shell
+corepack enable
+```
+
+Corepack reads the `packageManager` field in `package.json` and transparently
+uses the correct pnpm version.
+
+## Getting started
+
+```shell
+# 1. Fork the repo on GitHub, then clone your fork
+git clone https://github.com/<your-username>/flow.git
+cd flow
+
+# 2. Install dependencies
+pnpm install
+
+# 3. Install the local Git hooks (see below)
+pnpm dev:init-githooks
+
+# 4. Start the component dev environment (Storybook)
+pnpm nx dev components
+```
+
+Storybook opens on <http://localhost:6006>. This is where you'll spend most
+of your time when developing components.
+
+### Git hooks
+
+`pnpm dev:init-githooks` wires up
+[simple-git-hooks](https://github.com/toplenboren/simple-git-hooks). Once
+installed:
+
+- **pre-commit** runs `pnpm lint` (ESLint + Stylelint) on your changes.
+- **post-checkout** / **post-merge** run `pnpm install && pnpm clean` so your
+  dependencies and Nx cache stay in sync after switching branches or pulling.
+
+## Repository overview
+
+Flow is a **pnpm workspace** monorepo orchestrated with [Nx](https://nx.dev/)
+(task running & caching) and
+[Lerna-Lite](https://github.com/lerna-lite/lerna-lite) (versioning &
+publishing).
+
+The packages you're most likely to touch:
+
+| Package                        | npm name                              | What it is                                                 |
+| ------------------------------ | ------------------------------------- | ---------------------------------------------------------- |
+| `packages/components` ⭐       | `@mittwald/flow-react-components`     | **The core React component library.** Start here.          |
+| `packages/design-tokens`       | `@mittwald/flow-design-tokens`        | Design tokens (colors, spacing, typography) as YAML → CSS  |
+| `packages/icons` / `icons-pro` | `@mittwald/flow-icons` / `-icons-pro` | The default and pro icon sets (generated from `icons-base`) |
+| `packages/stylesheet`          | `@mittwald/flow-stylesheet`           | The components' `all.css`, published as a standalone CSS package |
+| `apps/docs`                    | `@mittwald/flow-documentation`        | The public documentation site (Next.js)                    |
+
+Supporting packages (touch these only when your change concerns them):
+
+| Package                                | Purpose                                                          |
+| -------------------------------------- | ---------------------------------------------------------------- |
+| `packages/remote-*`                    | The remote-rendering stack (render Flow UI from sandboxed mStudio extensions) |
+| `packages/react-tunnel`                | Render React components through a "tunnel" (portal-like)         |
+| `packages/ext-bridge`, `mstudio-ext-*` | Building blocks for mStudio embedded extensions                  |
+| `packages/codemods`                    | Codemods to help consumers migrate between versions              |
+| `packages/typescript-config`           | Shared TypeScript config                                         |
+| `apps/remote-dom-demo`                 | Demo app for the remote-rendering stack                          |
+
+## The ground rules
+
+Five invariants that hold everywhere in this repo — internalize these and
+the rest is detail:
+
+1. **Generated code is committed — and never hand-edited.** Remote views,
+   icon components, and `doc-properties.json` are generated. After changing
+   their sources, regenerate (`pnpm build` covers everything) and commit the
+   result. CI fails on any uncommitted generated diff.
+2. **Don't break extension developers.** Props of `@flr-generate` components
+   are a contract — mStudio extensions in the wild use them. Keep old paths
+   working and log their usage with `useWarnDeprecation`. Breaking changes
+   for consumers ship with a `MIGRATION.md` entry and ideally a codemod in
+   `packages/codemods`.
+3. **Design comes from UX.** Base design tokens are taboo. Component tokens
+   for a new component are fine — model them on existing components and ask
+   when unsure. Never invent visual design.
+4. **UI text is bilingual.** Everything user-facing ships in
+   `locales/de-DE.locale.json` **and** `locales/en-US.locale.json`. A new
+   language is welcome — but then translate everything initially.
+5. **Dependencies are deliberate.** New package versions younger than one
+   week won't resolve (`minimumReleaseAge`; `@mittwald/*` exempt), and the
+   pnpm patches in `patches/` are intentional — leave them alone.
+
+## Development workflow
+
+Nx runs the scripts of each package as **targets**. The general shape is
+`pnpm nx <target> <project>`:
+
+```shell
+pnpm nx dev components      # Storybook for the component library (port 6006)
+pnpm nx dev docs            # the documentation site (Next.js)
+pnpm nx dev remote-dom-demo # the remote-rendering demo app
+pnpm nx build components    # build a single package
+pnpm build                  # build everything (except docs)
+```
+
+A few things worth knowing:
+
+- **Nx caches** target results and only rebuilds what changed. If something
+  seems stale, `pnpm clean` (which runs `nx reset` + each package's `clean`)
+  resets it.
+- **Dependencies build automatically.** `dev`/`build` targets declare
+  `dependsOn`, so e.g. starting the docs site will first build the component
+  library it imports.
+- Inside a package you can also run its scripts directly, but going through
+  `pnpm nx …` from the repo root is preferred so caching and dependency
+  graphs work.
+- **Adding a script?** Wire up its Nx metadata (`dependsOn`,
+  `inputs`/`outputs` in `project.json` or `nx.json`) — otherwise caching
+  serves stale results and `nx affected` misses your target.
+
+## Anatomy of a component
+
+Every component lives in its own **PascalCase** folder under
+`packages/components/src/components/<Name>/` with colocated files:
+
+```
+packages/components/src/components/Button/
+├── Button.tsx              # implementation
+├── Button.module.scss      # styles (CSS Module written in SCSS)
+├── index.ts                # barrel export (3 lines, see below)
+├── view.ts                 # ⚙️ AUTO-GENERATED — do not edit by hand
+└── stories/
+    └── Default.stories.tsx # Storybook stories
+
+# richer components add, as needed:
+├── <Name>.browser.test.tsx # interaction tests (run in a real browser)
+├── locales/                # i18n strings, one file per locale
+│   ├── en-US.locale.json
+│   └── de-DE.locale.json
+├── components/             # nested sub-components (same layout, recursively)
+├── hooks/ · lib/           # component-specific hooks / pure helpers
+```
+
+Internally, source files import each other through the **`@/` alias**, which
+maps to `packages/components/src/`. Consumers (and the docs examples) import
+from the published name `@mittwald/flow-react-components`.
+
+## Adding or changing a component
+
+Components are **not** written with `forwardRef` or `FC` directly. They are
+wrapped in the **`flowComponent(name, impl)`** factory, use
+[`react-aria-components`](https://react-spectrum.adobe.com/react-aria/) for
+behavior and accessibility, [`clsx`](https://github.com/lukeed/clsx) for
+class composition, and CSS Modules for styling.
+
+Before you code: pick a similar existing component as your template —
+`TextField` (form control), `Modal` (overlay), `Alert` (simple semantic
+component), `Button` (action). Copying its structure is the fastest way to
+get every convention right.
+
+Here's the full checklist for a **new component** — using `Badge` as an
+example.
+
+### 1. Write the component
+
+`src/components/Badge/Badge.tsx`:
+
+```tsx
+import type { PropsWithChildren } from "react";
+import styles from "./Badge.module.scss";
+import clsx from "clsx";
+import type { FlowComponentProps } from "@/lib/componentFactory/flowComponent";
+import { flowComponent } from "@/lib/componentFactory/flowComponent";
+
+export interface BadgeProps
+  extends PropsWithChildren, FlowComponentProps<HTMLSpanElement> {
+  /** The color of the badge. @default "primary" */
+  color?: "primary" | "danger";
+}
+
+/** @flr-generate all */
+export const Badge = flowComponent("Badge", (props) => {
+  const { color = "primary", className, children, ref, ...restProps } = props;
+  const rootClassName = clsx(styles.badge, styles[color], className);
+
+  return (
+    <span className={rootClassName} ref={ref} {...restProps}>
+      {children}
+    </span>
+  );
+});
+
+export default Badge;
+```
+
+Conventions to follow **exactly**:
+
+- Export an interface named `<Name>Props` that extends the relevant
+  `Aria.*Props` (when wrapping a React Aria component) **and**
+  `FlowComponentProps<HTMLElement>` (this supplies `ref`, `tunnel`,
+  `wrapWith`, …). The **ref is a normal prop** (React 19) — no `forwardRef`.
+- **Document every public prop with a JSDoc comment.** These are extracted
+  into the property tables on the docs site — undocumented props ship with
+  empty descriptions. Use `@default` for defaults and `@internal` for props
+  that aren't part of the public API.
+- Wrap the implementation in `flowComponent("<Name>", (props) => …)`. The
+  string **must** match the name you register in step 4.
+- The `/** @flr-generate all */` tag marks the component as
+  **remote-capable**: the generator emits remote/view artifacts for it
+  (step 6), and its props become part of the extension contract. Only add it
+  when the component should be available to mStudio extensions.
+- Export the component **both** as a named export and as the `default`.
+
+### 2. Write the styles
+
+`src/components/Badge/Badge.module.scss` — a CSS Module in SCSS. Scoped
+class names are generated from the component path (semantic CSS by design),
+so don't bypass CSS Modules for component roots. **Never hard-code values**:
+use design-token CSS custom properties, and shared mixins from
+`@/styles/mixins/` (`focus`, `formControl`, `ellipsis`):
+
+```scss
+@use "@/styles/mixins/focus";
+
+.badge {
+  // generic tokens (defined in @mittwald/flow-design-tokens)
+  font-size: var(--font-size-text--s);
+  padding: var(--size-px--xxs) var(--size-px--xs);
+  // component-scoped tokens follow the `--<component>--*` naming convention
+  border-radius: var(--badge--corner-radius);
+
+  &:focus-visible {
+    @include focus.focus;
+  }
+}
+```
+
+The root class is the lower-camel component name; modifier classes match
+prop values (`.primary`, `.size-s`). Need new `--badge--*` tokens? See
+[Design tokens & icons](#design-tokens--icons).
+
+### 3. Add the barrel `index.ts`
+
+Always the same three lines (the `./view` line only exists on
+`@flr-generate` components — the file is generated in step 6):
+
+```ts
+export * from "./view";
+export { type BadgeProps, Badge } from "./Badge";
+export { default } from "./Badge";
+```
+
+### 4. Register the component in the public API
+
+This is the **easy-to-miss** step. Two central registries must be updated,
+or the component won't be exported / won't type-check:
+
+1. **`src/components/public.ts`** — add (alphabetically):
+
+   ```ts
+   export * from "@/components/Badge";
+   ```
+
+2. **`src/components/propTypes/index.ts`** — this is the type registry
+   `flowComponent()` is generic over. Import the props type, add it to the
+   `FlowComponentPropsTypes` interface, and (if the component supports
+   `PropsContext`) add it to `propsContextSupportingComponentsMap`:
+
+   ```ts
+   import type { BadgeProps } from "@/components/Badge/Badge";
+   // …
+   export interface FlowComponentPropsTypes {
+     // …
+     Badge: BadgeProps;
+   }
+   ```
+
+Remote-capable components are additionally exported from
+**`src/index/flr-universal.ts`** — being in `public.ts` does **not**
+automatically include a component there.
+
+### 5. Style children via PropsContext
+
+When your component composes other Flow components, don't thread `className`
+or defaults down manually — provide a `PropsContext` so children adapt
+automatically (this is the backbone of Flow's composability; e.g. an
+`<Icon>` inside `<IllustratedMessage>` automatically renders with
+`size="l"`):
+
+```tsx
+import { PropsContextProvider, type PropsContext } from "@/lib/propsContext";
+
+const propsContext: PropsContext = {
+  Icon: { className: styles.icon, size: "l" },
+};
+
+<PropsContextProvider props={propsContext}>{children}</PropsContextProvider>;
+```
+
+- `dynamic()` derives context values from the consumer's local props.
+- **Only remote-capable components belong in a context** — non-remote
+  components break remote rendering.
+- Inside `flr-universal` components, compose internals through **views**
+  (`@/views/*` — e.g. `ButtonView` instead of `Button`): views switch to the
+  remote counterpart automatically.
+
+### 6. Generate the remote artifacts
+
+`view.ts` is **auto-generated** from the `@flr-generate` tag — never edit it
+by hand. Regenerate it (and the auto-generated files in the `remote-*`
+packages) with:
+
+```shell
+pnpm nx build:remote-components components
+```
+
+> ⚠️ **Commit the generated files.** CI runs `git diff --exit-code` and will
+> fail if generated code (remote views, icons) isn't committed. See
+> [Testing](#testing).
+
+For remote-capable components, also:
+
+- Exclude props that must not cross the remote boundary with
+  `@flr-ignore-props` (`style` & friends are ignored globally — see
+  `dev/remote-components-generator/config.ts`).
+- Add a demo page in `apps/remote-dom-demo/src/app/remote/<component>/`.
+- Remember: from now on these props are a **contract with extension
+  developers** — never break them; deprecate with `useWarnDeprecation`.
+
+### 7. Add a Storybook story
+
+`src/components/Badge/stories/Default.stories.tsx`. The `title` groups the
+component into a category (`Actions`, `Form Controls`, `Status`,
+`Overlays`, …) — match the category used on the docs site. Use realistic
+args and add a named story per meaningful variant or state:
+
+```tsx
+import { Badge } from "../index";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof Badge> = {
+  title: "Status/Badge",
+  component: Badge,
+};
+
+export default meta;
+
+export const Default: StoryObj<typeof Badge> = {
+  args: { children: "New" },
+};
+```
+
+### 8. Localize (only if the component has user-facing strings)
+
+Add `locales/de-DE.locale.json` **and** `locales/en-US.locale.json`
+([ICU MessageFormat](https://formatjs.github.io/docs/core-concepts/icu-syntax/)
+is supported), then consume them with
+`useLocalizedStringFormatter(locales, "<Name>")` from
+`@/components/TranslationProvider`:
+
+```tsx
+import locales from "./locales/*.locale.json";
+import { useLocalizedStringFormatter } from "@/components/TranslationProvider";
+// …
+const stringFormatter = useLocalizedStringFormatter(locales, "Badge");
+stringFormatter.format("dismiss");
+stringFormatter.format("itemCount", { count: 3 });
+```
+
+```json
+// locales/de-DE.locale.json — plain strings, variables, plural/select:
+{
+  "dismiss": "Schließen",
+  "itemCount": "{count, plural, one {Ein Element} other {{count} Elemente}}"
+}
+```
+
+(For real-world plural/select usage, see
+`src/components/PasswordCreationField/locales/`.)
+
+Accessibility goes hand in hand with this: icon-only buttons need a
+localized `aria-label`, decorative icons are `aria-hidden` (the `Icon`
+component handles that automatically when no label is given).
+
+### 9. Document it on the docs site
+
+Add a doc set under `apps/docs/src/content/04-components/<category>/<slug>/`
+(the content is **not** colocated with the component — copy the structure of
+a neighbor like `actions/button/`):
+
+- `index.mdx` — frontmatter `component: Badge` + a `description:`
+- `overview.mdx` — usage narrative with `<LiveCodeEditor example="…" />`
+  blocks
+- `guidelines.mdx` — design guidelines (when to use / when not)
+- `develop.mdx` — usually `# Properties` + `<PropertiesTables />`
+  (generated from your prop JSDoc; regenerate with
+  `pnpm nx build:docs-properties components`)
+- `examples/*.tsx` — live-code snippets, importing from
+  `@mittwald/flow-react-components`
+
+The docs prose is written in **German**. Preview with `pnpm nx dev docs`.
+
+## Design tokens & icons
+
+Some source files are **generated** and must not be hand-edited:
+
+- **Design tokens** are authored as YAML in
+  `packages/design-tokens/src/**/*.yml` and built to CSS with
+  style-dictionary. Component tokens live in category files —
+  `src/actions/button.yml` defines the `--button--*` custom properties.
+  Adding a file like this for a new component is fine (model it on an
+  existing one). **Base tokens** (top-level files: colors, font, size, …)
+  are design authority — never change them on your own; ask when unsure.
+- **Icons** have a single source of truth: `packages/icons-base/src/icons.yaml`.
+  The icon sets and the component-internal icons are generated from it:
+  `pnpm nx build:icons icons`, `… icons-pro`, `… components` — or simply
+  `pnpm build`.
+
+## Testing
+
+Tests use [Vitest](https://vitest.dev/) and are **colocated** next to the
+code. Naming decides how a test runs:
+
+| File pattern         | Project   | Runs in        | Use for                            |
+| -------------------- | --------- | -------------- | ---------------------------------- |
+| `*.browser.test.tsx` | `browser` | a real browser | component interaction / rendering  |
+| `*.test.ts(x)`       | `unit`    | happy-dom      | pure logic (helpers, hooks)        |
+| `*.test-types.tsx`   | —         | type-check     | generic/typed public APIs          |
+
+The bar: **every component has stories** (they double as the review and
+visual-test surface); browser tests when there is real behavior
+(interaction, controlled state, async flows, forms); unit tests for lib
+functions; type tests for generic APIs.
+
+Run them per package via Nx:
+
+```shell
+pnpm nx test:compile components      # type-check (tsc --noEmit)
+pnpm nx test:unit components         # unit tests
+pnpm nx test:browser components --browser.name=webkit   # browser tests (headless)
+
+# watch mode while developing:
+pnpm nx test:unit:dev components
+pnpm nx test:browser:dev components
+```
+
+Browser tests need the Playwright browsers installed once:
+
+```shell
+pnpm test:browser:prepare
+```
+
+A browser interaction test looks like this:
+
+```tsx
+import TextField from "@/components/TextField";
+import { render } from "vitest-browser-react";
+import { userEvent } from "vitest/browser";
+
+test("TextField keeps its value on blur", async () => {
+  const dom = await render(<TextField aria-label="test" />);
+  const input = dom.getByRole("textbox");
+  await userEvent.type(input, "hello");
+  await userEvent.tab();
+  expect(input).toHaveDisplayValue("hello");
+});
+```
+
+(`globals: true` is set, so `test` / `expect` don't need to be imported.
+Query by role — that keeps the DOM accessible, too.)
+
+### Visual regression testing
+
+Visual regression tests live in **`packages/remote-react-components`**
+(`src/tests/visual/`). They render each component in **both** the local and
+the remote environment and compare against committed screenshots — catching
+unintended visual changes, such as a design-token tweak that ripples further
+than expected. Screenshots are keyed by browser and OS
+(e.g. `Badge-webkit-linux.png`).
+
+```shell
+# run the visual tests (headless, WebKit):
+pnpm nx test:visual remote-react-components --browser.name=webkit
+
+# open a real browser to inspect interactively:
+pnpm nx test:visual:dev remote-react-components --browser.name=webkit
+```
+
+When you add or change a component, update its screenshots and review the
+diffs:
+
+```shell
+pnpm nx test:visual:update remote-react-components          # all (slow!)
+pnpm nx test:visual:update remote-react-components <Name>   # single component
+```
+
+Local runs update the baselines for **your** OS. Additionally add the
+**`update-screenshots`** label to your PR — a GitHub Action regenerates the
+reference screenshots on Linux (matching CI) and commits them back to your
+branch.
+
+> ⚠️ When a visual test fails, it writes `*--Local--*.png` /
+> `*--Remote--*.png` diff artifacts showing the difference between the two
+> environments. Use them to inspect the failure — but **never commit them**;
+> only the baselines belong in the repo.
+
+To run everything the way CI does:
+
+```shell
+pnpm lint                                                       # ESLint + Stylelint
+pnpm affected:test                                              # unit + compile, changed projects
+pnpm affected:test:browser --parallel=1 --browser.name=webkit   # browser/e2e/visual
+```
+
+> ⚠️ **Generated code must be committed.** The final CI step is
+> `git diff --exit-code`. If you changed a component with `@flr-generate` or
+> touched icons, run the relevant `build:*` target and commit the result —
+> otherwise CI fails even though your code is correct.
+
+## Code style
+
+Formatting and linting are enforced; the pre-commit hook runs `pnpm lint`
+for you.
+
+```shell
+pnpm lint      # check with ESLint + Stylelint
+pnpm format    # auto-format everything with Prettier
+```
+
+Enforced conventions (see `eslint.config.js` / `.prettierrc.json`):
+
+- Double quotes, semicolons required, Unix (`\n`) line endings.
+- `import type { … }` for type-only imports (separated from value imports).
+- Unused variables are errors — intentionally-unused ones need `ignored` in
+  their name (e.g. `argIgnored`).
+
+## Commit conventions
+
+Flow uses [Conventional Commits](https://www.conventionalcommits.org/). This
+is **not optional cosmetics** — Lerna-Lite derives version bumps and the
+changelog from your commit messages.
+
+```
+<type>(<scope>): <short summary>
+```
+
+- **type**: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `ci`, …
+- **scope**: the component or area you touched — e.g. the component name
+  (`Button`, `TextField`), or an area (`components`, `docs`, `ci`, `Remote`).
+
+Real examples from the history:
+
+```
+feat(components): add deprecation warning provider
+fix(PasswordCreationField): adjust validation behavior
+fix(CodeEditor): fix height and colors
+chore(docs): migrate site URL and redirect pages
+```
+
+`feat` and `fix` are user-facing and drive releases; use `chore`/`docs`/`ci`
+for everything that isn't. Write messages for the changelog reader.
+
+## Opening a pull request
+
+1. Branch off `main`: `git checkout -b fix/button-focus-ring`.
+2. Make your change, following the conventions above.
+3. Before pushing, make sure the checklist passes:
+   - [ ] `pnpm lint` is clean
+   - [ ] `pnpm affected:test` passes (unit + type-check)
+   - [ ] browser tests pass if you touched behavior
+   - [ ] **generated code is committed** (`git diff` is empty after running
+         the relevant `build:*` targets)
+   - [ ] intentional visual changes: snapshots updated
+         (`test:visual:update` locally and/or the `update-screenshots` label)
+   - [ ] docs updated if you changed a public API
+4. Push to your fork and open a PR against `mittwald/flow`'s `main` branch.
+
+CI (`.github/workflows/test.yml`) runs lint, unit tests, and browser tests
+(WebKit) on every PR, and verifies all generated code is committed. A
+preview deployment of docs + Storybook is built for each PR so reviewers can
+see your changes live.
+
+PRs are **squash-merged**, so the PR title becomes the commit on `main` —
+give it a Conventional-Commits-style title.
+
+## Releases
+
+You don't need to do anything to release. When a PR is merged into `main`,
+Lerna-Lite (via `.github/workflows/publish.yml`) versions the packages based
+on the Conventional Commits, generates the changelogs, and publishes to npm.
+
+## Getting help
+
+- 🐛 **Found a bug?** Open an issue using the
+  [bug report template](.github/ISSUE_TEMPLATE/bug_report.yml).
+- 🎨 **Feedback on the design / style guide?** Use the
+  [style guide feedback template](.github/ISSUE_TEMPLATE/general-style_guide_feedback.yml).
+- 📖 **Docs:** [flow.mittwald.de](https://flow.mittwald.de/)
+- 🧩 **Storybook:**
+  [storybook.flow-components.de](https://storybook.flow-components.de)
+
+Happy contributing! 💙

--- a/apps/remote-dom-demo/AGENTS.md
+++ b/apps/remote-dom-demo/AGENTS.md
@@ -1,0 +1,9 @@
+# remote-dom-demo — Agent Guide
+
+Next.js demo app exercising the remote rendering stack (remote components,
+events, forms, suspense, ext-bridge, navigation, performance).
+
+- New remote-capable components (`@flr-generate`) should get a demo page here
+  — it is part of the Definition of Done (see the
+  [root AGENTS.md](../../AGENTS.md)).
+- Run with `pnpm nx dev remote-dom-demo`.

--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -1,0 +1,226 @@
+# @mittwald/flow-react-components — Agent Guide
+
+Component patterns for the core package. Read the
+[root AGENTS.md](../../AGENTS.md) first for repo-wide rules (generated code,
+Definition of Done, workflow).
+
+## Component anatomy
+
+```
+src/components/Button/
+├── Button.tsx               # implementation (hand-written)
+├── Button.module.scss       # styles (hand-written)
+├── index.ts                 # barrel (hand-written)
+├── view.ts                  # GENERATED — remote view declaration (@flr-generate only)
+├── stories/
+│   ├── Default.stories.tsx  # Storybook stories (expected for every component)
+│   └── lib.tsx              # shared story fixtures/helpers (optional)
+├── components/              # subcomponents, same anatomy (optional)
+├── locales/                 # de-DE.locale.json + en-US.locale.json (when UI text)
+└── *.browser.test.tsx       # behavior tests (when behavior is non-trivial)
+```
+
+The barrel exports the view first (only on `@flr-generate` components), then
+the component:
+
+```ts
+export * from "./view";
+export { type ButtonProps, Button } from "./Button";
+export { default } from "./Button";
+```
+
+## The flowComponent factory
+
+Nearly every component registers through
+`flowComponent(name, Implementation, options?)`
+(`src/lib/componentFactory/flowComponent.tsx`). It wires up the props context,
+tunnel support, `wrapWith`, and remote isolation — do not rebuild any of that
+manually.
+
+```tsx
+import type { PropsWithChildren } from "react";
+import type Aria from "react-aria-components";
+import {
+  flowComponent,
+  type FlowComponentProps,
+} from "@/lib/componentFactory/flowComponent";
+
+export interface ButtonProps
+  extends PropsWithChildren<Omit<Aria.ButtonProps, "children">>,
+    FlowComponentProps<HTMLButtonElement> {
+  /** The color of the button. @default "primary" */
+  color?: "primary" | "accent" | "secondary" | "danger";
+}
+
+/** @flr-generate all */
+export const Button = flowComponent("Button", (props) => {
+  const { color = "primary", className, ref, ...rest } = props;
+  // …
+});
+
+export default Button;
+```
+
+Conventions:
+
+- Props type is exported as `<Name>Props`; it extends the wrapped React Aria
+  props plus `FlowComponentProps<RefElement>`.
+- **Ref as prop** (React 19) — no `forwardRef`.
+- `options.type`: `"ui"` (default — gets props-context isolation),
+  `"layout"`, or `"provider"`. The factory applies `ClearPropsContext`
+  isolation for UI components itself — don't add extra clearing casually.
+- The registered name must match the component/directory name, and the props
+  type must be registered in `src/components/propTypes/index.ts`
+  (`FlowComponentPropsTypes`) — `flowComponent` names are typed as `keyof`
+  of that hand-maintained registry, so a missing entry fails the typecheck.
+- Most components wrap `react-aria-components` primitives; expose ARIA props
+  directly only where React Aria lacks the behavior.
+
+## PropsContext — contextual composability
+
+`PropsContext` makes components adapt **automatically** when composed inside
+other components: they receive default prop values and, mainly, CSS classes
+from their surroundings. This is the backbone of Flow's composability.
+
+```tsx
+// IllustratedMessage.tsx — every <Icon> inside renders large:
+const propsContext: PropsContext = {
+  Icon: { className: styles.icon, size: "l" },
+  Heading: { className: styles.heading, color },
+};
+
+return (
+  <div {...rest}>
+    <PropsContextProvider props={propsContext}>{children}</PropsContextProvider>
+  </div>
+);
+```
+
+- Contexts **nest** (a context can configure props contexts of nested
+  components) and support **dynamic props**:
+  `dynamic((localProps) => value)` derives values from the consumer's props.
+- Local props always win over context props.
+- Although exported, `PropsContext` is **primarily an internal API** — prefer
+  it for intra-Flow composition, not as a consumer-facing feature.
+- **Only put remote-capable components into a `PropsContext`** — non-remote
+  components break remote rendering.
+- When parent context must not leak into a component's children, use targeted
+  clearing, e.g. `wrapWith: <ClearPropsContext />` (see `Modal.tsx`).
+
+## Views — remote-transparent composition
+
+Components tagged `/** @flr-generate all */` get a generated view
+(`view.ts` + `src/views/<Name>View.tsx`). **Inside `flr-universal` components,
+compose other Flow components through their views** (`@/views/*`) — a view
+automatically switches to the remote counterpart in a remote context:
+
+```tsx
+import ButtonView from "@/views/ButtonView";   // ✓ works local and remote
+import { Button } from "@/components/Button";  // ✗ host-only in remote context
+```
+
+Remote generation details:
+
+- `@flr-generate all` on the component const marks it for generation.
+- `@flr-ignore-props` excludes props that must not cross the remote boundary —
+  either because they cannot be serialized, or because they could do **too
+  much on the host side**. A global ignore list lives in
+  `dev/remote-components-generator/config.ts`: `style` and
+  `dangerouslySetInnerHTML` are always ignored for safety; `ref`,
+  `controller`, `tunnel`, `key`, `children`, `wrapWith` because they don't
+  serialize. Use the per-component tag for additional cases (see
+  `TunnelEntry.tsx`).
+- After changing props of an `@flr-generate` component:
+  `pnpm nx build:remote-components components` and **commit** the results
+  (view.ts, `src/views/*`, `remote-*/src/auto-generated/**`).
+- Props of these components are consumed by mStudio extension developers —
+  no breaking changes; deprecate instead:
+
+```tsx
+const warnDeprecation = useWarnDeprecation();
+if ("action" in props) {
+  warnDeprecation("The 'action' prop is deprecated. Use 'onAction' instead.");
+}
+```
+
+## Styling
+
+- One `<Name>.module.scss` per component. Scoped class names are generated
+  from the component's **path** (`dev/vite/cssModuleClassNameGenerator.ts`) —
+  deliberately semantic CSS that could be used standalone. Never bypass CSS
+  modules for component roots (the global reset targets `flow--` classes).
+- Root class is the lower-camel component name (`.button`); modifier classes
+  match prop values (`.size-s`, `.primary`).
+- Class composition with `clsx`, consumer `className` appended last:
+  `clsx(styles.button, styles[size], styles[color], className)`.
+- **Use design-token CSS variables** — global (`--font-size-text--m`) or
+  component-namespaced (`--button--corner-radius`). No hard-coded colors,
+  sizes, radii.
+- Shared mixins via `@use "@/styles/mixins/…"`: `focus` (focus ring),
+  `formControl` (border/color/interaction states of form fields), `ellipsis`.
+  Group repeated variants in local mixins.
+- Structure sections with comments: `/* Elements */`, `/* States */`,
+  `/* Size */`, `/* Variants */`.
+
+## Testing — the actual bar
+
+| Artifact | When |
+| --- | --- |
+| `stories/Default.stories.tsx` | **Always.** Realistic args, controls, meaningful variants. Story title category matches the docs (`Actions/…`, `Form Controls/…`, `Overlays/…`, `Status/…`). |
+| `*.browser.test.tsx` (vitest browser mode) | Component has real **behavior**: interaction, controlled state, async flows, form integration, controllers. Render with `vitest-browser-react`, interact via `userEvent`, query by role. |
+| `*.test.ts(x)` (unit) | Pure logic in `src/lib/` or component utility functions. |
+| `*.test-types.tsx` | Generic/typed public APIs — `expectTypeOf` plus `@ts-expect-error` negative assertions. |
+
+Run: `pnpm nx test:unit components`,
+`pnpm nx test:browser components --browser.name=webkit`. Browser tests need
+`pnpm test:browser:prepare` once.
+
+## i18n & a11y
+
+- Component-internal UI text lives in colocated `locales/de-DE.locale.json`
+  **and** `locales/en-US.locale.json` — always add both languages. The
+  strings support ICU MessageFormat (variables, `plural`, `select` — see
+  `PasswordCreationField/locales/` for real usage). Import the files with a
+  glob import and consume them via the Flow hook:
+
+  ```tsx
+  import locales from "./locales/*.locale.json";
+  import { useLocalizedStringFormatter } from "@/components/TranslationProvider";
+
+  const stringFormatter = useLocalizedStringFormatter(locales, "Modal");
+  ```
+
+- Introducing a **new language** is welcome — but translate everything
+  initially: every `locales/` directory in the package gets the new file.
+- Icon-only buttons get a localized `aria-label`; decorative icons are
+  `aria-hidden` (the `Icon` component handles this when no label is given).
+- Form fields wire label/description/error via `useFieldComponent`
+  (generates ids, sets `aria-describedby`).
+
+## Public API surfaces
+
+| Export | Contents |
+| --- | --- |
+| `.` (default) | Everything listed **manually** in `src/components/public.ts` — new public components must be added there. |
+| `./internal` | Advanced internals (`flowComponent`, prop helper types, …). |
+| `./flr-universal` | Curated subset that works local *and* remote. Adding to `public.ts` does **not** add here. |
+| `./nextjs`, `./react-hook-form`, `./mittwald-password-tools-js` | Integrations (`src/integrations/`): wrappers around third-party dependencies that not every consumer should pay for — they get their own export entry instead of entering the core surface. |
+| `./all.css` | Bundled stylesheet. |
+| `./doc-properties` | Generated prop metadata for the docs site. |
+
+Prop JSDoc feeds the generated `doc-properties.json` and the docs site: write
+doc comments on public props, use `@default` for defaults and `@internal` for
+props to hide.
+
+## Misc
+
+- Feature flags: `src/flags.ts` holds a few behavior toggles; there is no
+  formal policy around them.
+- `SettingsProvider` (`src/components/SettingsProvider/`) is the built-in
+  persistence for component settings (e.g. `List` remembering its view
+  settings), with pluggable backends (localStorage by default). Internal
+  component infrastructure — extension developers don't need it.
+- `stories/lib.tsx` holds story-only fixtures — never import it from
+  component code.
+- Storybook discovers all `src/**/*.stories.tsx` automatically; there is no
+  registry to update.

--- a/packages/components/CLAUDE.md
+++ b/packages/components/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/design-tokens/AGENTS.md
+++ b/packages/design-tokens/AGENTS.md
@@ -1,0 +1,15 @@
+# @mittwald/flow-design-tokens — Agent Guide
+
+Design tokens for mittwald Flow. See the [root AGENTS.md](../../AGENTS.md).
+
+- The YAML files are the **source of truth**, defined together with UX —
+  **design authority**. **Base tokens** (top-level files: colors, font,
+  size, border, …) are taboo — never add or change them on your own.
+  Adding **component tokens** for a new component (category files like
+  `src/actions/button.yml`) is fine — model them on existing components
+  and ask when unsure.
+- `node build-tokens.js` (nx target `build`) compiles them with
+  [style-dictionary](https://styledictionary.com/) to `dist/css/*` (CSS
+  variables; theme variants keyed by `data-theme`) and `dist/json/*`.
+- Consumers: `components` SCSS uses the CSS variables; some runtime helpers
+  (e.g. categorical chart colors) read the JSON output.

--- a/packages/icons-base/AGENTS.md
+++ b/packages/icons-base/AGENTS.md
@@ -1,0 +1,15 @@
+# @mittwald/flow-icons-base — Agent Guide
+
+Private icon source + shared generator tooling. See the
+[root AGENTS.md](../../AGENTS.md).
+
+- `src/icons.yaml` is the **single source of truth** for all icon sets. An
+  icon defines a `category`, vendor names (`tb` = Tabler, `fa` = FontAwesome)
+  and/or a custom `svg`.
+- Generated outputs (all committed, never hand-edited):
+  - `packages/icons/src/components/*` — default set (Tabler)
+  - `packages/icons-pro/src/components/*` — pro set (FontAwesome sharp-regular)
+  - `packages/components/src/components/Icon/components/icons/*`
+- Adding/updating an icon: edit `src/icons.yaml`, then regenerate and commit:
+  `pnpm nx build:icons icons && pnpm nx build:icons icons-pro && pnpm nx build:icons components`
+  (or simply `pnpm build`).

--- a/packages/icons-pro/AGENTS.md
+++ b/packages/icons-pro/AGENTS.md
@@ -1,0 +1,7 @@
+# @mittwald/flow-icons-pro — Agent Guide
+
+Published pro icon set (FontAwesome sharp-regular, with Tabler/custom SVG
+fallback). `src/components/*` and `src/iconSet.ts` are **fully generated**
+from [`packages/icons-base`](../icons-base/AGENTS.md) — never edit them by
+hand. Change `packages/icons-base/src/icons.yaml` and run
+`pnpm nx build:icons icons-pro` instead.

--- a/packages/icons/AGENTS.md
+++ b/packages/icons/AGENTS.md
@@ -1,0 +1,7 @@
+# @mittwald/flow-icons — Agent Guide
+
+Published default icon set (Tabler). `src/components/*`, `src/iconSet.ts` and
+`src/iconCategories.ts` are **fully generated** from
+[`packages/icons-base`](../icons-base/AGENTS.md) — never edit them by hand.
+Change `packages/icons-base/src/icons.yaml` and run
+`pnpm nx build:icons icons` instead.

--- a/packages/remote-core/AGENTS.md
+++ b/packages/remote-core/AGENTS.md
@@ -1,0 +1,16 @@
+# @mittwald/flow-remote-core — Agent Guide
+
+Connection + serialization layer between host (mStudio) and remote apps
+(extensions). See the remote-DOM overview in the
+[root AGENTS.md](../../AGENTS.md).
+
+- Built on `@quilted/threads` (patched via `patches/` — leave the patch alone)
+  and a fork of [Shopify remote-dom](https://github.com/Shopify/remote-dom).
+  The fork lives at <https://github.com/mfal/remote-dom>, branch
+  `publish/mittwald` (published as `@mittwald/remote-dom-*`).
+- The connection protocol is **versioned**: the host reacts to different
+  remote versions at connection time. **Changes here must stay backwards
+  compatible** — extensions in the wild connect with older versions.
+- `FlowThreadSerialization` controls which values cross the thread boundary
+  (deliberately excludes `HTMLElement`/`window`).
+- Unit tests run in happy-dom: `pnpm nx test:unit remote-core`.

--- a/packages/remote-elements/AGENTS.md
+++ b/packages/remote-elements/AGENTS.md
@@ -1,0 +1,10 @@
+# @mittwald/flow-remote-elements — Agent Guide
+
+Custom elements (`flr-*`) representing Flow components on the remote side.
+See the remote-DOM overview in the [root AGENTS.md](../../AGENTS.md).
+
+- `src/auto-generated/**` is **generated** from `packages/components`
+  (`pnpm nx build:remote-components components`) — never edit by hand.
+- Hand-written parts live in `src/lib/` (e.g. `FlowRemoteElement`, the base
+  class all Flow remote elements extend) plus a few special elements
+  (Form, SlotRootWrapper).

--- a/packages/remote-react-components/AGENTS.md
+++ b/packages/remote-react-components/AGENTS.md
@@ -1,0 +1,19 @@
+# @mittwald/flow-remote-react-components — Agent Guide
+
+React API used *inside* remote apps (mStudio extensions). This package's
+exports are what extension developers program against — **treat its API as a
+contract** (see the remote-DOM rules in the [root AGENTS.md](../../AGENTS.md)).
+
+- `src/auto-generated/**` is **generated** from `packages/components` — never
+  edit by hand.
+- Hand-written: `RemoteRoot` (connects to the host render root, initializes
+  ext-bridge) and the `createFlowRemoteComponent` machinery.
+- Richest test surface outside `components`: unit, browser, e2e and visual
+  tests. **Visual tests must pass in both environments — `Local` and
+  `Remote`** (see `CONTRIBUTE.md` and `src/tests/lib/environments.tsx`).
+- Update visual snapshots: `pnpm nx test:visual:update remote-react-components`.
+  Updating everything takes long — for a single component use
+  `pnpm nx test:visual:update remote-react-components MyNewComponent`.
+- Failing visual tests write `*--Local--*.png` / `*--Remote--*.png` diff
+  artifacts — useful for inspection, **never commit them**. Only the
+  baselines (`<Name>-<browser>-<os>.png`) belong in the repo.

--- a/packages/remote-react-renderer/AGENTS.md
+++ b/packages/remote-react-renderer/AGENTS.md
@@ -1,0 +1,10 @@
+# @mittwald/flow-remote-react-renderer — Agent Guide
+
+Host-side renderer: receives the remote DOM and materializes `flr-*` elements
+as real Flow components. See the remote-DOM overview in the
+[root AGENTS.md](../../AGENTS.md).
+
+- `src/auto-generated/**` (the component renderer map) is **generated** from
+  `packages/components` — never edit by hand.
+- Hand-written: `RemoteRendererBrowser` (hidden iframe + `RemoteReceiver`
+  wiring) and special-case renderers merged in `src/components.ts`.


### PR DESCRIPTION
## What

Adds a canonical documentation layer for AI coding agents and human contributors:

- **`AGENTS.md` (root)** — the project map: what Flow is, the three systems (design system core, remote DOM/"flr", token pipeline), repository map, tech stack, commands, generated-code rules, Definition of Done for component work, and the hard rules.
- **Per-package `AGENTS.md` deep dives** — component patterns in `packages/components` (flowComponent factory, PropsContext, views, styling, testing bar, i18n, public API surfaces), the remote stack (`remote-core`, `remote-elements`, `remote-react-components`, `remote-react-renderer`), icon pipeline (`icons-base`, `icons`, `icons-pro`), design tokens, and the remote demo app.
- **`CLAUDE.md` pointers** (root + components) — one-line `@AGENTS.md` imports so Claude Code loads the same canonical guides (no content duplication, portable instead of symlinks).
- **`CONTRIBUTE.md`** — human contributor guide: setup, repository overview, ground rules, and a step-by-step walkthrough for contributing a component (scaffold → implementation → registries → PropsContext → remote artifacts → stories → locales → docs page), plus testing (incl. visual regression), code style, commit conventions, and PR workflow.
- **`.claude/commands/review-flow.md`** — a shared review command that checks a diff against the documented patterns and CI gates (generated code committed, extension-contract backwards compatibility, Definition of Done, token rules).

## Why

Convention knowledge was spread across package READMEs and team memory. Codifying it in `AGENTS.md`/`CONTRIBUTE.md` gives AI agents (Claude Code, Codex) and new contributors one source of truth — improving code reviews ("were the patterns followed? were tests written?"), questions, and day-to-day development in this repo.

## Notes for reviewers

- All factual claims (commands, file structures, code snippets, naming) were verified against the actual code; conventions were additionally confirmed in a maintainer Q&A.
- The normative sections deserve the closest read: **Definition of Done** and **Hard rules** (root `AGENTS.md`), the **testing bar** (`packages/components/AGENTS.md`), and the **ground rules** (`CONTRIBUTE.md`).
- The existing package-level `CONTRIBUTE.md` files are untouched; their content is now covered by the `AGENTS.md` layer — removing them can be a follow-up.
- Docs-only change: no runtime code, no generated artifacts affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)