### PR TITLE
chore: drop pnpm clean from post-checkout/post-merge git hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "watch": "nx watch --projects=\"$@\" --includeDependentProjects -- run nx build:deps \"$@\""
   },
   "simple-git-hooks": {
-    "post-checkout": "pnpm install && pnpm clean",
-    "post-merge": "pnpm install && pnpm clean",
+    "post-checkout": "pnpm install",
+    "post-merge": "pnpm install",
     "pre-commit": "pnpm lint"
   },
   "dependencies": {


### PR DESCRIPTION
## Problem

Generated icon components are **committed** source files (133 each in `packages/icons/src/components/`, `packages/icons-pro/src/components/`, `packages/components/src/components/Icon/components/icons/`). The `post-checkout` and `post-merge` git hooks ran `pnpm install && pnpm clean`, and `pnpm clean` (`nx reset` + `nx run-many --targets=clean`) deleted those committed sources on **every branch switch, pull and merge**. They only reappeared after a full `pnpm build` — a recurring "my icons are gone" surprise.

## Change

Drop `pnpm clean` from both hooks, keeping only the dependency sync:

```json
"post-checkout": "pnpm install",
"post-merge":    "pnpm install",
"pre-commit":    "pnpm lint"
```

nx caching is input-hash based, so a blanket reset+clean on every checkout is unnecessary. `pnpm clean` stays available to run manually when a fresh build is actually wanted.

## Notes

- Only the `simple-git-hooks` config in the root `package.json` changes; the installed `.git/hooks/*` are regenerated by simple-git-hooks on the next `pnpm install`.
- The per-package `clean` scripts are left untouched — running `pnpm clean` manually still resets everything as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)