### PR TITLE
fix(Overlay): keep browser extension overlays clickable inside modals

### DIFF
--- a/packages/components/src/components/Modal/Modal.browser.test.tsx
+++ b/packages/components/src/components/Modal/Modal.browser.test.tsx
@@ -395,6 +395,11 @@ test("browser extension UI stays interactive while a modal is open", async () =>
   const customElement = document.createElement("some-extension-overlay");
   const shadowHost = document.createElement("div");
   shadowHost.attachShadow({ mode: "open" });
+
+  for (const node of [customElement, shadowHost]) {
+    node.inert = true;
+    node.setAttribute("aria-hidden", "true");
+  }
   document.body.append(customElement, shadowHost);
 
   try {
@@ -402,6 +407,7 @@ test("browser extension UI stays interactive while a modal is open", async () =>
       for (const node of [customElement, shadowHost]) {
         expect(node.hasAttribute("data-react-aria-top-layer")).toBe(true);
         expect(node.inert).toBe(false);
+        expect(node.hasAttribute("aria-hidden")).toBe(false);
       }
     });
   } finally {

--- a/packages/components/src/components/Modal/Modal.browser.test.tsx
+++ b/packages/components/src/components/Modal/Modal.browser.test.tsx
@@ -382,3 +382,50 @@ test("Form in Modal is not auto-resetted on close when opted-out", async () => {
   await userEvent.click(openModalButton);
   expect(isDirtyText).toBeInTheDocument();
 });
+
+test("browser extension UI stays interactive while a modal is open", async () => {
+  await render(
+    <Modal isOpen>
+      <Content>
+        <Text>Hello World</Text>
+      </Content>
+    </Modal>,
+  );
+
+  const customElement = document.createElement("some-extension-overlay");
+  const shadowHost = document.createElement("div");
+  shadowHost.attachShadow({ mode: "open" });
+  document.body.append(customElement, shadowHost);
+
+  try {
+    await vitest.waitFor(() => {
+      for (const node of [customElement, shadowHost]) {
+        expect(node.hasAttribute("data-react-aria-top-layer")).toBe(true);
+        expect(node.inert).toBe(false);
+      }
+    });
+  } finally {
+    customElement.remove();
+    shadowHost.remove();
+  }
+});
+
+test("unrelated background nodes stay isolated while a modal is open", async () => {
+  await render(
+    <Modal isOpen>
+      <Content>
+        <Text>Hello World</Text>
+      </Content>
+    </Modal>,
+  );
+
+  const background = document.createElement("div");
+  document.body.append(background);
+
+  try {
+    await vitest.waitFor(() => expect(background.inert).toBe(true));
+    expect(background.hasAttribute("data-react-aria-top-layer")).toBe(false);
+  } finally {
+    background.remove();
+  }
+});

--- a/packages/components/src/components/Overlay/components/OverlayContent.tsx
+++ b/packages/components/src/components/Overlay/components/OverlayContent.tsx
@@ -4,6 +4,7 @@ import type { PropsWithClassName } from "@/lib/types/props";
 import { OverlaySuspenseFallback } from "@/components/Overlay/components/OverlaySuspenseFallback";
 import styles from "../Overlay.module.scss";
 import DivView from "@/views/DivView";
+import { useKeepBrowserExtensionsInteractive } from "@/lib/hooks/dom/useKeepBrowserExtensionsInteractive";
 
 export interface OverlayContentProps
   extends
@@ -24,6 +25,8 @@ export const OverlayContent: FC<OverlayContentProps> = (props) => {
     "aria-labelledby": ariaLabelledBy,
     ...restProps
   } = props;
+
+  useKeepBrowserExtensionsInteractive(restProps.isOpen ?? false);
 
   const Fallback = () => {
     return (

--- a/packages/components/src/lib/hooks/dom/useKeepBrowserExtensionsInteractive.ts
+++ b/packages/components/src/lib/hooks/dom/useKeepBrowserExtensionsInteractive.ts
@@ -1,0 +1,91 @@
+import { useEffect } from "react";
+
+/**
+ * Attribute react-aria checks to keep a node out of the `inert` / `aria-hidden`
+ * isolation it applies to everything outside an open modal overlay.
+ *
+ * @see `isAlwaysVisibleNode` in `@react-aria/overlays` (`ariaHideOutside`)
+ */
+const keepInteractiveAttribute = "data-react-aria-top-layer";
+
+const extensionUrlSchemes = [
+  "chrome-extension:",
+  "moz-extension:",
+  "safari-web-extension:",
+  "safari-extension:",
+];
+
+const isBrowserExtensionNode = (element: Element): boolean => {
+  if (element.tagName.includes("-")) {
+    return true;
+  }
+  if (element.shadowRoot !== null) {
+    return true;
+  }
+  if (element instanceof HTMLIFrameElement) {
+    const source = element.getAttribute("src") ?? "";
+    return extensionUrlSchemes.some((scheme) => source.startsWith(scheme));
+  }
+  return false;
+};
+
+const keepInteractive = (element: Element): void => {
+  if (!element.hasAttribute(keepInteractiveAttribute)) {
+    element.setAttribute(keepInteractiveAttribute, "");
+  }
+  if (element instanceof HTMLElement && element.inert) {
+    element.inert = false;
+  }
+  if (element.getAttribute("aria-hidden") === "true") {
+    element.removeAttribute("aria-hidden");
+  }
+};
+
+/**
+ * While a modal overlay is open, react-aria isolates the rest of the document
+ * by setting `inert` on every sibling of the modal (see `ariaHideOutside`) —
+ * and it keeps doing so for nodes that appear afterwards via a
+ * `MutationObserver`. That also catches UI a browser extension injects while
+ * the modal is open, e.g. a password manager's autofill dropdown on a field, or
+ * its "save credentials" popover. An `inert` node stays visible but cannot be
+ * clicked, so the user sees the extension UI but cannot interact with it.
+ *
+ * This hook watches the document while `isActive` and re-enables such
+ * extension-injected, document-level nodes, so browser extensions keep working
+ * on top of modals. It targets the structural fingerprint of extension UI (see
+ * {@link isBrowserExtensionNode}) rather than a fixed list of vendors.
+ */
+export const useKeepBrowserExtensionsInteractive = (
+  isActive: boolean,
+): void => {
+  useEffect(() => {
+    if (!isActive || typeof MutationObserver === "undefined") {
+      return;
+    }
+
+    const root = document.body;
+
+    const process = (node: Node): void => {
+      if (node instanceof Element && isBrowserExtensionNode(node)) {
+        keepInteractive(node);
+      }
+    };
+
+    for (const child of Array.from(root.children)) {
+      process(child);
+    }
+
+    const observer = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        for (const node of Array.from(mutation.addedNodes)) {
+          process(node);
+        }
+      }
+    });
+    observer.observe(root, { childList: true });
+
+    return () => observer.disconnect();
+  }, [isActive]);
+};
+
+export default useKeepBrowserExtensionsInteractive;


### PR DESCRIPTION
react-aria isolates the page behind a modal by setting `inert` on everything
outside it (ariaHideOutside with shouldUseInert), and a MutationObserver keeps
inert-ing nodes injected while the modal is open. This caught the UI browser
extensions inject on focus, e.g. a password manager's autofill dropdown or its
"save credentials" popover, leaving it visible but impossible to click.

Add a useKeepBrowserExtensionsInteractive hook, wired into OverlayContent while
the overlay is open, that detects extension-injected document-level nodes by
their structural fingerprint (custom element, shadow host, or extension iframe),
marks them data-react-aria-top-layer and clears inert. Genuine background
content stays isolated.

This works around https://github.com/adobe/react-spectrum/issues/8784#issuecomment-3556910800, which the react-aria maintainers have declined to fix upstream (WONTFIX)