### PR TITLE
docs: add remote-UI explainer for contributors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,9 @@ it. Patterns are documented in
 ### 2. Remote DOM ("flr" = **Fl**ow **R**emote)
 
 mStudio extensions run in a hidden iframe and render UI that the host
-materializes with real Flow components:
+materializes with real Flow components. For the full picture — end-to-end flow,
+the mental model, and what remote-capability means when you implement a
+component — see [docs/remote-ui.md](docs/remote-ui.md).
 
 ```
 extension (iframe)                          host (mStudio)
@@ -184,8 +186,8 @@ A new or substantially changed component comes with:
 7. Remote-capable (`@flr-generate`): generated code regenerated + committed, and
    a demo page in `apps/remote-dom-demo`
 8. Visual changes: run the suite on demand with the `run-visual-tests` PR label
-   (verify only); for intentional changes, update snapshots (`test:visual:update`
-   or the `update-screenshots` PR label)
+   (verify only); for intentional changes, update snapshots
+   (`test:visual:update` or the `update-screenshots` PR label)
 
 ## Hard rules
 
@@ -208,6 +210,7 @@ A new or substantially changed component comes with:
 | Component patterns, styling, testing, i18n  | [packages/components/AGENTS.md](packages/components/AGENTS.md)                          |
 | Remote connection & serialization           | [packages/remote-core/AGENTS.md](packages/remote-core/AGENTS.md)                        |
 | Remote elements / React API / host renderer | `packages/remote-{elements,react-components,react-renderer}/AGENTS.md`                  |
+| Remote-UI concepts & component implications | [docs/remote-ui.md](docs/remote-ui.md)                                                  |
 | Icon pipeline                               | [packages/icons-base/AGENTS.md](packages/icons-base/AGENTS.md)                          |
 | Design tokens                               | [packages/design-tokens/AGENTS.md](packages/design-tokens/AGENTS.md)                    |
 | Styleguide content authoring                | [apps/docs/AGENTS.md](apps/docs/AGENTS.md) → [apps/docs/README.md](apps/docs/README.md) |

--- a/docs/remote-ui.md
+++ b/docs/remote-ui.md
@@ -183,6 +183,156 @@ directly.
 
 ## Implementing a component
 
+### Three ways a component participates in remote
+
+Every component in `packages/components` falls into exactly one of three
+categories, and the category determines what you can and cannot do with it.
+
+- **Self remote-capable** — annotated `/** @flr-generate all */`. Generation
+  turns it into a self-contained remote unit with its own `flr-*` element. From
+  the remote side it is "closed": the only way to extend what it renders is
+  through its `children`, and its props are exactly the serialized contract
+  described below — nothing more crosses the boundary.
+- **Universal component** — carries no `@flr-generate` annotation but is
+  exported additionally from `src/index/flr-universal.ts`. It wires and renders
+  other remote-capable components itself rather than owning an `flr-*` element
+  directly. Inside it, compose **only** through view components (`@/views/*`): a
+  view renders the plain Flow component locally, or its `flr-*` counterpart when
+  running in a remote context. This local/remote switch inside a single import
+  is exactly what lets a composite component work correctly in both worlds.
+- **Host-only** — exported only from `src/components/public.ts`, with no sibling
+  `view.ts`, no `@flr-generate` tag, and absent from `flr-universal.ts`
+  (examples: `Activity`, `RouterProvider`, the `OverlayTrigger` wrapper). It has
+  no `flr-*` element and cannot render remotely at all. **Gotcha:** if a
+  universal component composes a host-only component through a direct
+  `@/components/*` import instead of a view, it will silently render nothing in
+  a remote context — there is no error, the output is just missing (see
+  `packages/components/PATTERNS.md:274-277`).
+
+### State, data loading, and side effects belong on the remote side
+
+Because the host only mirrors output and relays events (see
+[The mental model](#the-mental-model)), any logic that produces or reacts to
+state — fetching data, tracking loading states, sorting or filtering, controlled
+input state — has to run on the remote side. Never assume that a piece of your
+component's logic executes on the host; the host has nothing to run it against.
+The `List` example above is the pattern to follow: state and behavior live
+remotely, and the host only ever shows the latest emitted output.
+
+### How props cross the boundary — the contract mechanics
+
+The remote-components generator classifies every prop of a `@flr-generate`
+component
+(`packages/components/dev/remote-components-generator/lib/propClassifiers.ts`),
+and the classification decides how that prop behaves once it crosses into remote
+territory:
+
+- **Callbacks must be named `on[A-Z]…`** to become cross-boundary _events_. A
+  function prop under any other name is treated as an ordinary serialized
+  property, not an event. The event name is derived from the prop name minus the
+  `on` prefix, with the first letter lowercased — `onPress` becomes the `press`
+  event.
+- **Event handlers receive exactly one argument: the event's `detail`** — not a
+  DOM or synthetic event. There is no `preventDefault`, `target`, or
+  `currentTarget` to call. Callbacks are proxied across the thread connection
+  and are effectively **async and fire-and-forget**: whatever the handler
+  returns does not cross back, so patterns like "return `false` to cancel" only
+  work within a single runtime.
+- **Props typed `ReactNode` become slots**, not serialized data — they cross as
+  rendered child content rather than as values that get cloned across the
+  connection.
+- **There are no HTML attributes.** `isAttribute` in the generator is hard-coded
+  to `false`
+  (`packages/components/dev/remote-components-generator/lib/propClassifiers.ts`),
+  so every non-event, non-slot prop is treated as a serialized _property_ —
+  don't rely on boolean or number props reflecting as DOM attributes on the
+  `flr-*` element.
+- **Non-serializable props generate cleanly but break at runtime.** Class
+  instances lose their prototype once cloned, `HTMLElement` and `window` coerce
+  to `null`, and raw DOM events degrade to near-empty objects. Nothing in the
+  type system stops you from adding such a prop to a `@flr-generate` component —
+  it will only misbehave once actually exercised across the boundary. This is
+  exactly why the ignore list below exists.
+
+Props of a `@flr-generate` component form a **contract** with extension
+developers: they can be relied on across arbitrary remote versions, so changing
+or removing one is a breaking change. Evolve them instead by adding new props
+and deprecating the old ones with `useWarnDeprecation` (see
+[Versioning & backwards compatibility](#versioning--backwards-compatibility)).
+
+### The ignore list, and why `ref` / `controller` / `tunnel` don't cross
+
+Some props are excluded from generation outright, either globally or per
+component. The global ignore list lives in
+`packages/components/dev/remote-components-generator/config.ts`: `style`,
+`dangerouslySetInnerHTML`, `ref`, `controller`, `tunnel`, `key`, `children`, and
+`wrapWith`. A component can additionally exclude one of its own props with a
+`@flr-ignore-props` JSDoc tag.
+
+Three of these deserve a specific explanation, because they look like they
+should cross the boundary and deliberately don't:
+
+- **`ref`** resolves to the _remote_ custom element, not to any host DOM node —
+  there is no host element to hand back. Patterns that rely on a host DOM
+  measurement or imperative call (`getBoundingClientRect`, `focus`) simply have
+  nothing to attach to across the boundary.
+- **`controller`** is a live MobX object that drives rendering on the **remote**
+  side. It coordinates components within the same remote tree; it has no
+  host-side counterpart to coordinate with.
+- **`tunnel`** is an intra-tree portal (`@mittwald/react-tunnel`) that resolves
+  entirely before anything crosses the boundary — it is not a boundary-crossing
+  mechanism at all, just implemented with the same "cannot serialize"
+  characteristics as the others.
+
+### Controlled text inputs need echo-suppression
+
+Every keystroke in a controlled remote text input has to round-trip
+asynchronously: the remote side updates its value, serializes the change, sends
+it to the host, the host renders it, and — for a controlled field — the new
+value has to make it back to the remote side as a prop update. Naively wiring
+this up causes dropped or reordered characters under fast typing, so controlled
+text fields pair `useControlledRemoteValueProps` (used on the remote side) with
+`useControlledHostValueProps` (used on the host side) to suppress the echo of a
+value the remote side just sent.
+
+This pairing is opted into through a hardcoded allowlist,
+`controlledComponentNames`, in
+`packages/remote-react-components/src/lib/createRemoteComponent.ts`. Adding a
+new controlled remote text field means adding its `flr-*` tag name to that list
+— skip it, and the field will drop characters under fast typing.
+
+### Placement and registration for a new remote-capable component
+
+A new `@flr-generate` component has two placement requirements beyond the
+annotation itself: it must live under `src/components` or `src/integrations` in
+`packages/components` (the glob the doc-extraction step scans), and it must be
+registered in the hand-maintained `FlowComponentPropsTypes` registry at
+`packages/components/src/components/propTypes/index.ts`. Miss either one and the
+component is silently skipped by the generator or fails typecheck — there is no
+generator-side error pointing at the missing registration.
+
+### PropsContext — only remote-capable components belong in one
+
+`PropsContext` is plain React context: it is resolved independently on each side
+of the boundary and is never itself serialized. That independence has a
+consequence worth internalizing. A host `PropsContextProvider` placed above
+`<RemoteRenderer>` _does_ reach the mirrored `flr-*` components, because each
+one becomes a host `flowComponent` that re-reads context from its position in
+the host's React tree. But a non-remote-capable child that lives only inside the
+extension iframe resolves context purely against the iframe's own tree — it has
+no path back to host-side context — so it silently misses whatever the host
+provider set, without any warning that the value never arrived. Only put
+remote-capable components in a `PropsContext` that is meant to reach across the
+boundary.
+
+### Definition of Done for a remote-capable component
+
+Beyond the general
+[Definition of Done](../AGENTS.md#definition-of-done--component-work) for
+component work, a remote-capable component additionally needs: regenerated and
+committed generated artifacts, a demo page in `apps/remote-dom-demo`, and
+passing visual tests in **both** the `Local` and `Remote` test targets.
+
 ## Versioning & backwards compatibility
 
 ## Host-side rendering — special cases

--- a/docs/remote-ui.md
+++ b/docs/remote-ui.md
@@ -11,12 +11,12 @@ building the Flow components themselves.
 
 ## Why remote-UI exists
 
-mStudio extensions run inside a hidden iframe, sandboxed away from the host (the
-mittwald backoffice) for security. Yet the UI an extension produces has to look
-and feel like it belongs in the backoffice — buttons, tables, forms, and layouts
-that are indistinguishable from the surrounding product. Remote-UI is the system
-that bridges that gap: extensions describe their UI in terms of Flow components,
-and the host renders real Flow components on their behalf.
+mStudio extensions run inside a hidden iframe, sandboxed away from the host
+(mStudio) for security. Yet the UI an extension produces has to look and feel
+like it belongs in mStudio — buttons, tables, forms, and layouts that are
+indistinguishable from the surrounding product. Remote-UI is the system that
+bridges that gap: extensions describe their UI in terms of Flow components, and
+the host renders real Flow components on their behalf.
 
 The alternative — shipping a component library inside every extension bundle —
 was rejected for reasons that all trace back to control. A bundled library
@@ -42,7 +42,7 @@ to that hidden tree is serialized and sent across a
 [`@quilted/threads`](https://github.com/lemonmade/quilt) connection to the host.
 On the host side, a `RemoteReceiver` accepts the incoming mutations and a
 `RemoteRenderer` maps each `flr-*` element to its real Flow component
-counterpart, so the backoffice ends up rendering actual Flow components — not a
+counterpart, so the host ends up rendering actual Flow components — not a
 re-implementation of them. Events run in the opposite direction: user
 interaction on the rendered host component is captured and forwarded back across
 the same connection so the handler, which lives in the extension, can respond to
@@ -56,7 +56,7 @@ flowchart LR
     RDOM["hidden remote DOM<br/>(flr-* elements)"]
     RR --> RDOM
   end
-  subgraph HOST["Host (mStudio backoffice)"]
+  subgraph HOST["Host (mStudio)"]
     direction TB
     RECV["RemoteReceiver"]
     REND["RemoteRenderer"]
@@ -86,10 +86,10 @@ Five packages divide the responsibilities along this flow:
 
 The clearest way to think about remote-UI is as two worlds separated by a
 serialization boundary: the **remote** world (the extension, running inside the
-hidden iframe) and the **host** world (the backoffice). Everything that crosses
-between them has to survive being serialized, sent over the thread connection,
-and deserialized on the other side. `FlowThreadSerialization`
-(`packages/remote-core/src/serialization/FlowThreadSerialization.ts`)
+hidden iframe) and the **host** world (mStudio). Everything that crosses between
+them has to survive being serialized, sent over the thread connection, and
+deserialized on the other side. `FlowThreadSerialization`
+([`packages/remote-core/src/serialization/FlowThreadSerialization.ts`](../packages/remote-core/src/serialization/FlowThreadSerialization.ts))
 deliberately excludes `HTMLElement` and `window` from what it will serialize —
 they simply cannot mean anything on the other side of the boundary. The `flr-*`
 custom elements exist precisely to stand in for host components inside this
@@ -102,12 +102,12 @@ flowchart LR
     direction TB
     R["state · data loading · effects<br/>Suspense resolves here<br/>flr-* output tree<br/>event handlers run here"]
   end
-  subgraph HOST["HOST (backoffice)"]
+  subgraph HOST["HOST (mStudio)"]
     direction TB
     H["mirror of remote output<br/>real Flow components render<br/>every event forwarded back"]
   end
-  REMOTE -- "serialized mutations ▶" --> HOST
-  HOST -- "◀ events" --> REMOTE
+  REMOTE -- "serialized mutations" --> HOST
+  HOST -- "events" --> REMOTE
 ```
 
 Across that boundary, what **crosses** is: serializable props, `on*` events (the
@@ -146,7 +146,7 @@ Two worked examples make the principle concrete:
   for the boundary mechanism itself — only its `fallback` crosses, and the
   fallback, like anything rendered remote-side, must be remote-capable.
   `SuspenseTrigger`
-  (`packages/components/src/components/SuspenseTrigger/SuspenseTrigger.tsx`)
+  [(`packages/components/src/components/SuspenseTrigger/SuspenseTrigger.tsx`)](../packages/components/src/components/SuspenseTrigger/SuspenseTrigger.tsx)
   illustrates the underlying mechanism: it renders a lazy element that never
   resolves, which is enough to hold a boundary suspended for testing or demo
   purposes.
@@ -155,9 +155,9 @@ Two worked examples make the principle concrete:
 
 A component becomes remote-capable by carrying a `/** @flr-generate all */`
 JSDoc tag directly above its declaration (see, for example,
-`packages/components/src/components/Button/Button.tsx`). The `all` value is
-decorative — the generator only checks that the `flr-generate` tag is _present_
-on the component, not what value it carries.
+[`packages/components/src/components/Button/Button.tsx`](../packages/components/src/components/Button/Button.tsx)).
+The `all` value is decorative — the generator only checks that the
+`flr-generate` tag is _present_ on the component, not what value it carries.
 
 That single tag drives a chain of generated artifacts:
 
@@ -214,7 +214,8 @@ categories, and the category determines what you can and cannot do with it.
   universal component composes a host-only component through a direct
   `@/components/*` import instead of a view, it will silently render nothing in
   a remote context — there is no error, the output is just missing (see the
-  host-only components note in `packages/components/PATTERNS.md`).
+  host-only components note in
+  [`packages/components/PATTERNS.md`](../packages/components/PATTERNS.md)).
 
 ### State, data loading, and side effects belong on the remote side
 
@@ -230,7 +231,7 @@ remotely, and the host only ever shows the latest emitted output.
 
 The remote-components generator classifies every prop of a `@flr-generate`
 component
-(`packages/components/dev/remote-components-generator/lib/propClassifiers.ts`),
+([`packages/components/dev/remote-components-generator/lib/propClassifiers.ts`](../packages/components/dev/remote-components-generator/lib/propClassifiers.ts)),
 and the classification decides how that prop behaves once it crosses into remote
 territory:
 
@@ -250,7 +251,7 @@ territory:
   connection.
 - **There are no HTML attributes.** `isAttribute` in the generator is hard-coded
   to `false`
-  (`packages/components/dev/remote-components-generator/lib/propClassifiers.ts`),
+  ([`packages/components/dev/remote-components-generator/lib/propClassifiers.ts`](../packages/components/dev/remote-components-generator/lib/propClassifiers.ts)),
   so every non-event, non-slot prop is treated as a serialized _property_ —
   don't rely on boolean or number props reflecting as DOM attributes on the
   `flr-*` element.
@@ -271,10 +272,10 @@ and deprecating the old ones with `useWarnDeprecation` (see
 
 Some props are excluded from generation outright, either globally or per
 component. The global ignore list lives in
-`packages/components/dev/remote-components-generator/config.ts`: `style`,
-`dangerouslySetInnerHTML`, `ref`, `controller`, `tunnel`, `key`, `children`, and
-`wrapWith`. A component can additionally exclude one of its own props with a
-`@flr-ignore-props` JSDoc tag.
+[`packages/components/dev/remote-components-generator/config.ts`](../packages/components/dev/remote-components-generator/config.ts):
+`style`, `dangerouslySetInnerHTML`, `ref`, `controller`, `tunnel`, `key`,
+`children`, and `wrapWith`. A component can additionally exclude one of its own
+props with a `@flr-ignore-props` JSDoc tag.
 
 Three of these deserve a specific explanation, because they look like they
 should cross the boundary and deliberately don't:
@@ -304,9 +305,9 @@ value the remote side just sent.
 
 This pairing is opted into through a hardcoded allowlist,
 `controlledComponentNames`, in
-`packages/remote-react-components/src/lib/createRemoteComponent.ts`. Adding a
-new controlled remote text field means adding its `flr-*` tag name to that list
-— skip it, and the field will drop characters under fast typing.
+[`packages/remote-react-components/src/lib/createRemoteComponent.ts`](../packages/remote-react-components/src/lib/createRemoteComponent.ts).
+Adding a new controlled remote text field means adding its `flr-*` tag name to
+that list — skip it, and the field will drop characters under fast typing.
 
 ### Placement and registration for a new remote-capable component
 
@@ -314,9 +315,10 @@ A new `@flr-generate` component has two placement requirements beyond the
 annotation itself: it must live under `src/components` or `src/integrations` in
 `packages/components` (the glob the doc-extraction step scans), and it must be
 registered in the hand-maintained `FlowComponentPropsTypes` registry at
-`packages/components/src/components/propTypes/index.ts`. Miss either one and the
-component is silently skipped by the generator or fails typecheck — there is no
-generator-side error pointing at the missing registration.
+[`packages/components/src/components/propTypes/index.ts`](../packages/components/src/components/propTypes/index.ts).
+Miss either one and the component is silently skipped by the generator or fails
+typecheck — there is no generator-side error pointing at the missing
+registration.
 
 ### PropsContext — only remote-capable components belong in one
 
@@ -347,28 +349,29 @@ were built against many different remote releases — the protocol has to tolera
 that spread, and it does so through two independent version mechanisms.
 
 The first is the connection handshake: a `Version` enum (`vUnknown`, `v1`…`v5`
-in `packages/remote-core/src/connection/types.ts`) that the remote side reports
-when it connects. The host feature-gates behavior with `>=` checks against this
-version and always defaults to the most conservative path when in doubt.
-Critically, there is **no hard mismatch error** — a remote that reports nothing,
-or an old remote build, simply normalizes to `v1` and gets the oldest supported
-behavior rather than a broken connection.
+in
+[`packages/remote-core/src/connection/types.ts`](../packages/remote-core/src/connection/types.ts))
+that the remote side reports when it connects. The host feature-gates behavior
+with `>=` checks against this version and always defaults to the most
+conservative path when in doubt. Critically, there is **no hard mismatch error**
+— a remote that reports nothing, or an old remote build, simply normalizes to
+`v1` and gets the oldest supported behavior rather than a broken connection.
 
 The second mechanism is per-element rather than per-connection: each `flr-*`
 element carries a `data-flr-version` and a `data-flr-initialized` attribute
 (`FlowRemoteElement.versionPropertyName` and
 `FlowRemoteElement.initializationPropertyName` in
-`packages/remote-elements/src/lib/FlowRemoteElement.ts`). From `v3` onward, the
-host renders `null` for an element until it signals `data-flr-initialized`,
-which avoids a visible flash of the component rendering with its bare default
-props before its real remote props have arrived.
+[`packages/remote-elements/src/lib/FlowRemoteElement.ts`](../packages/remote-elements/src/lib/FlowRemoteElement.ts)).
+From `v3` onward, the host renders `null` for an element until it signals
+`data-flr-initialized`, which avoids a visible flash of the component rendering
+with its bare default props before its real remote props have arrived.
 
 Underneath both mechanisms sits the actual backwards-compatibility boundary that
 must never break: the `HostExports` interface
-(`packages/remote-core/src/connection/types.ts`). Its own doc comment spells out
-the rule — never remove, rename, or otherwise change the meaning of an existing
-member, since older remotes may depend on it; when adding a new member, release
-the host before any client that uses it.
+([`packages/remote-core/src/connection/types.ts`](../packages/remote-core/src/connection/types.ts)).
+Its own doc comment spells out the rule — never remove, rename, or otherwise
+change the meaning of an existing member, since older remotes may depend on it;
+when adding a new member, release the host before any client that uses it.
 
 Deprecations travel a defined path rather than being an ad hoc `console.warn`:
 `useWarnDeprecation` (deferred to an effect and deduplicated so a warning fires
@@ -385,20 +388,21 @@ render-and-mirror model above and are worth knowing about directly:
 
 - `<script>` elements in the remote tree render to `null` on the host — a
   deliberate security omission, not an oversight
-  (`packages/remote-react-renderer/src/components.ts`). A set of raw HTML tags,
-  by contrast — `svg`, `path`, `ul`, `li`, and similar — pass straight through
-  as real DOM elements, which is what lets rich-text and Markdown output render
-  correctly. `flr-notification` is a special case handled imperatively: it is
-  pushed into the host's notification controller rather than rendered inline
-  (`packages/remote-react-renderer/src/components.ts`).
+  ([`packages/remote-react-renderer/src/components.ts`](../packages/remote-react-renderer/src/components.ts)).
+  A set of raw HTML tags, by contrast — `svg`, `path`, `ul`, `li`, and similar —
+  pass straight through as real DOM elements, which is what lets rich-text and
+  Markdown output render correctly. `flr-notification` is a special case handled
+  imperatively: it is pushed into the host's notification controller rather than
+  rendered inline
+  ([`packages/remote-react-renderer/src/components.ts`](../packages/remote-react-renderer/src/components.ts)).
 - **Suspense on the host does not unmount.** A suspended remote subtree is
   transmitted with `display: none !important` rather than being removed, so it
   stays mounted (and any state inside it survives) while hidden.
 - **Performance characteristics worth knowing:** navigation changes are detected
   by polling `location.href` every 50 ms, because no appropriate browser API
   exists for observing it otherwise
-  (`packages/remote-react-components/src/hooks/useWatchPathname.ts`); and
-  serialization shallow-clones every non-base object prop (`{ ...val }` in
+  ([`packages/remote-react-components/src/hooks/useWatchPathname.ts`](../packages/remote-react-components/src/hooks/useWatchPathname.ts));
+  and serialization shallow-clones every non-base object prop (`{ ...val }` in
   `FlowThreadSerialization`) on every pass across the boundary, so passing deep
   or large object props is more expensive over the wire than it would be
   locally.

--- a/docs/remote-ui.md
+++ b/docs/remote-ui.md
@@ -96,17 +96,24 @@ custom elements exist precisely to stand in for host components inside this
 boundary: the remote side only ever manipulates `flr-*` elements, never a real
 DOM node.
 
-```text
-  REMOTE (iframe)                    │  thread boundary  │      HOST (backoffice)
-  ────────────────                   │                   │      ─────────────────
-  state · data loading · effects     │  serialized       │  mirror of remote output
-  Suspense resolves here             │  mutations  ────► │  real Flow components render
-  flr-* output tree                  │                   │
-  event handlers run here      ◄──── │  events           │  every event forwarded back
-
-  crosses:      serializable props · on* events (detail only) · slots (ReactNode)
-  never crosses: HTMLElement/window · ref · controller · tunnel · return values
+```mermaid
+flowchart LR
+  subgraph REMOTE["REMOTE (iframe)"]
+    direction TB
+    R["state · data loading · effects<br/>Suspense resolves here<br/>flr-* output tree<br/>event handlers run here"]
+  end
+  subgraph HOST["HOST (backoffice)"]
+    direction TB
+    H["mirror of remote output<br/>real Flow components render<br/>every event forwarded back"]
+  end
+  REMOTE -- "serialized mutations ▶" --> HOST
+  HOST -- "◀ events" --> REMOTE
 ```
+
+Across that boundary, what **crosses** is: serializable props, `on*` events (the
+event `detail` only), and slots (`ReactNode`). What **never crosses** is:
+`HTMLElement`/`window`, `ref`, `controller`, `tunnel`, and callback return
+values.
 
 **Render-and-mirror, events-back.** The relationship between the two sides is
 directional, not symmetric. The host renders only what the remote emits — it is

--- a/docs/remote-ui.md
+++ b/docs/remote-ui.md
@@ -146,6 +146,41 @@ Two worked examples make the principle concrete:
 
 ## The generation pipeline
 
+A component becomes remote-capable by carrying a `/** @flr-generate all */`
+JSDoc tag directly above its declaration (see, for example,
+`packages/components/src/components/Button/Button.tsx`). The `all` value is
+decorative — the generator only checks that the `flr-generate` tag is _present_
+on the component, not what value it carries.
+
+That single tag drives a chain of generated artifacts:
+
+- `view.ts` next to the component, plus a generated view component under
+  `packages/components/src/views/` (e.g. `<Name>View.tsx`) — the piece that lets
+  other components compose it transparently through `@/views/*` (see
+  [Implementing a component](#implementing-a-component)).
+- A custom `flr-*` element in `packages/remote-elements/src/auto-generated/`.
+- A remote React component in
+  `packages/remote-react-components/src/auto-generated/`, which is what
+  extension code actually imports and renders.
+- An entry in the host-side component map in
+  `packages/remote-react-renderer/src/auto-generated/`, which is what lets
+  `RemoteRenderer` turn the `flr-*` element back into the real component.
+
+The whole pipeline runs with `pnpm nx build:remote-components components` (or
+simply `pnpm build`, which runs every generator). It depends on prop
+documentation extracted from JSDoc: `pnpm nx build:docs-properties components`
+writes `packages/components/dist/assets/doc-properties.json`, which the
+remote-components generator reads to decide which props become which kind of
+contract (see [How props cross the boundary](#implementing-a-component)).
+Because of this dependency, changing prop JSDoc without rebuilding leaves the
+generated artifacts out of sync.
+
+Generated files are committed, never hand-edited — every header on a generated
+file says so, and CI enforces this with `git diff --exit-code` after running the
+build. Fixing something that looks wrong in a generated file means fixing the
+generator or the source component and regenerating, not editing the output
+directly.
+
 ## Implementing a component
 
 ## Versioning & backwards compatibility

--- a/docs/remote-ui.md
+++ b/docs/remote-ui.md
@@ -206,8 +206,8 @@ categories, and the category determines what you can and cannot do with it.
   no `flr-*` element and cannot render remotely at all. **Gotcha:** if a
   universal component composes a host-only component through a direct
   `@/components/*` import instead of a view, it will silently render nothing in
-  a remote context — there is no error, the output is just missing (see
-  `packages/components/PATTERNS.md:274-277`).
+  a remote context — there is no error, the output is just missing (see the
+  host-only components note in `packages/components/PATTERNS.md`).
 
 ### State, data loading, and side effects belong on the remote side
 

--- a/docs/remote-ui.md
+++ b/docs/remote-ui.md
@@ -335,6 +335,85 @@ passing visual tests in **both** the `Local` and `Remote` test targets.
 
 ## Versioning & backwards compatibility
 
+A host is deployed once and then runs for a long time next to extensions that
+were built against many different remote releases — the protocol has to tolerate
+that spread, and it does so through two independent version mechanisms.
+
+The first is the connection handshake: a `Version` enum (`vUnknown`, `v1`…`v5`
+in `packages/remote-core/src/connection/types.ts`) that the remote side reports
+when it connects. The host feature-gates behavior with `>=` checks against this
+version and always defaults to the most conservative path when in doubt.
+Critically, there is **no hard mismatch error** — a remote that reports nothing,
+or an old remote build, simply normalizes to `v1` and gets the oldest supported
+behavior rather than a broken connection.
+
+The second mechanism is per-element rather than per-connection: each `flr-*`
+element carries a `data-flr-version` and a `data-flr-initialized` attribute
+(`FlowRemoteElement.versionPropertyName` and
+`FlowRemoteElement.initializationPropertyName` in
+`packages/remote-elements/src/lib/FlowRemoteElement.ts`). From `v3` onward, the
+host renders `null` for an element until it signals `data-flr-initialized`,
+which avoids a visible flash of the component rendering with its bare default
+props before its real remote props have arrived.
+
+Underneath both mechanisms sits the actual backwards-compatibility boundary that
+must never break: the `HostExports` interface
+(`packages/remote-core/src/connection/types.ts`). Its own doc comment spells out
+the rule — never remove, rename, or otherwise change the meaning of an existing
+member, since older remotes may depend on it; when adding a new member, release
+the host before any client that uses it.
+
+Deprecations travel a defined path rather than being an ad hoc `console.warn`:
+`useWarnDeprecation` (deferred to an effect and deduplicated so a warning fires
+once, not on every render) writes to `console.warn` and to a context `onWarning`
+handler; in a remote context, `RemoteRoot` forwards the message across the
+connection via `connection.imports.reportDeprecation?.(message)` — the optional
+chaining is a deliberate guard for hosts that predate the `reportDeprecation`
+export — which surfaces on the host side as `onDeprecation`.
+
 ## Host-side rendering — special cases
 
+A handful of host-rendering behaviors don't fit neatly into the
+render-and-mirror model above and are worth knowing about directly:
+
+- `<script>` elements in the remote tree render to `null` on the host — a
+  deliberate security omission, not an oversight
+  (`packages/remote-react-renderer/src/components.ts`). A set of raw HTML tags,
+  by contrast — `svg`, `path`, `ul`, `li`, and similar — pass straight through
+  as real DOM elements, which is what lets rich-text and Markdown output render
+  correctly. `flr-notification` is a special case handled imperatively: it is
+  pushed into the host's notification controller rather than rendered inline
+  (`packages/remote-react-renderer/src/components.ts`).
+- **Suspense on the host does not unmount.** A suspended remote subtree is
+  transmitted with `display: none !important` rather than being removed, so it
+  stays mounted (and any state inside it survives) while hidden.
+- **Performance characteristics worth knowing:** navigation changes are detected
+  by polling `location.href` every 50 ms, because no appropriate browser API
+  exists for observing it otherwise
+  (`packages/remote-react-components/src/hooks/useWatchPathname.ts`); and
+  serialization shallow-clones every non-base object prop (`{ ...val }` in
+  `FlowThreadSerialization`) on every pass across the boundary, so passing deep
+  or large object props is more expensive over the wire than it would be
+  locally.
+
 ## Where to go deeper
+
+This document covers the concepts; the following are where the procedural and
+package-level detail lives:
+
+- [`packages/remote-core/AGENTS.md`](../packages/remote-core/AGENTS.md) —
+  connection and serialization internals.
+- [`packages/remote-elements/AGENTS.md`](../packages/remote-elements/AGENTS.md)
+  — the custom `flr-*` elements.
+- [`packages/remote-react-components/AGENTS.md`](../packages/remote-react-components/AGENTS.md)
+  — the remote React API and Local/Remote testing.
+- [`packages/remote-react-renderer/AGENTS.md`](../packages/remote-react-renderer/AGENTS.md)
+  — the host-side renderer.
+- [`packages/components/AGENTS.md`](../packages/components/AGENTS.md) —
+  component patterns: views, `PropsContext`, and generation details.
+- [`CONTRIBUTE.md`](../CONTRIBUTE.md), section
+  ["Adding or changing a component"](../CONTRIBUTE.md#adding-or-changing-a-component)
+  → step 6, "Generate the remote artifacts" — the concrete procedure for
+  regenerating and committing.
+- [`apps/remote-dom-demo/AGENTS.md`](../apps/remote-dom-demo/AGENTS.md) — the
+  demo app every remote-capable component needs a page in.

--- a/docs/remote-ui.md
+++ b/docs/remote-ui.md
@@ -1,0 +1,26 @@
+# Remote-UI ("flr") — how it works and what it means for components
+
+This document explains Flow's remote-UI system for **contributors** — the people
+(and agents) who build and change components in this repository. It covers how
+the system works end to end, why it is built this way, and — most importantly —
+what remote-capability means when you implement or change a component.
+
+This is not extension-developer documentation. That lives on
+<https://flow.mittwald.de> (`apps/docs`, in German). This document is about
+building the Flow components themselves.
+
+## Why remote-UI exists
+
+## End-to-end architecture
+
+## The mental model
+
+## The generation pipeline
+
+## Implementing a component
+
+## Versioning & backwards compatibility
+
+## Host-side rendering — special cases
+
+## Where to go deeper

--- a/docs/remote-ui.md
+++ b/docs/remote-ui.md
@@ -11,7 +11,76 @@ building the Flow components themselves.
 
 ## Why remote-UI exists
 
+mStudio extensions run inside a hidden iframe, sandboxed away from the host (the
+mittwald backoffice) for security. Yet the UI an extension produces has to look
+and feel like it belongs in the backoffice — buttons, tables, forms, and layouts
+that are indistinguishable from the surrounding product. Remote-UI is the system
+that bridges that gap: extensions describe their UI in terms of Flow components,
+and the host renders real Flow components on their behalf.
+
+The alternative — shipping a component library inside every extension bundle —
+was rejected for reasons that all trace back to control. A bundled library
+cannot be sandboxed away from the host DOM without losing visual consistency,
+since every extension would carry its own (possibly stale) copy of the design
+system and render it without any central oversight. Remote-UI instead keeps one
+set of real Flow components under the host's control: the host decides which
+version of a component actually renders, can evolve components without requiring
+every extension to rebuild and redeploy in lockstep, and can serve many
+extensions — built against different remote versions — from a single, consistent
+rendering surface. This is also why the connection protocol between extension
+and host is versioned (see
+[Versioning & backwards compatibility](#versioning--backwards-compatibility)): a
+host will run for years next to extensions built against older remote releases.
+
 ## End-to-end architecture
+
+At the center of remote-UI is a data flow between two runtimes. The extension
+renders a `RemoteRoot` tree built from remote React components; that tree
+materializes as a hidden remote DOM of `flr-*` elements — never attached to any
+visible document, since the extension iframe itself stays hidden. Every mutation
+to that hidden tree is serialized and sent across a
+[`@quilted/threads`](https://github.com/lemonmade/quilt) connection to the host.
+On the host side, a `RemoteReceiver` accepts the incoming mutations and a
+`RemoteRenderer` maps each `flr-*` element to its real Flow component
+counterpart, so the backoffice ends up rendering actual Flow components — not a
+re-implementation of them. Events run in the opposite direction: user
+interaction on the rendered host component is captured and forwarded back across
+the same connection so the handler, which lives in the extension, can respond to
+it.
+
+```mermaid
+flowchart LR
+  subgraph EXT["Extension (hidden iframe)"]
+    direction TB
+    RR["RemoteRoot +<br/>remote React components"]
+    RDOM["hidden remote DOM<br/>(flr-* elements)"]
+    RR --> RDOM
+  end
+  subgraph HOST["Host (mStudio backoffice)"]
+    direction TB
+    RECV["RemoteReceiver"]
+    REND["RemoteRenderer"]
+    FLOW["real Flow components"]
+    RECV --> REND --> FLOW
+  end
+  RDOM -- "@quilted/threads (serialized mutations)" --> RECV
+  HOST -. "events forwarded back" .-> EXT
+```
+
+The connection layer itself is not bespoke: it is built on a fork of
+[Shopify's remote-dom](https://github.com/Shopify/remote-dom), published under
+the `@mittwald/remote-dom-*` scope, which supplies the generic custom-element
+and serialization machinery that Flow's own packages specialize.
+
+Five packages divide the responsibilities along this flow:
+
+| Package                                  | Side   | Role                                                                                                               |
+| ---------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------ |
+| `@mittwald/flow-remote-core`             | both   | Connection + serialization (`@quilted/threads`); the versioned protocol.                                           |
+| `@mittwald/flow-remote-react-components` | remote | React API extensions program against (`RemoteRoot`, generated `flr-*` React components).                           |
+| `@mittwald/flow-remote-elements`         | remote | Custom `flr-*` elements (`FlowRemoteElement` base + a few hand-written ones).                                      |
+| `@mittwald/flow-remote-react-renderer`   | host   | Maps `flr-*` elements to real Flow components; `RemoteRendererBrowser` wires the hidden iframe + `RemoteReceiver`. |
+| `@mittwald/flow-react-components`        | both   | The components themselves; `@flr-generate` marks the ones that get remote artifacts.                               |
 
 ## The mental model
 

--- a/docs/remote-ui.md
+++ b/docs/remote-ui.md
@@ -84,6 +84,66 @@ Five packages divide the responsibilities along this flow:
 
 ## The mental model
 
+The clearest way to think about remote-UI is as two worlds separated by a
+serialization boundary: the **remote** world (the extension, running inside the
+hidden iframe) and the **host** world (the backoffice). Everything that crosses
+between them has to survive being serialized, sent over the thread connection,
+and deserialized on the other side. `FlowThreadSerialization`
+(`packages/remote-core/src/serialization/FlowThreadSerialization.ts`)
+deliberately excludes `HTMLElement` and `window` from what it will serialize —
+they simply cannot mean anything on the other side of the boundary. The `flr-*`
+custom elements exist precisely to stand in for host components inside this
+boundary: the remote side only ever manipulates `flr-*` elements, never a real
+DOM node.
+
+```text
+  REMOTE (iframe)                    │  thread boundary  │      HOST (backoffice)
+  ────────────────                   │                   │      ─────────────────
+  state · data loading · effects     │  serialized       │  mirror of remote output
+  Suspense resolves here             │  mutations  ────► │  real Flow components render
+  flr-* output tree                  │                   │
+  event handlers run here      ◄──── │  events           │  every event forwarded back
+
+  crosses:      serializable props · on* events (detail only) · slots (ReactNode)
+  never crosses: HTMLElement/window · ref · controller · tunnel · return values
+```
+
+**Render-and-mirror, events-back.** The relationship between the two sides is
+directional, not symmetric. The host renders only what the remote emits — it is
+a mirror of the remote output tree, nothing more. In the other direction, the
+host forwards **all** events back to the remote side, where the actual event
+handlers run. This is why state and logic live on the remote side: the host is
+deliberately "dumb", a rendering surface that reflects output and relays input.
+
+**Everything rendered remote-side must itself be remote-capable.** This is the
+general principle the boundary enforces. In extension code, it is guaranteed
+structurally: extension developers can only render components imported from
+`@mittwald/flow-remote-react-components`, so there is no way to accidentally
+render something the host cannot mirror (this is a user-land concern for
+extension developers and out of scope here). The contributor-side equivalent —
+what this means when you compose components _inside_ Flow itself — is covered in
+[Implementing a component](#implementing-a-component), where composing through
+views (`@/views/*`) is what keeps a composite component remote-safe.
+
+Two worked examples make the principle concrete:
+
+- **List.** Data loading for `List` runs entirely on the remote side
+  (`List/setupComponents/ListLoaderAsync*`, `List/model/ListSettingsStore`). The
+  loading state is rendered by the remote and mirrored to the host; once data
+  arrives, the list entries themselves are produced remotely and mirrored the
+  same way. The remote side holds the state and drives the interaction end to
+  end — the host only reflects whatever output currently exists and relays
+  events (like a row click) back.
+- **Suspense.** Suspense resolves on the remote side too. The Suspense boundary
+  itself renders no DOM elements, so nothing is transmitted across the boundary
+  for the boundary mechanism itself — only its `fallback` crosses, and the
+  fallback, like anything rendered remote-side, must be remote-capable.
+  `SuspenseTrigger`
+  (`packages/components/src/components/SuspenseTrigger/SuspenseTrigger.tsx`)
+  illustrates the underlying mechanism: it renders a lazy element that never
+  resolves, which is enough to hold a boundary suspended for testing or demo
+  purposes.
+
 ## The generation pipeline
 
 ## Implementing a component

--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -25,8 +25,8 @@ src/components/Button/
 └── *.browser.test.tsx       # behavior tests (when behavior is non-trivial)
 ```
 
-The barrel exports the view first (only on `@flr-generate` components), then
-the component:
+The barrel exports the view first (only on `@flr-generate` components), then the
+component:
 
 ```ts
 export * from "./view";
@@ -51,7 +51,8 @@ import {
 } from "@/lib/componentFactory/flowComponent";
 
 export interface ButtonProps
-  extends PropsWithChildren<Omit<Aria.ButtonProps, "children">>,
+  extends
+    PropsWithChildren<Omit<Aria.ButtonProps, "children">>,
     FlowComponentProps<HTMLButtonElement> {
   /** The color of the button. @default "primary" */
   color?: "primary" | "accent" | "secondary" | "danger";
