### PR TITLE
docs(List): document loading and empty view patterns

### DIFF
--- a/apps/docs/src/content/04-components/structure/list/develop.mdx
+++ b/apps/docs/src/content/04-components/structure/list/develop.mdx
@@ -102,6 +102,69 @@ return {
 
 ---
 
+# Lade- und Leeransichten
+
+## Loading View
+
+Während die Daten initial geladen werden, zeigt die List eine Loading View aus
+Skeleton-Platzhaltern an. Über `loadingView` an einem `<List.Item />` – oder an
+einem `<TableCell />` in der Tabellenansicht – kann diese Ansicht angepasst
+werden:
+
+```tsx
+<List.Item
+  loadingView={
+    <List.ItemView>
+      <Avatar>
+        <Skeleton />
+      </Avatar>
+      <Heading>
+        <SkeletonText width="12em" />
+      </Heading>
+    </List.ItemView>
+  }
+>
+  {(item) => /* ... */}
+</List.Item>
+```
+
+Wird kein `loadingView` gesetzt, verwendet die List ein generisches Skeleton.
+
+## Empty View
+
+- `emptyView`: Wird angezeigt, wenn die Liste keine Einträge enthält.
+- `emptySearchResultView`: Wird angezeigt, wenn eine Suche oder ein Filter kein
+  Ergebnis liefert.
+
+Ist das jeweilige Property nicht gesetzt, zeigt die List eine passende,
+vordefinierte Ansicht an.
+
+## Initiale Suspense-Boundary
+
+Beim initialen Laden umschließt die List das Laden der Daten standardmäßig mit
+einer eigenen [Suspense](https://react.dev/reference/react/Suspense)-Boundary
+und zeigt währenddessen ihre Loading View an. Über
+`disableInitialSuspenseBoundary` an der Datenquelle (`<List.StaticData />`,
+`<List.LoaderAsync />`, `<List.LoaderHooks />`) lässt sich dieses Verhalten
+steuern:
+
+| Wert              | Verhalten                                                                                                                                                                                             |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `false` (Default) | Die List rendert beim initialen Laden ihre eigene Loading View (Skeleton).                                                                                                                            |
+| `true`            | Die List rendert beim initialen Laden keine eigene Suspense-Boundary. Das Suspending wird an die nächste übergeordnete Suspense-Boundary weitergereicht; die List erscheint erst mit geladenen Daten. |
+
+### Wann welchen Wert wählen?
+
+- Belasse den Wert bei **`false`**, wenn die List den Hauptinhalt darstellt oder
+  keine übergeordnete Ladeanzeige existiert. Nutzer erhalten so unmittelbar ein
+  visuelles Feedback direkt in der Liste.
+- Setze den Wert auf **`true`**, wenn die List in eine Seite oder einen Bereich
+  eingebettet ist, die bzw. der bereits einen eigenen Ladezustand anzeigt. So
+  wird die List atomar dargestellt und der Layout-Shift zwischen Loading und
+  Empty View vermieden.
+
+---
+
 # Filter
 
 In der Regel werden Filter für ein Property der List gesetzt:

--- a/apps/docs/src/content/04-components/structure/list/examples/loadingView.tsx
+++ b/apps/docs/src/content/04-components/structure/list/examples/loadingView.tsx
@@ -1,0 +1,58 @@
+import {
+  Avatar,
+  Heading,
+  IconDomain,
+  Skeleton,
+  SkeletonText,
+  Text,
+  typedList,
+} from "@mittwald/flow-react-components";
+import {
+  type Domain,
+  domains,
+} from "@/content/04-components/structure/list/examples/domainApi";
+
+export default () => {
+  const List = typedList<Domain>();
+
+  return (
+    <List.List aria-label="Domains">
+      {/* The loader waits a moment before resolving, so the loading view is
+          briefly visible before the data appears. */}
+      <List.LoaderAsync>
+        {() =>
+          new Promise<{ data: Domain[] }>((resolve) => {
+            setTimeout(
+              () => resolve({ data: domains.slice(0, 3) }),
+              2000,
+            );
+          })
+        }
+      </List.LoaderAsync>
+      <List.Item
+        textValue={(domain) => domain.hostname}
+        loadingView={
+          <List.ItemView>
+            <Avatar>
+              <Skeleton />
+            </Avatar>
+            <Heading>
+              <SkeletonText width="12em" />
+            </Heading>
+            <SkeletonText width="6em" />
+          </List.ItemView>
+        }
+      >
+        {(domain) => (
+          <List.ItemView>
+            <Avatar>
+              <IconDomain />
+            </Avatar>
+            <Heading>{domain.hostname}</Heading>
+            <Text>{domain.type}</Text>
+          </List.ItemView>
+        )}
+      </List.Item>
+    </List.List>
+  );
+};

--- a/apps/docs/src/content/04-components/structure/list/overview.mdx
+++ b/apps/docs/src/content/04-components/structure/list/overview.mdx
@@ -141,6 +141,22 @@ Die Pagination ist standardmäßig bei jeder List aktiviert, kann jedoch über
 `hidePagination` deaktiviert werden. Über die `batchSize`-Property kann
 festgelegt werden, wie viele Einträge gleichzeitig angezeigt werden sollen.
 
+## Loading View
+
+Während die Daten einer List initial geladen werden, zeigt die List eine
+**Loading View** aus Skeleton-Platzhaltern an. Ohne weitere Angabe wird dafür
+ein generisches Skeleton verwendet. Über das `loadingView`-Property eines
+`<List.Item />` (bzw. eines `<TableCell />` in der Tabellenansicht) lässt sich
+diese Ansicht anpassen.
+
+Gestalte die Loading View so, dass sie dem tatsächlichen Inhalt in Aufbau und
+Größe möglichst nahekommt, und verwende dafür
+[Skeleton](/04-components/content/skeleton/overview) und `SkeletonText`. So
+wirkt der Übergang von der Lade- zur Inhaltsansicht ruhig und ohne
+Layout-Sprung.
+
+<LiveCodeEditor example="loadingView" editorCollapsed stretch />
+
 ## Empty View
 
 Mit `emptyView` kann eine benutzerdefinierte Ansicht angezeigt werden, wenn die
@@ -153,6 +169,23 @@ In der Regel sollte als Empty View eine IllustratedMessage verwendet werden, um
 eine konsistente Nutzererfahrung zu gewährleisten.
 
 <LiveCodeEditor example="customEmptyView" editorCollapsed stretch />
+
+Für den Fall, dass eine Suche oder ein Filter kein Ergebnis liefert, kann über
+`emptySearchResultView` eine eigene Ansicht angezeigt werden. Wird sie nicht
+gesetzt, zeigt die List einen passenden, vordefinierten Hinweis an.
+
+## Layout-Shift zwischen Loading und Empty View
+
+Loading View (mehrere Skeleton-Zeilen) und Empty View (in der Regel eine
+einzelne IllustratedMessage) unterscheiden sich in der Höhe. Beim initialen
+Laden einer leeren Liste entsteht dadurch ein sichtbarer Sprung, sobald von der
+Lade- zur Leeransicht gewechselt wird.
+
+Ist die List in eine Seite eingebettet, die bereits einen eigenen Ladezustand
+anzeigt, lässt sich dieser Sprung vermeiden, indem die List beim initialen Laden
+keinen eigenen Ladezustand rendert. Wie sich das über das
+`disableInitialSuspenseBoundary`-Property steuern lässt, ist im Develop-Tab
+beschrieben.
 
 ---
 


### PR DESCRIPTION
Closes #2468.

## What

Documents the loading/empty view patterns introduced in #2440 for the `List` component.

- **`overview.mdx`** (design tab):
  - New **Loading View** section explaining the skeleton loading state and how `loadingView` on `List.Item` / `TableCell` customizes it, with a live example.
  - Extended **Empty View** with a note on `emptySearchResultView`.
  - New **Layout-Shift zwischen Loading und Empty View** section describing the shift and pointing to the Develop tab for `disableInitialSuspenseBoundary`.
- **`develop.mdx`** (technical tab):
  - New **Lade- und Leeransichten** section covering `loadingView`, `emptyView` vs. `emptySearchResultView`, and `disableInitialSuspenseBoundary` with a behaviour table and "when to choose which value" guidance.
- New **`examples/loadingView.tsx`** live example.

## Why

Issue #2468 asked to document when/how to use the custom loading and empty views and the `disableInitialSuspenseBoundary` option, and to settle its default.

## Notes for reviewers

- **Docs only — no behaviour change.** The `disableInitialSuspenseBoundary` default stays `false`; per discussion it is documented as guidance (both values explained) rather than changed in code.
- The live example uses a loader that resolves after a short delay so the skeleton is briefly visible before data appears. A never-resolving loader was intentionally avoided because it keeps the SSR stream open (static-build hang risk).
- Verified both pages render in the docs dev server with no runtime errors; `build:imports` produces no diff; ESLint and Prettier pass on the changed files.
- Docs content is in German, consistent with the rest of `apps/docs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)