### PR TITLE
fix(ci): fix two flaky visual/browser test failures (firefox hang retry + Modal deflake)

### DIFF
--- a/.github/workflows/test-visual-scheduled.yml
+++ b/.github/workflows/test-visual-scheduled.yml
@@ -27,9 +27,24 @@ jobs:
         run: pnpm test:browser:prepare --only-shell
 
       - name: Run visual tests
-        # run without file parallelism, because firefox has issues with parallel visual tests
+        # Run without file parallelism, because firefox has issues with parallel visual tests.
+        # Retry the whole step because firefox intermittently *hangs* (not a snapshot diff) on a
+        # single visual test file in headless CI, which aborts the run with exit code 1 even though
+        # every test that runs passes. A hang can't be recovered by vitest's per-test `retry`, so we
+        # re-run the step with a fresh vitest/browser process. Successful `^build` deps are served
+        # from the nx cache, so retries only re-execute test:visual.
         run: |
-          pnpm nx run-many -t test:visual --parallel=1 --browser.fileParallelism=false
+          for attempt in 1 2 3; do
+            echo "::group::Visual tests (attempt $attempt/3)"
+            if pnpm nx run-many -t test:visual --parallel=1 --browser.fileParallelism=false; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            echo "::warning::Visual tests failed on attempt $attempt/3 (likely a flaky firefox hang), retrying..."
+          done
+          echo "::error::Visual tests still failing after 3 attempts."
+          exit 1
 
       - name: Send alerting message to Slack
         if: failure()

--- a/packages/components/src/components/Modal/Modal.browser.test.tsx
+++ b/packages/components/src/components/Modal/Modal.browser.test.tsx
@@ -274,8 +274,12 @@ test("useOnClosed is called when the closing animation has finished", async () =
   expect(modalText).toBeInTheDocument();
   expect(onClosed).not.toHaveBeenCalledOnce();
 
-  await sleep(500);
-  expect(modalText).not.toBeInTheDocument();
+  // Wait for the close animation to finish and the Modal to unmount instead of
+  // relying on a fixed delay: the animation duration varies and a hard-coded
+  // sleep races against it under CI load, which made this test flaky.
+  await vitest.waitFor(() => expect(modalText).not.toBeInTheDocument(), {
+    timeout: 2000,
+  });
 
   // onClosed is just called, when the Modal has unmounted (after close animation)
   expect(onClosed).toHaveBeenCalledOnce();


### PR DESCRIPTION
Fixes two **unrelated** flaky failures found by analyzing the failed GitHub Actions runs.

---

## 1. `Run scheduled visual tests` — firefox intermittently hangs (~15%, 6/40 runs)

**Analysis of the failed runs:**
- Not snapshot/pixel regressions — every test that runs passes, **zero** assertion (`×`) failures.
- Failing runs are missing **exactly one** test-file summary (81 vs. 82 in a green run).
- The missing file is always a **firefox** instance (e.g. `Switch.browser.test.tsx`); **webkit always completes**.
- `ResizeObserver loop completed with undelivered notifications.` is a red herring — appears identically (4×) in passing runs too.

**Root cause:** firefox intermittently hangs on a single visual test file in headless CI, aborting the run with exit code 1. Same class of browser flakiness for which chromium was already disabled and file parallelism already turned off.

**Fix:** wrap the `Run visual tests` step in a retry loop (up to 3 attempts). A hang can't be recovered by vitest's per-test `retry` (the whole process is killed), so we re-run `test:visual` in a fresh vitest/browser process. Successful `^build` deps come from the nx cache, so retries only re-execute the visual tests. The Slack alert still fires only when all three attempts fail. Expected residual failure rate ≈ 0.15³ ≈ 0.3%.

> Note: this is a **symptom mitigation**, not a root-cause fix for the firefox hang. Verification can only happen on real scheduled runs (2×/day) or a manual `workflow_dispatch` once on `main`.

## 2. `Run tests` — flaky Modal animation-timing test

**Analysis:** the recurring `Run tests` failures were always a **single** assertion in `Modal.browser.test.tsx > useOnClosed is called when the closing animation has finished` (`expect(element).not.toBeInTheDocument()`). It is flaky, not a regression: it passed/failed on unrelated commits (including a pure version-bump commit) and the latest main run was green.

**Root cause:** the test waited a fixed **550ms** (`sleep(50)` + `sleep(500)`) for the close animation to finish and the modal to unmount, but the animation lasts `--transition--duration--slow` = **400ms**, leaving only ~150ms for `animationend` + React state update + unmount. Under CI load that margin is too tight.

**Fix:** replace the fixed sleep with condition-based waiting (`vitest.waitFor`, 2s timeout) that polls until the modal has unmounted, removing the race entirely.

**Verification:** ran the Modal browser test in webkit locally across repeated runs — passes reliably (`8 passed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)