@@ -71,21 +72,21 @@ Conventions:
 - Props type is exported as `<Name>Props`; it extends the wrapped React Aria
   props plus `FlowComponentProps<RefElement>`.
 - **Ref as prop** (React 19) — no `forwardRef`.
-- `options.type`: `"ui"` (default — gets props-context isolation),
-  `"layout"`, or `"provider"`. The factory applies `ClearPropsContext`
-  isolation for UI components itself — don't add extra clearing casually.
+- `options.type`: `"ui"` (default — gets props-context isolation), `"layout"`,
+  or `"provider"`. The factory applies `ClearPropsContext` isolation for UI
+  components itself — don't add extra clearing casually.
 - The registered name must match the component/directory name, and the props
   type must be registered in `src/components/propTypes/index.ts`
-  (`FlowComponentPropsTypes`) — `flowComponent` names are typed as `keyof`
-  of that hand-maintained registry, so a missing entry fails the typecheck.
+  (`FlowComponentPropsTypes`) — `flowComponent` names are typed as `keyof` of
+  that hand-maintained registry, so a missing entry fails the typecheck.
 - Most components wrap `react-aria-components` primitives; expose ARIA props
   directly only where React Aria lacks the behavior.
 
 ## PropsContext — contextual composability
 
 `PropsContext` makes components adapt **automatically** when composed inside
