### PR TITLE
feat(components): serve all.css via CSS cascade layers

### DIFF
--- a/apps/docs/src/content/01-get-started/stylesheet/index.mdx
+++ b/apps/docs/src/content/01-get-started/stylesheet/index.mdx
@@ -102,3 +102,42 @@ sowie den spezialisierten Klassennamen (`flow--alert--heading`), um spezifische
 Styles des Inline Alerts zu erhalten.
 
 <LiveCodeEditor example="composition" />
+
+---
+
+# CSS Cascade Layers
+
+Alle Regeln des Stylesheets liegen in CSS Cascade Layern unterhalb eines
+`flow`-Layers (Sublayer `flow.reset`, `flow.base`, `flow.components` und
+`flow.components-override`, aufsteigend nach Priorität). Design Tokens (CSS
+Custom Properties) und `@font-face` sind bewusst **nicht** gelayert.
+
+Das Wichtigste in Kürze: **ungelayertes CSS gewinnt immer gegen gelayertes
+CSS.** Dein eigenes (ungelayertes) CSS überschreibt Flow also automatisch — ohne
+Spezifitäts-Kämpfe und ohne `!important`:
+
+```css
+.flow--button {
+  border-radius: 0; /* gewinnt zuverlässig über Flow */
+}
+```
+
+Falls dein globales CSS Flow dadurch **ungewollt** überschreibt und Flow die
+Oberhand behalten soll, lege deine betroffene Regel in einen Layer, den du
+**vor** `flow` deklarierst:
+
+```css
+@layer base, flow; /* flow wird später deklariert und gewinnt über base */
+
+@layer base {
+  /* Regeln hier werden von Flow überschrieben */
+}
+```
+
+Design Tokens überschreibst du ebenfalls ungelayert:
+
+```css
+:root {
+  --primary--color--500: #6b21a8;
+}
+```

