### PR TITLE
fix(Link): keep client-side navigation with interactive children

### DIFF
--- a/packages/components/src/components/Link/Link.browser.test.tsx
+++ b/packages/components/src/components/Link/Link.browser.test.tsx
@@ -1,0 +1,43 @@
+import { render } from "vitest-browser-react";
+import { page, userEvent } from "vitest/browser";
+import type { Mock } from "vitest";
+import { RouterProvider } from "react-aria-components";
+import { Link } from "@/components/Link";
+import { Button } from "@/components/Button";
+
+let navigate: Mock;
+
+beforeEach(() => {
+  vitest.resetAllMocks();
+  navigate = vitest.fn();
+});
+
+const href = `${location.origin}/target`;
+
+test("plain link navigates client-side via RouterProvider", async () => {
+  render(
+    <RouterProvider navigate={navigate}>
+      <Link href={href}>Zur App</Link>
+    </RouterProvider>,
+  );
+
+  await userEvent.click(page.getByText("Zur App"));
+
+  expect(navigate).toHaveBeenCalledWith(href, undefined);
+});
+
+test("link with a nested button still navigates client-side", async () => {
+  render(
+    <RouterProvider navigate={navigate}>
+      <Link href={href}>
+        <Button data-testid="button" color="secondary" variant="soft">
+          Zur App
+        </Button>
+      </Link>
+    </RouterProvider>,
+  );
+
+  await userEvent.click(page.getByTestId("button"));
+
+  expect(navigate).toHaveBeenCalledWith(href, undefined);
+});

--- a/packages/components/src/components/Link/Link.tsx
+++ b/packages/components/src/components/Link/Link.tsx
@@ -2,6 +2,7 @@ import type {
   ComponentProps,
   ComponentType,
   CSSProperties,
+  MouseEvent,
   PropsWithChildren,
 } from "react";
 import { useContext } from "react";
@@ -19,6 +20,7 @@ import {
 } from "@/lib/types/props";
 import { linkContext } from "@/components/Link/context";
 import { LinkIcon } from "@/components/Link/components/LinkIcon";
+import { handleLinkClick, useRouter } from "@react-aria/utils";
 
 export interface LinkProps
   extends
@@ -56,6 +58,7 @@ export const Link = flowComponent("Link", (props) => {
     style,
     whiteSpace,
     size = "m",
+    onClickCapture: onClickCaptureFromProps,
     ...rest
   } = props;
 
@@ -65,6 +68,25 @@ export const Link = flowComponent("Link", (props) => {
     : props.href && linkComponentFromContext
       ? (linkComponentFromContext as typeof Aria.Link)
       : Aria.Link;
+
+  const router = useRouter();
+
+  /**
+   * An interactive child (e.g. a Button) stops click propagation via React
+   * Aria's `usePress`, so the anchor's own `onClick` never runs and navigation
+   * falls back to a full page load. Handling it in the capture phase (top-down,
+   * before the child) keeps navigation client-side. Only needed for React
+   * Aria's `<a>`; custom link components handle navigation themselves.
+   */
+  const handleClickCapture =
+    Link === Aria.Link && props.href
+      ? (event: MouseEvent<HTMLAnchorElement>) => {
+          onClickCaptureFromProps?.(event);
+          if (event.target !== event.currentTarget) {
+            handleLinkClick(event, router, props.href, props.routerOptions);
+          }
+        }
+      : onClickCaptureFromProps;
 
   const rootClassName = unstyled
     ? className
@@ -98,6 +120,7 @@ export const Link = flowComponent("Link", (props) => {
     <Link
       {...unsupportedTypingsLinkProps}
       {...rest}
+      onClickCapture={handleClickCapture}
       className={rootClassName}
       ref={ref}
       style={{ ...style, whiteSpace }}


### PR DESCRIPTION
closes #2018 