-other components: they receive default prop values and, mainly, CSS classes
-from their surroundings. This is the backbone of Flow's composability.
+other components: they receive default prop values and, mainly, CSS classes from
+their surroundings. This is the backbone of Flow's composability.
 
 ```tsx
 // IllustratedMessage.tsx — every <Icon> inside renders large:
@@ -102,44 +103,50 @@ return (
 ```
 
 - Contexts **nest** (a context can configure props contexts of nested
-  components) and support **dynamic props**:
-  `dynamic((localProps) => value)` derives values from the consumer's props.
+  components) and support **dynamic props**: `dynamic((localProps) => value)`
+  derives values from the consumer's props.
 - Local props always win over context props.
-- Although exported, `PropsContext` is **primarily an internal API** — prefer
-  it for intra-Flow composition, not as a consumer-facing feature.
+- Although exported, `PropsContext` is **primarily an internal API** — prefer it
+  for intra-Flow composition, not as a consumer-facing feature.
 - **Only put remote-capable components into a `PropsContext`** — non-remote
   components break remote rendering.
 - When parent context must not leak into a component's children, use targeted
   clearing, e.g. `wrapWith: <ClearPropsContext />` (see `Modal.tsx`).
 
+Why this works the way it does across the remote boundary:
+[docs/remote-ui.md](../../docs/remote-ui.md).
+
 ## Views — remote-transparent composition
 