--- a/packages/components/CONTRIBUTE.md
+++ b/packages/components/CONTRIBUTE.md
@@ -31,3 +31,46 @@ export const Component: FC<Props> = (props) => {
   );
 };
 ```
+
+## Styling with CSS cascade layers
+
+The generated stylesheet (`all.css`) is organized into CSS cascade layers under
+a top-level `flow` layer, so that unlayered CSS in a consuming application
+overrides Flow automatically. The order (lowest → highest priority) is:
+
+```css
+@layer flow.reset, flow.base, flow.components, flow.components-override;
+```
+
+- **Component CSS modules** (`*.module.scss` / `*.module.css`) are wrapped in
+  `@layer flow.components` automatically at build time — you don't need to do
+  anything for normal component styles.
+- **Design tokens** (CSS custom properties) and `@font-face` are intentionally
+  left unlayered.
+
+### Overriding third-party CSS: `@layer unlayered`
+
+Some components restyle a third-party library whose CSS is injected
+**unlayered** at runtime (e.g. CodeMirror in `CodeEditor`, react-easy-crop in
+`ImageCropper`). Layered CSS always loses to unlayered CSS, so those overrides
+must stay unlayered. Wrap them in a `@layer unlayered { … }` block — the build
+unwraps it so the rules are emitted with no layer at all:
+
+```scss
+.myWidget {
+  // normal styles → end up in @layer flow.components
+
+  @layer unlayered {
+    // overrides of the library's runtime CSS → emitted unlayered so they win
+    :global(.third-party-class) {
+      color: var(--my-token);
+    }
+  }
+}
+```
+
+### Raising priority within Flow: `@layer flow.components-override`
+
+To make a rule win over other Flow component styles in a controlled way (without
+leaving the layer system), put it in `@layer flow.components-override { … }` —
+the highest Flow sublayer.

--- a/packages/components/MIGRATION.md
+++ b/packages/components/MIGRATION.md
@@ -1,5 +1,58 @@
 # Migrations
 
+## From version `0.2.0-alpha.896` to `>=0.2.0-alpha.897`
+
+### CSS Cascade Layers
+
+> Flow's component styles are now emitted inside CSS cascade layers. Every rule
+> in `all.css` (and in the standalone `@mittwald/flow-stylesheet`) lives under a
+> top-level `flow` layer, split into the sublayers `flow.reset`, `flow.base`,
+> `flow.components` and `flow.components-override` (in ascending priority).
+> Design tokens (CSS custom properties) and `@font-face` remain **unlayered**.
+
+**What this means for you**
+
+Unlayered CSS always wins over layered CSS. So any **unlayered** style in your
+application now overrides Flow automatically — no specificity tricks and no
+`!important` needed:
+
+```css
+/* Reliably wins over Flow's component styles */
+.flow--button {
+  border-radius: 0;
+}
+```
+
+**Potential breaking change**
+
+If you previously relied on Flow winning over your own **unlayered** global CSS
+(for example an app-wide reset, `box-sizing`, link colors or base typography
+that Flow used to override), that relationship is now reversed — your unlayered
+CSS wins. Review your global styles. If you want Flow to keep precedence for a
+given rule, move that rule into a layer that you declare **before** `flow`:
+
+```css
+/* `flow` is declared last, so it wins over `base` again */
+@layer base, flow;
+
+@layer base {
+  /* rules here are overridden by Flow */
+}
+```
+
+**Overriding design tokens**
+
+Because design tokens are intentionally left unlayered, override them with
+unlayered CSS as well (a layered override would lose to Flow's unlayered token):
+
+```css
+:root {
+  --primary--color--500: #6b21a8;
+}
+```
+
+---
+
 ## From version `0.2.0-alpha.779` to `>=0.2.0-alpha.780`
 
 ### CartesianChart

--- a/packages/components/dev/vite/flowCssLayerPlugin.test.ts
+++ b/packages/components/dev/vite/flowCssLayerPlugin.test.ts
@@ -1,0 +1,222 @@
+import postcss, { type Container, type Rule } from "postcss";
+import { describe, test, expect } from "vitest";
+import {
+  flowComponentsLayerPostcssPlugin,
+  flowLayerOrderPlugin,
+} from "./flowCssLayerPlugin";
+
+const layerOrder =
+  "@layer flow.reset, flow.base, flow.components, flow.components-override;\n";
+
+const processCss = async (input: string, from: string) => {
+  const result = await postcss([flowComponentsLayerPostcssPlugin()]).process(
+    input,
+    { from },
+  );
+
+  return result.css;
+};
+
+const enclosingLayerForSelector = (css: string, selectorSubstring: string) => {
+  const root = postcss.parse(css);
+  let layer: string | null | undefined;
+
+  root.walkRules((rule) => {
+    if (layer !== undefined || !rule.selector.includes(selectorSubstring)) {
+      return;
+    }
+
+    let parent: Container | undefined = (rule as Rule).parent;
+    while (parent) {
+      if (parent.type === "atrule" && parent.name === "layer") {
+        layer = parent.params;
+        return;
+      }
+      parent = parent.parent;
+    }
+
+    layer = null;
+  });
+
+  return layer ?? null;
+};
+
+interface Asset {
+  type: "asset";
+  fileName: string;
+  source: string;
+}
+
+interface Chunk {
+  type: "chunk";
+  fileName: string;
+  code: string;
+}
+
+type Bundle = Record<string, Asset | Chunk>;
+
+const runGenerateBundle = (bundle: Bundle) => {
+  const plugin = flowLayerOrderPlugin();
+  const hook = plugin.generateBundle as (
+    options: unknown,
+    bundle: Record<string, unknown>,
+  ) => void;
+
+  hook({}, bundle);
+};
+
+describe("flow components layer postcss plugin", () => {
+  test("is a postcss plugin factory", () => {
+    expect(flowComponentsLayerPostcssPlugin.postcss).toBe(true);
+  });
+
+  test("wraps module rules", async () => {
+    const css = await processCss(
+      ".flow--button { color: red; }",
+      "/x/Button.module.scss",
+    );
+
+    expect(enclosingLayerForSelector(css, ".flow--button")).toBe(
+      "flow.components",
+    );
+  });
+
+  test("also .module.css", async () => {
+    const css = await processCss(
+      ".flow--list { color: red; }",
+      "/x/List.module.css",
+    );
+
+    expect(enclosingLayerForSelector(css, ".flow--list")).toBe(
+      "flow.components",
+    );
+  });
+
+  test("leaves flow.components-override untouched", async () => {
+    const css = await processCss(
+      "@layer flow.components-override { .a { z-index: 1; } }\n.b { color: red; }",
+      "/x/Button.module.scss",
+    );
+
+    expect(enclosingLayerForSelector(css, ".a")).toBe(
+      "flow.components-override",
+    );
+    expect(enclosingLayerForSelector(css, ".b")).toBe("flow.components");
+  });
+
+  test("unwraps @layer unlayered", async () => {
+    const css = await processCss(
+      "@layer unlayered { .cm { color: red; } }\n.b { color: blue; }",
+      "/x/Button.module.scss",
+    );
+
+    expect(enclosingLayerForSelector(css, ".cm")).toBeNull();
+    expect(css).not.toContain("@layer unlayered");
+    expect(enclosingLayerForSelector(css, ".b")).toBe("flow.components");
+  });
+
+  test("module with only @layer unlayered", async () => {
+    const css = await processCss(
+      "@layer unlayered { .cm { color: red; } }",
+      "/x/Button.module.scss",
+    );
+
+    expect(enclosingLayerForSelector(css, ".cm")).toBeNull();
+    expect(css).not.toContain("@layer unlayered");
+  });
+
+  test("non-module file is untouched", async () => {
+    const input = ".x { color: red; }";
+    const css = await processCss(input, "/x/index.scss");
+
+    expect(enclosingLayerForSelector(css, ".x")).toBeNull();
+    expect(postcss.parse(css).toString()).toBe(postcss.parse(input).toString());
+  });
+});
+
+describe("flow layer order vite plugin", () => {
+  test("prepends after @charset", () => {
+    const bundle: Bundle = {
+      "css/all.css": {
+        type: "asset",
+        fileName: "css/all.css",
+        source: '@charset "UTF-8";.a{}',
+      },
+    };
+
+    runGenerateBundle(bundle);
+
+    expect(bundle["css/all.css"].source).toBe(
+      '@charset "UTF-8";' + layerOrder + ".a{}",
+    );
+  });
+
+  test("prepends at start when no @charset", () => {
+    const bundle: Bundle = {
+      "css/all.css": {
+        type: "asset",
+        fileName: "css/all.css",
+        source: ".a{}",
+      },
+    };
+
+    runGenerateBundle(bundle);
+
+    expect(bundle["css/all.css"].source).toBe(layerOrder + ".a{}");
+  });
+
+  test("also handles globals.css", () => {
+    const bundle: Bundle = {
+      "css/globals.css": {
+        type: "asset",
+        fileName: "css/globals.css",
+        source: ".a{}",
+      },
+    };
+
+    runGenerateBundle(bundle);
+
+    expect(bundle["css/globals.css"].source).toBe(layerOrder + ".a{}");
+  });
+
+  test("is idempotent", () => {
+    const bundle: Bundle = {
+      "css/all.css": {
+        type: "asset",
+        fileName: "css/all.css",
+        source: layerOrder + ".a{}",
+      },
+    };
+
+    runGenerateBundle(bundle);
+    runGenerateBundle(bundle);
+
+    expect(bundle["css/all.css"].source).toBe(layerOrder + ".a{}");
+  });
+
+  test("ignores non-target assets", () => {
+    const bundle: Bundle = {
+      "js/default.mjs": {
+        type: "chunk",
+        fileName: "js/default.mjs",
+        code: "export {};",
+      },
+      "css/other.css": {
+        type: "asset",
+        fileName: "css/other.css",
+        source: ".other{}",
+      },
+      "css/all.css": {
+        type: "asset",
+        fileName: "css/all.css",
+        source: ".a{}",
+      },
+    };
+
+    runGenerateBundle(bundle);
+
+    expect(bundle["js/default.mjs"].code).toBe("export {};");
+    expect(bundle["css/other.css"].source).toBe(".other{}");
+    expect(bundle["css/all.css"].source).toBe(layerOrder + ".a{}");
+  });
+});

--- a/packages/components/dev/vite/flowCssLayerPlugin.ts
+++ b/packages/components/dev/vite/flowCssLayerPlugin.ts
@@ -1,0 +1,84 @@
+import type { Plugin } from "vite";
+import type { Plugin as PostcssPlugin, Root } from "postcss";
+import { atRule } from "postcss";
+
+const LAYER_ORDER =
+  "@layer flow.reset, flow.base, flow.components, flow.components-override;\n";
+
+type PostcssPluginFactory = (() => PostcssPlugin) & { postcss: true };
+
+export const flowComponentsLayerPostcssPlugin: PostcssPluginFactory =
+  Object.assign(
+    (): PostcssPlugin => ({
+      postcssPlugin: "flow-components-layer",
+      Once(root: Root, { result }) {
+        const from = result.opts.from ?? root.source?.input.file ?? "";
+        if (!from.includes(".module.scss") && !from.includes(".module.css")) {
+          return;
+        }
+
+        // Wrap every top-level rule that is not already inside an `@layer`
+        // into `@layer flow.components`. Existing `@layer` at-rules (including
+        // the `unlayered` sentinel handled below) are left out of the wrap.
+        const nodes = root.nodes?.filter(
+          (node) => node.type !== "atrule" || node.name !== "layer",
+        );
+        if (nodes && nodes.length > 0) {
+          const layer = atRule({ name: "layer", params: "flow.components" });
+          root.insertBefore(nodes[0], layer);
+          nodes.forEach((node) => {
+            node.remove();
+            layer.append(node);
+          });
+        }
+
+        // Unwrap the `@layer unlayered { … }` sentinel: hoist its rules back to
+        // the top level so they emit with NO `@layer`. Truly-unlayered CSS is
+        // the only way to override third-party CSS injected unlayered at
+        // runtime (CodeMirror, react-easy-crop, …) — any layer loses to it.
+        root.nodes
+          ?.filter(
+            (node) =>
+              node.type === "atrule" &&
+              node.name === "layer" &&
+              node.params.trim() === "unlayered",
+          )
+          .forEach((node) => {
+            const children = node.nodes ? [...node.nodes] : [];
+            children.forEach((child) => root.insertBefore(node, child));
+            node.remove();
+          });
+      },
+    }),
+    { postcss: true as const },
+  );
+
+export const flowLayerOrderPlugin = (): Plugin => ({
+  name: "flow-layer-order",
+  // `post` so this runs after Vite's CSS finalization (minify + `@charset`
+  // injection); otherwise the prepend is clobbered when the asset is re-emitted.
+  enforce: "post",
+  generateBundle(_options, bundle) {
+    for (const file of Object.values(bundle)) {
+      if (
+        file.type !== "asset" ||
+        !(
+          file.fileName.endsWith("all.css") ||
+          file.fileName.endsWith("globals.css")
+        )
+      ) {
+        continue;
+      }
+      const source = String(file.source);
+      // `@charset` must remain the very first rule, so the layer order goes
+      // right after it when present.
+      const charset = source.match(/^@charset [^;]+;/);
+      const head = charset ? charset[0] : "";
+      const body = charset ? source.slice(charset[0].length) : source;
+      if (body.startsWith("@layer flow.reset")) {
+        continue;
+      }
+      file.source = head + LAYER_ORDER + body;
+    }
+  },
+});

--- a/packages/components/src/components/CartesianChart/CartesianChart.module.scss
+++ b/packages/components/src/components/CartesianChart/CartesianChart.module.scss
@@ -1,8 +1,10 @@
 .cartesianChart {
   font-family: Inter, sans-serif;
 
-  *:focus:not(:focus-visible) {
-    outline: none !important;
+  @layer flow.components-override {
+    *:focus:not(:focus-visible) {
+      outline: none;
+    }
   }
 
   :global(.flow--illustrated-message--illustrated-message-container) {

--- a/packages/components/src/components/CheckboxGroup/CheckboxGroup.module.scss
+++ b/packages/components/src/components/CheckboxGroup/CheckboxGroup.module.scss
@@ -15,8 +15,10 @@
 
   .checkbox,
   .checkboxButton {
-    :global(.flow--form-field) {
-      display: block;
+    @layer flow.components-override {
+      :global(.flow--form-field) {
+        display: block;
+      }
     }
 
     &[data-invalid]:not([data-selected]) {

--- a/packages/components/src/components/CodeBlock/CodeBlock.module.scss
+++ b/packages/components/src/components/CodeBlock/CodeBlock.module.scss
@@ -25,8 +25,10 @@
     }
   }
 
-  &.codeBlock div:global(.flow--code-editor--code-mirror) {
-    border-color: var(--code-block--border-color);
+  @layer flow.components-override {
+    &.codeBlock div:global(.flow--code-editor--code-mirror) {
+      border-color: var(--code-block--border-color);
+    }
   }
 }
 

--- a/packages/components/src/components/CodeEditor/CodeEditor.module.scss
+++ b/packages/components/src/components/CodeEditor/CodeEditor.module.scss
@@ -31,40 +31,42 @@
       z-index: 1;
     }
 
-    & :global(.cm-editor) {
-      outline: none;
+    @layer unlayered {
+      & :global(.cm-editor) {
+        outline: none;
 
-      & :global(.cm-lineNumbers .cm-gutterElement) {
-        min-width: var(--code-editor--gutter-element-min-width);
-      }
+        & :global(.cm-lineNumbers .cm-gutterElement) {
+          min-width: var(--code-editor--gutter-element-min-width);
+        }
 
-      & :global(.cm-foldGutter) {
-        min-width: var(--code-editor--gutter-element-min-width);
-        text-align: center;
-      }
+        & :global(.cm-foldGutter) {
+          min-width: var(--code-editor--gutter-element-min-width);
+          text-align: center;
+        }
 
-      & :global(.cm-panels) {
-        display: none;
-      }
+        & :global(.cm-panels) {
+          display: none;
+        }
 
-      & :global(.cm-content) {
-        padding-block: var(--form-control--padding-y);
-      }
+        & :global(.cm-content) {
+          padding-block: var(--form-control--padding-y);
+        }
 
-      & :global(.cm-activeLineGutter),
-      & :global(.cm-activeLine) {
-        background-color: color-mix(
-          in srgb,
-          var(--form-control--background-color--hover) 65%,
-          transparent
-        );
-      }
+        & :global(.cm-activeLineGutter),
+        & :global(.cm-activeLine) {
+          background-color: color-mix(
+            in srgb,
+            var(--form-control--background-color--hover) 65%,
+            transparent
+          );
+        }
 
-      & :global(.cm-gutters) {
-        border-top-left-radius: calc(var(--form-control--corner-radius) - 1px);
-        border-bottom-left-radius: calc(
-          var(--form-control--corner-radius) - 1px
-        );
+        & :global(.cm-gutters) {
+          border-top-left-radius: calc(var(--form-control--corner-radius) - 1px);
+          border-bottom-left-radius: calc(
+            var(--form-control--corner-radius) - 1px
+          );
+        }
       }
     }
   }

--- a/packages/components/src/components/DatePicker/components/DateInput/DateInput.module.scss
+++ b/packages/components/src/components/DatePicker/components/DateInput/DateInput.module.scss
@@ -21,12 +21,14 @@
     }
   }
 
-  :global(.flow--button) {
-    margin-block: calc((var(--form-control--padding-y) - 1px) * -1);
-    margin-inline-end: calc(var(--form-control--padding-x) * -1);
-    padding: calc(
-      var(--button--padding-icon-only) - var(--form-control--border-width)
-    );
-    outline-offset: calc(var(--size-px--xxxs) * -1);
+  @layer flow.components-override {
+    :global(.flow--button) {
+      margin-block: calc((var(--form-control--padding-y) - 1px) * -1);
+      margin-inline-end: calc(var(--form-control--padding-x) * -1);
+      padding: calc(
+        var(--button--padding-icon-only) - var(--form-control--border-width)
+      );
+      outline-offset: calc(var(--size-px--xxxs) * -1);
+    }
   }
 }

--- a/packages/components/src/components/DateRangePicker/components/DateRangeInput/DateRangeInput.module.scss
+++ b/packages/components/src/components/DateRangePicker/components/DateRangeInput/DateRangeInput.module.scss
@@ -39,12 +39,14 @@
     padding-inline-start: 2px;
   }
 
-  :global(.flow--button) {
-    margin-block: calc((var(--form-control--padding-y) - 1px) * -1);
-    margin-inline-end: calc(var(--form-control--padding-x) * -1);
-    padding: calc(
-      var(--button--padding-icon-only) - var(--form-control--border-width)
-    );
-    outline-offset: calc(var(--size-px--xxxs) * -1);
+  @layer flow.components-override {
+    :global(.flow--button) {
+      margin-block: calc((var(--form-control--padding-y) - 1px) * -1);
+      margin-inline-end: calc(var(--form-control--padding-x) * -1);
+      padding: calc(
+        var(--button--padding-icon-only) - var(--form-control--border-width)
+      );
+      outline-offset: calc(var(--size-px--xxxs) * -1);
+    }
   }
 }

--- a/packages/components/src/components/ImageCropper/ImageCropper.module.scss
+++ b/packages/components/src/components/ImageCropper/ImageCropper.module.scss
@@ -13,18 +13,20 @@
     border-width: var(--image-cropper--border-width);
   }
 
-  :global(.reactEasyCrop_CropArea) {
-    color: var(--image-cropper--mask-color);
-    border-color: var(--image-cropper--mask-border-color);
-    box-sizing: content-box;
-  }
+  @layer unlayered {
+    :global(.reactEasyCrop_CropArea) {
+      color: var(--image-cropper--mask-color);
+      border-color: var(--image-cropper--mask-border-color);
+      box-sizing: content-box;
+    }
 
-  :global(.reactEasyCrop_CropAreaGrid::before) {
-    border-color: var(--image-cropper--grid-color);
-    border-width: var(--image-cropper--grid-width);
-  }
+    :global(.reactEasyCrop_CropAreaGrid::before) {
+      border-color: var(--image-cropper--grid-color);
+      border-width: var(--image-cropper--grid-width);
+    }
 
-  :global(.reactEasyCrop_Container) {
-    border-radius: var(--image-cropper--corner-radius);
+    :global(.reactEasyCrop_Container) {
+      border-radius: var(--image-cropper--corner-radius);
+    }
   }
 }

--- a/packages/components/src/components/LayoutCard/LayoutCard.module.scss
+++ b/packages/components/src/components/LayoutCard/LayoutCard.module.scss
@@ -18,9 +18,11 @@
       border-top-left-radius: calc(var(--layout-card--corner-radius) - 1px);
     }
 
-    :global(.flow--tabs--tab-title):first-child,
-    :global(.flow--tabs--tab-list--context-menu-button) {
-      border-top-left-radius: calc(var(--layout-card--corner-radius) - 1px);
+    @layer flow.components-override {
+      :global(.flow--tabs--tab-title):first-child,
+      :global(.flow--tabs--tab-list--context-menu-button) {
+        border-top-left-radius: calc(var(--layout-card--corner-radius) - 1px);
+      }
     }
   }
 

--- a/packages/components/src/components/List/components/ListItemView/ListItemView.module.scss
+++ b/packages/components/src/components/List/components/ListItemView/ListItemView.module.scss
@@ -174,13 +174,15 @@
       height: 100%;
       border-radius: 0;
 
-      :global(.flow--avatar--icon) {
-        width: var(--size-px--xxl);
-        height: var(--size-px--xxl);
-      }
+      @layer flow.components-override {
+        :global(.flow--avatar--icon) {
+          width: var(--size-px--xxl);
+          height: var(--size-px--xxl);
+        }
 
-      :global(.flow--avatar--initials) {
-        font-size: var(--size-px--xxl);
+        :global(.flow--avatar--initials) {
+          font-size: var(--size-px--xxl);
+        }
       }
     }
 

--- a/packages/components/src/components/MarkdownEditor/MarkdownEditor.module.scss
+++ b/packages/components/src/components/MarkdownEditor/MarkdownEditor.module.scss
@@ -43,8 +43,10 @@
     @include formControl.formColor;
   }
 
-  :global(.flow--form-field) {
-    display: contents;
+  @layer flow.components-override {
+    :global(.flow--form-field) {
+      display: contents;
+    }
   }
 
   textarea,

--- a/packages/components/src/components/Message/Message.module.scss
+++ b/packages/components/src/components/Message/Message.module.scss
@@ -78,8 +78,10 @@
       .user {
         flex-direction: row-reverse;
 
-        :global(.flow--text) {
-          text-align: end;
+        @layer flow.components-override {
+          :global(.flow--text) {
+            text-align: end;
+          }
         }
       }
     }

--- a/packages/components/src/styles/globals-base.scss
+++ b/packages/components/src/styles/globals-base.scss
@@ -1,9 +1,3 @@
-/**
-  CSS reset for all Flow components that
-  - are not part of other Flow components (avoid eager reset)
-  - are not SVGs (see https://stackoverflow.com/questions/46758871/css-reset-via-all-unset-breaks-inline-svg)
- */
-
 @media (prefers-reduced-motion: reduce) {
   *,
   ::before,
@@ -16,43 +10,6 @@
       transition-delay: 0s !important;
     }
   }
-}
-
-// CSS Specificity: 0-0-2
-html
-  body
-  *:where(
-    [class*="flow--"]:not([class*="flow--"] [class*="flow--"], svg, table)
-  ) {
-  all: initial;
-}
-
-/**
-  "all: initial" sets "display: inline" for **all elements**. This rule, reverts this for common block elements.
- */
-body article:where([class*="flow--"]),
-body aside:where([class*="flow--"]),
-body address:where([class*="flow--"]),
-body blockquote:where([class*="flow--"]),
-body div:where([class*="flow--"]),
-body footer:where([class*="flow--"]),
-body header:where([class*="flow--"]),
-body hr:where([class*="flow--"]),
-body main:where([class*="flow--"]),
-body nav:where([class*="flow--"]),
-body p:where([class*="flow--"]),
-body pre:where([class*="flow--"]) {
-  display: block;
-}
-
-body table:where([class*="flow--"]) {
-  display: table;
-}
-
-// CSS Specificity: 0-0-2
-html body *:where([class*="flow--"] [class*="flow--"]) {
-  color: inherit;
-  font: inherit;
 }
 
 // CSS Specificity: 0-0-2

--- a/packages/components/src/styles/globals-reset.scss
+++ b/packages/components/src/styles/globals-reset.scss
@@ -1,0 +1,42 @@
+/**
+  CSS reset for all Flow components that
+  - are not part of other Flow components (avoid eager reset)
+  - are not SVGs (see https://stackoverflow.com/questions/46758871/css-reset-via-all-unset-breaks-inline-svg)
+ */
+
+// CSS Specificity: 0-0-2
+html
+  body
+  *:where(
+    [class*="flow--"]:not([class*="flow--"] [class*="flow--"], svg, table)
+  ) {
+  all: initial;
+}
+
+/**
+  "all: initial" sets "display: inline" for **all elements**. This rule, reverts this for common block elements.
+ */
+body article:where([class*="flow--"]),
+body aside:where([class*="flow--"]),
+body address:where([class*="flow--"]),
+body blockquote:where([class*="flow--"]),
+body div:where([class*="flow--"]),
+body footer:where([class*="flow--"]),
+body header:where([class*="flow--"]),
+body hr:where([class*="flow--"]),
+body main:where([class*="flow--"]),
+body nav:where([class*="flow--"]),
+body p:where([class*="flow--"]),
+body pre:where([class*="flow--"]) {
+  display: block;
+}
+
+body table:where([class*="flow--"]) {
+  display: table;
+}
+
+// CSS Specificity: 0-0-2
+html body *:where([class*="flow--"] [class*="flow--"]) {
+  color: inherit;
+  font: inherit;
+}

--- a/packages/components/src/styles/index.scss
+++ b/packages/components/src/styles/index.scss
@@ -1,10 +1,22 @@
 @use "sass:meta";
 
+// Design tokens are pure CSS custom properties (cascade-layer-neutral) and are
+// intentionally left unlayered so consumers can override them with unlayered CSS.
 @forward "@mittwald/flow-design-tokens/css/base.css";
 @forward "@mittwald/flow-design-tokens/css/colors-light.css";
 @forward "@mittwald/flow-design-tokens/css/colors-dark.css";
+
+// @font-face is not affected by cascade layers; keep it unlayered.
 @forward "./fonts";
-@forward "./globals";
+
+// Flow global styles are assigned to sublayers of `flow`.
+@layer flow.reset {
+  @include meta.load-css("./globals-reset");
+}
+
+@layer flow.base {
+  @include meta.load-css("./globals-base");
+}
 
 @media (prefers-color-scheme: dark) {
   @include meta.load-css(

--- a/packages/components/vite.build.config.ts
+++ b/packages/components/vite.build.config.ts
@@ -3,11 +3,20 @@ import dts from "vite-plugin-dts";
 import baseConfig from "./vite.config";
 import { externalizeDeps } from "vite-plugin-externalize-deps";
 import { defineConfig, mergeConfig } from "vite";
+import {
+  flowComponentsLayerPostcssPlugin,
+  flowLayerOrderPlugin,
+} from "./dev/vite/flowCssLayerPlugin";
 
 export default mergeConfig(
   baseConfig,
   defineConfig({
     experimental: {},
+    css: {
+      postcss: {
+        plugins: [flowComponentsLayerPostcssPlugin()],
+      },
+    },
     build: {
       minify: false,
       sourcemap: true,
@@ -58,6 +67,7 @@ export default mergeConfig(
         include: ["src"],
         outDirs: "dist/types",
       }),
+      flowLayerOrderPlugin(),
     ],
   }),
 );


### PR DESCRIPTION
## Summary

Serve the generated component stylesheet (`all.css`) via **CSS cascade layers**, so consuming applications can override Flow with unlayered CSS without specificity battles.

Layer order (low → high priority):

```css
@layer flow.reset, flow.base, flow.components, flow.components-override;
```

- **`flow.reset`** – the hard reset (`all: initial` + display restoration).
- **`flow.base`** – base typography, Josh-Comeau reset, `color-scheme`, reduced-motion.
- **`flow.components`** – every component CSS module (wrapped automatically at build time).
- **`flow.components-override`** – inter-component overrides (one Flow component restyling another).
- **Unlayered on purpose:** design tokens (CSS custom properties) and `@font-face`.

## How it works

- Split `styles/globals.scss` into `globals-reset.scss` / `globals-base.scss`, loaded into `flow.reset` / `flow.base`.
- New Vite/PostCSS plugin `dev/vite/flowCssLayerPlugin.ts`:
  - wraps every `*.module.(scss|css)` in `@layer flow.components`;
  - prepends the layer-order statement to `all.css` (after `@charset`, via a `post` `generateBundle` hook).
- **`@layer unlayered { … }` escape hatch:** the plugin hoists such rules out of any layer, so components can still override third-party CSS injected *unlayered* at runtime. Applied to **CodeEditor** (CodeMirror) and **ImageCropper** (react-easy-crop).
- **`@layer flow.components-override`** applied to the genuine inter-component overrides (CartesianChart, CheckboxGroup, MarkdownEditor, CodeBlock, DateInput, DateRangeInput, Message, LayoutCard, ListItemView) — replacing reliance on specificity/source-order and one `!important`.

## Behavior change (documented, not a forced major)

Flow's styles now live in a cascade layer, so **unlayered CSS in a consuming app overrides Flow automatically**. Apps that relied on Flow winning over their own *unlayered* global CSS can move those rules into a layer ordered before `flow`. Documented in:

- `packages/components/MIGRATION.md` (consumer migration note)
- docs stylesheet page (`apps/docs/.../01-get-started/stylesheet/index.mdx`)
- `packages/components/CONTRIBUTE.md` (the `@layer unlayered` / `flow.components-override` conventions)

## Verification

- Built the components package: `all.css` is emitted with the correct layer order (`@charset` → order statement → layer blocks), tokens/`@font-face` unlayered, all component modules in `flow.components`, and the CodeMirror / react-easy-crop overrides correctly unlayered.
- Visual regression (WebKit): the initial layering broke **CodeEditor / CodeBlock / ImageCropper** (they override third-party unlayered CSS) — the `@layer unlayered` fix restored all three to green.
- The remaining visual diffs were confirmed **pre-existing** via a pristine-master control run (byte-identical renders with and without layers) — environment/baseline noise (font AA + `backdrop-filter` blur), not caused by this change.
- The `flow.components-override` moves are behavior-preserving (selectors/values unchanged; only the layer assignment changes).

## Notes

- `MIGRATION.md` uses a placeholder version (`>=0.2.0-alpha.897`) — adjust to the actual release version.
- Branch is a few commits behind `main`; rebase before merge if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
