### PR TITLE
feat(remote): surface "No component found" error on the remote side

### DIFF
--- a/apps/remote-dom-demo/src/app/layout.tsx
+++ b/apps/remote-dom-demo/src/app/layout.tsx
@@ -57,6 +57,9 @@ export default function Layout(props: PropsWithChildren) {
                       Ext Bridge
                     </NavigationItem>
                     <NavigationItem page="error">Error</NavigationItem>
+                    <NavigationItem page="no-component">
+                      No component
+                    </NavigationItem>
                     <NavigationItem page="navigation">
                       Navigation
                     </NavigationItem>

--- a/apps/remote-dom-demo/src/app/remote/no-component/page.tsx
+++ b/apps/remote-dom-demo/src/app/remote/no-component/page.tsx
@@ -1,0 +1,23 @@
+"use client";
+import { Button, Section, Text } from "@mittwald/flow-remote-react-components";
+import { createElement, useState } from "react";
+
+export default function Page() {
+  const [renderUnknown, setRenderUnknown] = useState(false);
+
+  return (
+    <Section>
+      <Text>
+        Renders a remote element with a tag the host cannot map, triggering the
+        &quot;No component found for remote element&quot; error. The host holds
+        the error back until it has been delivered to the remote, then re-throws
+        it. The error therefore surfaces on both sides.
+      </Text>
+      {renderUnknown &&
+        createElement("flr-unknown-component", {}, "unknown component")}
+      <Button color="danger" onPress={() => setRenderUnknown(true)}>
+        Render unknown component
+      </Button>
+    </Section>
+  );
+}

--- a/packages/remote-core/src/connection/connectHostRenderRoot.ts
+++ b/packages/remote-core/src/connection/connectHostRenderRoot.ts
@@ -12,6 +12,7 @@ import { ThreadNestedIframe } from "@quilted/threads";
 interface Options {
   root: HTMLDivElement;
   onPathnameChanged?: (pathname: string) => void;
+  onHostError?: (error: string) => void;
   packageVersion?: string;
 }
 
@@ -32,7 +33,7 @@ export const connectRemoteReceiver = (
 export const connectHostRenderRoot = async (
   options: Options,
 ): Promise<RemoteToHostConnection> => {
-  const { root, onPathnameChanged, packageVersion } = options;
+  const { root, onPathnameChanged, onHostError, packageVersion } = options;
 
   const connection = new ThreadNestedIframe<HostExports, RemoteExports>({
     serialization: new FlowThreadSerialization(),
@@ -41,6 +42,9 @@ export const connectHostRenderRoot = async (
         connectRemoteReceiver(root, connection),
       setPathname: async (pathname) => {
         onPathnameChanged?.(pathname);
+      },
+      setHostError: async (error) => {
+        onHostError?.(error);
       },
     },
   });
@@ -51,7 +55,7 @@ export const connectHostRenderRoot = async (
 
   try {
     await connection.imports.setIsReady({
-      version: Version.v4,
+      version: Version.v5,
       packageVersion,
     });
 

--- a/packages/remote-core/src/connection/connectRemoteIframe.ts
+++ b/packages/remote-core/src/connection/connectRemoteIframe.ts
@@ -101,6 +101,11 @@ export const connectRemoteIframe = (opts: Options): HostToRemoteConnection => {
         result.thread.imports.setPathname(hostPathname);
       }
     },
+    reportHostError: async (error) => {
+      if (result.version >= Version.v5) {
+        await result.thread.imports.setHostError(error);
+      }
+    },
     version: 0,
   };
 

--- a/packages/remote-core/src/connection/types.ts
+++ b/packages/remote-core/src/connection/types.ts
@@ -49,6 +49,7 @@ export interface HostExports extends ExtBridgeConnectionApi {
 export interface RemoteExports {
   render: (connection: RemoteConnection) => Promise<void>;
   setPathname: (pathname: string) => Promise<void>;
+  setHostError: (error: string) => Promise<void>;
 }
 
 export type RemoteToHostConnection = ThreadNestedIframe<
@@ -60,6 +61,7 @@ export interface HostToRemoteConnection {
   version: Version;
   thread: ThreadIframe<RemoteExports, HostExports>;
   updateHostPathname: (hostPathname?: string) => void;
+  reportHostError: (error: string) => Promise<void>;
 }
 
 export interface HostToRemoteConnectionReadyEvent {
@@ -73,4 +75,5 @@ export enum Version {
   v2 = 2,
   v3 = 3,
   v4 = 4,
+  v5 = 5,
 }

--- a/packages/remote-react-components/src/components/RemoteRoot.tsx
+++ b/packages/remote-react-components/src/components/RemoteRoot.tsx
@@ -83,6 +83,7 @@ export const RemoteRoot: FC<RemoteRootProps> = (props) => {
   const hostConfigRef = useRef<HostConfig | undefined>(undefined);
   const isConnectionInitialized = useRef(false);
   const [connectionError, setConnectionError] = useState(null);
+  const [hostError, setHostError] = useState<string | undefined>(undefined);
   const [isConnected, setIsConnected] = useState(false);
 
   const fallbackLanguage = useLanguage();
@@ -131,9 +132,14 @@ export const RemoteRoot: FC<RemoteRootProps> = (props) => {
     throw connectionError;
   }
 
+  if (hostError) {
+    throw new Error(hostError);
+  }
+
   const connect = connectHostRenderRootRef({
     onPathnameChanged: (pathname) =>
       startPathnameChangedTransition(() => onHostPathnameChanged?.(pathname)),
+    onHostError: (error) => setHostError(error),
     packageVersion,
   });
 

--- a/packages/remote-react-components/src/version.ts
+++ b/packages/remote-react-components/src/version.ts
@@ -1,6 +1,6 @@
 import { Version } from "@mittwald/flow-remote-core";
 
-export const communicationVersion = Version.v4;
+export const communicationVersion = Version.v5;
 export const packageVersion = __FLOW_REMOTE_REACT_COMPONENTS_PACKAGE_VERSION__;
 
 export const version = communicationVersion;

--- a/packages/remote-react-renderer/src/RemoteRendererBrowser.tsx
+++ b/packages/remote-react-renderer/src/RemoteRendererBrowser.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { HostRenderErrorBoundary } from "@/components/HostRenderErrorBoundary";
 import { useMergedComponents } from "@/hooks/useMergedComponents";
 import { useControllableSuspenseTrigger } from "@/hooks/useControllableSuspenseTrigger";
 import { useUpdateHostPathnameOnRemote } from "@/hooks/useUpdateHostPathnameOnRemote";
@@ -186,7 +187,15 @@ export const RemoteRendererBrowser: FC<RemoteRendererBrowserProps> = (
 
   return (
     <>
-      <RemoteRootRenderer components={remoteComponents} receiver={receiver} />
+      <HostRenderErrorBoundary
+        onNoComponentError={async (error) => {
+          await connection.current?.reportHostError(
+            error instanceof Error ? error.message : String(error),
+          );
+        }}
+      >
+        <RemoteRootRenderer components={remoteComponents} receiver={receiver} />
+      </HostRenderErrorBoundary>
       <iframe
         src={src}
         ref={(ref) => {

--- a/packages/remote-react-renderer/src/components/HostRenderErrorBoundary.tsx
+++ b/packages/remote-react-renderer/src/components/HostRenderErrorBoundary.tsx
@@ -1,0 +1,59 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+const HOST_ERROR_DELIVERY_TIMEOUT_MS = 1000;
+
+const isNoComponentFoundError = (error: unknown): error is Error =>
+  // Couples to the message thrown by @mittwald/remote-dom-react's host renderer.
+  error instanceof Error &&
+  error.message.startsWith("No component found for remote element");
+
+interface Props {
+  children: ReactNode;
+  onNoComponentError: (error: Error) => Promise<void>;
+}
+
+interface State {
+  errorToRethrow?: unknown;
+  isHandling: boolean;
+}
+
+export class HostRenderErrorBoundary extends Component<Props, State> {
+  override state: State = { isHandling: false };
+
+  static getDerivedStateFromError(error: unknown): Partial<State> {
+    if (isNoComponentFoundError(error)) {
+      return { isHandling: true };
+    }
+
+    return { errorToRethrow: error };
+  }
+
+  override componentDidCatch(error: unknown, _info: ErrorInfo): void {
+    if (!isNoComponentFoundError(error)) {
+      return;
+    }
+
+    const timeout = new Promise<void>((resolve) =>
+      setTimeout(resolve, HOST_ERROR_DELIVERY_TIMEOUT_MS),
+    );
+
+    Promise.race([
+      this.props.onNoComponentError(error).catch(() => undefined),
+      timeout,
+    ]).finally(() => {
+      this.setState({ errorToRethrow: error, isHandling: false });
+    });
+  }
+
+  override render(): ReactNode {
+    if ("errorToRethrow" in this.state) {
+      throw this.state.errorToRethrow;
+    }
+
+    if (this.state.isHandling) {
+      return null;
+    }
+
+    return this.props.children;
+  }
+}

--- a/packages/remote-react-renderer/src/components/HostRenderErrorBoundary.tsx
+++ b/packages/remote-react-renderer/src/components/HostRenderErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import { Component, type ErrorInfo, type ReactNode } from "react";
+import { Component, type ReactNode } from "react";
 
 const HOST_ERROR_DELIVERY_TIMEOUT_MS = 1000;
 
@@ -28,7 +28,7 @@ export class HostRenderErrorBoundary extends Component<Props, State> {
     return { errorToRethrow: error };
   }
 
-  override componentDidCatch(error: unknown, _info: ErrorInfo): void {
+  override componentDidCatch(error: unknown): void {
     if (!isNoComponentFoundError(error)) {
       return;
     }


### PR DESCRIPTION
Closes #2441

## What & why

When the host cannot map a remote element to a Flow component, it throws `No component found for remote element: <tag>`. Until now that error only surfaced **host-side**. Since the fault actually originates on the remote side — an extension developer rendering an element the host doesn't provide — it should surface there too, where it can be fixed.

## Approach

The catch: the moment the host error bubbles, `RemoteRendererBrowser` unmounts and the connection is torn down. So the host now **holds the error back**:

1. A host-side error boundary (`HostRenderErrorBoundary`) catches the render error.
2. If it's the `No component found…` error, it delivers the message to the remote over the still-alive connection and awaits delivery (with a 1s timeout fallback).
3. Only **then** does it re-throw, so the error bubbles to the host error boundary and tears down the connection **exactly as before**.

On the remote, the delivered error is thrown at the `RemoteRoot` level — above its internal `ErrorBoundary`, mirroring the existing `connectionError` pattern — so it reaches the **extension developer's own error boundary** rather than being swallowed/reported back to the host.

Only the `No component found…` error gets this treatment; any other host render error keeps today's immediate-bubble behavior.

## Protocol / backwards compatibility

Adds a new versioned host→remote RPC `setHostError` and bumps the negotiated protocol to **`Version.v5`**. The host guards the call on the remote's reported version (`>= v5`), and only additive changes are made to the `RemoteExports`/`HostExports` wire contract:

- **new remote + new host** → error propagates both ways;
- **old remote (≤v4) + new host** → guarded call is a no-op that resolves immediately, so the error just re-throws (today's behavior, no hang);
- **new remote + old host** → `setHostError` is simply never called.

## Verified

- `tsc --noEmit` on `remote-core`, `remote-react-components`, `remote-react-renderer`, and the demo app.
- **Live, in the demo app** (new "No component" page, `/host/no-component`): protocol negotiates to version 5, and on triggering the error the timeline is `remote throws while the iframe is still alive (t≈11ms) → host re-throws and tears down the connection (t≈20ms)` — i.e. the host genuinely holds the error until it has reached the remote.

## Note for reviewers

- Issue #2441 says the error should be thrown *only* remote-side; this PR intentionally keeps the host-side throw as well (to preserve the connection-teardown behavior) **and** adds the remote-side surfacing. Worth confirming that refinement.
- Detecting the target error couples to the message string thrown by the forked `@mittwald/remote-dom-react` host renderer — the only signal available (noted in a code comment).
- No automated round-trip test: the existing browser-test harness uses the in-process `__remoteReceiver` shortcut, which bypasses the thread connection, so the propagation can't be exercised there. The demo page is the manual-verification path.