-Components tagged `/** @flr-generate all */` get a generated view
-(`view.ts` + `src/views/<Name>View.tsx`). **Inside `flr-universal` components,
-compose other Flow components through their views** (`@/views/*`) — a view
-automatically switches to the remote counterpart in a remote context:
+Components tagged `/** @flr-generate all */` get a generated view (`view.ts` +
+`src/views/<Name>View.tsx`). **Inside `flr-universal` components, compose other
+Flow components through their views** (`@/views/*`) — a view automatically
+switches to the remote counterpart in a remote context:
 
 ```tsx
-import ButtonView from "@/views/ButtonView";   // ✓ works local and remote
-import { Button } from "@/components/Button";  // ✗ host-only in remote context
+import ButtonView from "@/views/ButtonView"; // ✓ works local and remote
+import { Button } from "@/components/Button"; // ✗ host-only in remote context
 ```
+
+Why this works the way it does across the remote boundary:
+[docs/remote-ui.md](../../docs/remote-ui.md).
 
 Remote generation details:
 
 - `@flr-generate all` on the component const marks it for generation.
 - `@flr-ignore-props` excludes props that must not cross the remote boundary —
-  either because they cannot be serialized, or because they could do **too
-  much on the host side**. A global ignore list lives in
+  either because they cannot be serialized, or because they could do **too much
+  on the host side**. A global ignore list lives in
   `dev/remote-components-generator/config.ts`: `style` and
-  `dangerouslySetInnerHTML` are always ignored for safety; `ref`,
-  `controller`, `tunnel`, `key`, `children`, `wrapWith` because they don't
-  serialize. Use the per-component tag for additional cases (see
-  `TunnelEntry.tsx`).
+  `dangerouslySetInnerHTML` are always ignored for safety; `ref`, `controller`,
+  `tunnel`, `key`, `children`, `wrapWith` because they don't serialize. Use the
+  per-component tag for additional cases (see `TunnelEntry.tsx`).
 - After changing props of an `@flr-generate` component:
   `pnpm nx build:remote-components components` and **commit** the results
   (view.ts, `src/views/*`, `remote-*/src/auto-generated/**`).
-- Props of these components are consumed by mStudio extension developers —
-  no breaking changes; deprecate instead:
+- Props of these components are consumed by mStudio extension developers — no
+  breaking changes; deprecate instead. Why this matters:
+  [docs/remote-ui.md](../../docs/remote-ui.md).
 
 ```tsx
 const warnDeprecation = useWarnDeprecation();
@@ -150,8 +157,8 @@ if ("action" in props) {
 
 ## Styling
 
-- One `<Name>.module.scss` per component. Scoped class names are generated
-  from the component's **path** (`dev/vite/cssModuleClassNameGenerator.ts`) —
+- One `<Name>.module.scss` per component. Scoped class names are generated from
+  the component's **path** (`dev/vite/cssModuleClassNameGenerator.ts`) —
   deliberately semantic CSS that could be used standalone. Never bypass CSS
   modules for component roots (the global reset targets `flow--` classes).
 - Root class is the lower-camel component name (`.button`); modifier classes
@@ -159,8 +166,8 @@ if ("action" in props) {
 - Class composition with `clsx`, consumer `className` appended last:
   `clsx(styles.button, styles[size], styles[color], className)`.
 - **Use design-token CSS variables** — global (`--font-size-text--m`) or
-  component-namespaced (`--button--corner-radius`). No hard-coded colors,
-  sizes, radii.
+  component-namespaced (`--button--corner-radius`). No hard-coded colors, sizes,
+  radii.
 - Shared mixins via `@use "@/styles/mixins/…"`: `focus` (focus ring),
   `formControl` (border/color/interaction states of form fields), `ellipsis`.
   Group repeated variants in local mixins.
@@ -169,12 +176,12 @@ if ("action" in props) {
 
 ## Testing — the actual bar
 
-| Artifact | When |
-| --- | --- |
-| `stories/Default.stories.tsx` | **Always.** Realistic args, controls, meaningful variants. Story title category matches the docs (`Actions/…`, `Form Controls/…`, `Overlays/…`, `Status/…`). |
+| Artifact                                   | When                                                                                                                                                                                     |
+| ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `stories/Default.stories.tsx`              | **Always.** Realistic args, controls, meaningful variants. Story title category matches the docs (`Actions/…`, `Form Controls/…`, `Overlays/…`, `Status/…`).                             |
 | `*.browser.test.tsx` (vitest browser mode) | Component has real **behavior**: interaction, controlled state, async flows, form integration, controllers. Render with `vitest-browser-react`, interact via `userEvent`, query by role. |
-| `*.test.ts(x)` (unit) | Pure logic in `src/lib/` or component utility functions. |
-| `*.test-types.tsx` | Generic/typed public APIs — `expectTypeOf` plus `@ts-expect-error` negative assertions. |
+| `*.test.ts(x)` (unit)                      | Pure logic in `src/lib/` or component utility functions.                                                                                                                                 |
+| `*.test-types.tsx`                         | Generic/typed public APIs — `expectTypeOf` plus `@ts-expect-error` negative assertions.                                                                                                  |
 
 Run: `pnpm nx test:unit components`,
 `pnpm nx test:browser components --browser.name=webkit`. Browser tests need
@@ -183,10 +190,10 @@ Run: `pnpm nx test:unit components`,
 ## i18n & a11y
 
 - Component-internal UI text lives in colocated `locales/de-DE.locale.json`
-  **and** `locales/en-US.locale.json` — always add both languages. The
-  strings support ICU MessageFormat (variables, `plural`, `select` — see
-  `PasswordCreationField/locales/` for real usage). Import the files with a
-  glob import and consume them via the Flow hook:
+  **and** `locales/en-US.locale.json` — always add both languages. The strings
+  support ICU MessageFormat (variables, `plural`, `select` — see
+  `PasswordCreationField/locales/` for real usage). Import the files with a glob
+  import and consume them via the Flow hook:
 
   ```tsx
   import locales from "./locales/*.locale.json";
@@ -199,19 +206,19 @@ Run: `pnpm nx test:unit components`,
   initially: every `locales/` directory in the package gets the new file.
 - Icon-only buttons get a localized `aria-label`; decorative icons are
   `aria-hidden` (the `Icon` component handles this when no label is given).
-- Form fields wire label/description/error via `useFieldComponent`
-  (generates ids, sets `aria-describedby`).
+- Form fields wire label/description/error via `useFieldComponent` (generates
+  ids, sets `aria-describedby`).
 
 ## Public API surfaces
 
-| Export | Contents |
-| --- | --- |
-| `.` (default) | Everything listed **manually** in `src/components/public.ts` — new public components must be added there. |
-| `./internal` | Advanced internals (`flowComponent`, prop helper types, …). |
-| `./flr-universal` | Curated subset that works local *and* remote. Adding to `public.ts` does **not** add here. |
+| Export                                              | Contents                                                                                                                                                                                    |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `.` (default)                                       | Everything listed **manually** in `src/components/public.ts` — new public components must be added there.                                                                                   |
+| `./internal`                                        | Advanced internals (`flowComponent`, prop helper types, …).                                                                                                                                 |
+| `./flr-universal`                                   | Curated subset that works local _and_ remote. Adding to `public.ts` does **not** add here.                                                                                                  |
 | `./nextjs`, `./react-hook-form`, `./password-tools` | Integrations (`src/integrations/`): wrappers around third-party dependencies that not every consumer should pay for — they get their own export entry instead of entering the core surface. |
-| `./all.css` | Bundled stylesheet. |
-| `./doc-properties` | Generated prop metadata for the docs site. |
+| `./all.css`                                         | Bundled stylesheet.                                                                                                                                                                         |
+| `./doc-properties`                                  | Generated prop metadata for the docs site.                                                                                                                                                  |
 
 Prop JSDoc feeds the generated `doc-properties.json` and the docs site: write
 doc comments on public props, use `@default` for defaults and `@internal` for
@@ -219,14 +226,14 @@ props to hide.
 
 ## Misc
 
-- Feature flags: `src/flags.ts` holds a few behavior toggles; there is no
-  formal policy around them.
+- Feature flags: `src/flags.ts` holds a few behavior toggles; there is no formal
+  policy around them.
 - `SettingsProvider` (`src/components/SettingsProvider/`) is the built-in
   persistence for component settings (e.g. `List` remembering its view
   settings), with pluggable backends (localStorage by default). Internal
   component infrastructure — extension developers don't need it.
-- `stories/lib.tsx` holds story-only fixtures — never import it from
-  component code.
+- `stories/lib.tsx` holds story-only fixtures — never import it from component
+  code.
 - Storybook discovers all `src/**/*.stories.tsx` automatically; there is no
   registry to update.
 
@@ -235,12 +242,12 @@ props to hide.
 Easy-to-miss conventions not spelled out above. Full details and examples in
 [PATTERNS.md](./PATTERNS.md).
 
-- **`PropsContext` is structural, not just styling** — nested entries,
-  `dynamic` children, semantic defaults (icon size, heading level, status), and
-  contextual `wrapWith` define much of a composite's internal API.
+- **`PropsContext` is structural, not just styling** — nested entries, `dynamic`
+  children, semantic defaults (icon size, heading level, status), and contextual
+  `wrapWith` define much of a composite's internal API.
 - **The factory supplies hidden infrastructure** — memoization, nested-context
-  preservation, slot propagation, UI isolation, and tunnel entry/provider
-  wiring are all automatic consequences of `flowComponent`; don't rebuild them.
+  preservation, slot propagation, UI isolation, and tunnel entry/provider wiring
+  are all automatic consequences of `flowComponent`; don't rebuild them.
 - **Raw string children get `Text`-normalized** where typography is
   context-driven (detect raw strings, wrap in `Text`); explicit structured
   children are left intact.
@@ -248,7 +255,7 @@ Easy-to-miss conventions not spelled out above. Full details and examples in
   still use `:global(.flow--…)` when independently rendered Flow descendants
   must affect layout.
 - **Controllers coexist with declarative props** — overlay-like APIs support
-  controlled/uncontrolled props *and* a controller object, not one or the other.
+  controlled/uncontrolled props _and_ a controller object, not one or the other.
 - **Complex behavior is split by vocabulary** — `components/` for render,
   `hooks/` for behavior, `lib/` for pure transforms, `models/` for durable
   state.
@@ -258,8 +265,8 @@ Easy-to-miss conventions not spelled out above. Full details and examples in
 - **The empty `Default` story is intentional** — realistic args and rendering
   live in the typed `meta`, so `export const Default: Story = {}` is the norm.
 - **CSS leans on modern relational/low-specificity selectors** — `:has`,
-  `:where`, logical properties, data attributes, and container boundaries
-  reduce the need for runtime styling props.
-- **Universal exports are deliberately explicit** — remote-safe values and
-  their types are curated in `flr-universal.ts` independently of the main
-  public surface; adding to `public.ts` does not add them there.
+  `:where`, logical properties, data attributes, and container boundaries reduce
+  the need for runtime styling props.
+- **Universal exports are deliberately explicit** — remote-safe values and their
+  types are curated in `flr-universal.ts` independently of the main public
+  surface; adding to `public.ts` does not add them there.

--- a/packages/remote-core/AGENTS.md
+++ b/packages/remote-core/AGENTS.md
@@ -2,15 +2,16 @@
 
 Connection + serialization layer between host (mStudio) and remote apps
 (extensions). See the remote-DOM overview in the
-[root AGENTS.md](../../AGENTS.md).
+[root AGENTS.md](../../AGENTS.md) and the full explainer in
+[docs/remote-ui.md](../../docs/remote-ui.md).
 
 - Built on `@quilted/threads` (patched via `patches/` — leave the patch alone)
-  and a fork of [Shopify remote-dom](https://github.com/Shopify/remote-dom).
-  The fork lives at <https://github.com/mfal/remote-dom>, branch
-  `publish/mittwald` (published as `@mittwald/remote-dom-*`).
-- The connection protocol is **versioned**: the host reacts to different
-  remote versions at connection time. **Changes here must stay backwards
-  compatible** — extensions in the wild connect with older versions.
+  and a fork of [Shopify remote-dom](https://github.com/Shopify/remote-dom). The
+  fork lives at <https://github.com/mfal/remote-dom>, branch `publish/mittwald`
+  (published as `@mittwald/remote-dom-*`).
+- The connection protocol is **versioned**: the host reacts to different remote
+  versions at connection time. **Changes here must stay backwards compatible** —
+  extensions in the wild connect with older versions.
 - `FlowThreadSerialization` controls which values cross the thread boundary
   (deliberately excludes `HTMLElement`/`window`).
 - Unit tests run in happy-dom: `pnpm nx test:unit remote-core`.

--- a/packages/remote-elements/AGENTS.md
+++ b/packages/remote-elements/AGENTS.md
@@ -1,10 +1,11 @@
 # @mittwald/flow-remote-elements — Agent Guide
 
-Custom elements (`flr-*`) representing Flow components on the remote side.
-See the remote-DOM overview in the [root AGENTS.md](../../AGENTS.md).
+Custom elements (`flr-*`) representing Flow components on the remote side. See
+the remote-DOM overview in the [root AGENTS.md](../../AGENTS.md) and the full
+explainer in [docs/remote-ui.md](../../docs/remote-ui.md).
 
 - `src/auto-generated/**` is **generated** from `packages/components`
   (`pnpm nx build:remote-components components`) — never edit by hand.
 - Hand-written parts live in `src/lib/` (e.g. `FlowRemoteElement`, the base
-  class all Flow remote elements extend) plus a few special elements
-  (Form, SlotRootWrapper).
+  class all Flow remote elements extend) plus a few special elements (Form,
+  SlotRootWrapper).

--- a/packages/remote-react-components/AGENTS.md
+++ b/packages/remote-react-components/AGENTS.md
@@ -1,19 +1,20 @@
 # @mittwald/flow-remote-react-components — Agent Guide
 
-React API used *inside* remote apps (mStudio extensions). This package's
-exports are what extension developers program against — **treat its API as a
-contract** (see the remote-DOM rules in the [root AGENTS.md](../../AGENTS.md)).
+React API used _inside_ remote apps (mStudio extensions). This package's exports
+are what extension developers program against — **treat its API as a contract**
+(see the remote-DOM rules in the [root AGENTS.md](../../AGENTS.md) and the full
+explainer in [docs/remote-ui.md](../../docs/remote-ui.md)).
 
 - `src/auto-generated/**` is **generated** from `packages/components` — never
   edit by hand.
 - Hand-written: `RemoteRoot` (connects to the host render root, initializes
   ext-bridge) and the `createFlowRemoteComponent` machinery.
 - Richest test surface outside `components`: unit, browser, e2e and visual
-  tests. **Visual tests must pass in both environments — `Local` and
-  `Remote`** (see `CONTRIBUTE.md` and `src/tests/lib/environments.tsx`).
+  tests. **Visual tests must pass in both environments — `Local` and `Remote`**
+  (see `CONTRIBUTE.md` and `src/tests/lib/environments.tsx`).
 - Update visual snapshots: `pnpm nx test:visual:update remote-react-components`.
   Updating everything takes long — for a single component use
   `pnpm nx test:visual:update remote-react-components MyNewComponent`.
 - Failing visual tests write `*--Local--*.png` / `*--Remote--*.png` diff
-  artifacts — useful for inspection, **never commit them**. Only the
-  baselines (`<Name>-<browser>-<os>.png`) belong in the repo.
+  artifacts — useful for inspection, **never commit them**. Only the baselines
+  (`<Name>-<browser>-<os>.png`) belong in the repo.

--- a/packages/remote-react-renderer/AGENTS.md
+++ b/packages/remote-react-renderer/AGENTS.md
@@ -1,8 +1,9 @@
 # @mittwald/flow-remote-react-renderer — Agent Guide
 
-Host-side renderer: receives the remote DOM and materializes `flr-*` elements
-as real Flow components. See the remote-DOM overview in the
-[root AGENTS.md](../../AGENTS.md).
+Host-side renderer: receives the remote DOM and materializes `flr-*` elements as
+real Flow components. See the remote-DOM overview in the
+[root AGENTS.md](../../AGENTS.md) and the full explainer in
+[docs/remote-ui.md](../../docs/remote-ui.md).
 
 - `src/auto-generated/**` (the component renderer map) is **generated** from
   `packages/components` — never edit by hand.


### PR DESCRIPTION
## What

Adds a single conceptual explainer, [`docs/remote-ui.md`](../blob/claude/remote-ui-documentation-052db1/docs/remote-ui.md), that makes the Flow remote-UI ("flr") system understandable to **contributors** (humans and agents) and spells out what remote-capability means when you implement or change a component. Existing `AGENTS.md` files now link to it instead of duplicating the concepts.

## Why

Remote-UI is one of Flow's three core systems but the least discoverable — knowledge was scattered across terse package `AGENTS.md` files and procedural `CONTRIBUTE.md` steps, with no single explanation of how it works end to end or what it means for building components. That gap makes it easy to break the extension-facing contract, forget the generate/commit step, or compose components in a way that silently breaks remote rendering.

## What the explainer covers

- **Why remote-UI exists** and the **end-to-end architecture** (Mermaid diagram + package-roles table)
- **The mental model** — render-and-mirror / events-back, the "everything rendered remote-side must be remote-capable" principle (with the user-land caveat), worked examples for **List** and **Suspense**, an ASCII boundary sketch
- **The generation pipeline** (`@flr-generate` → views + `auto-generated/**`)
- **Implementing a component** — the three participation modes (self remote-capable / universal / host-only, incl. the silent-break gotcha), how props cross the boundary (`on*` events, one-arg handlers, `ReactNode`→slots, no attributes, runtime serialization coercion), `ref`/`controller`/`tunnel`, controlled-input echo-suppression + allowlist, placement + `propTypes` registration, `PropsContext` asymmetry, and the Definition of Done
- **Versioning & backwards compatibility** — the two version mechanisms, the `HostExports` boundary, the deprecation delivery path
- **Host-side special cases** and where to go deeper

## Notes

- Documentation only — no source files touched.
- Every file path and identifier cited was verified against the code; Prettier passes.
- `AGENTS.md` edits only add links (plus Prettier re-wrapping) — no content removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)