### PR TITLE
feat(docs): add skip link and adopt layered Flow CSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ coverage/*.json
 .DS_Store
 **/.DS_Store
 packages/remote-react-components/.vitest-attachments
+
+# Local Claude Code preview launch config
+.claude/launch.json

--- a/apps/docs/src/app/_components/layout/Footer/Footer.module.scss
+++ b/apps/docs/src/app/_components/layout/Footer/Footer.module.scss
@@ -1,4 +1,4 @@
-.footer.footer {
+.footer {
   margin-top: var(--size-px--l);
 
   .footerContent {
@@ -24,7 +24,7 @@
 }
 
 @media (max-width: 1400px) {
-  .footer.footer {
+  .footer {
     .feedbackImage {
       display: none;
     }

--- a/apps/docs/src/app/_components/layout/Header/Header.module.scss
+++ b/apps/docs/src/app/_components/layout/Header/Header.module.scss
@@ -1,4 +1,4 @@
-.header.header {
+.header {
   backdrop-filter: blur(5px);
   background-color: color-mix(
     in srgb,
@@ -23,6 +23,12 @@
   padding-inline: var(--size-px--xl);
   align-items: center;
   flex-wrap: wrap;
+}
+
+.brand {
+  position: relative;
+  display: flex;
+  align-items: center;
 }
 
 .logo {
@@ -65,7 +71,7 @@
 }
 
 [data-theme="dark"] {
-  .header.header {
+  .header {
     background-color: color-mix(in srgb, #121518 40%, transparent);
   }
 }

--- a/apps/docs/src/app/_components/layout/Header/Header.tsx
+++ b/apps/docs/src/app/_components/layout/Header/Header.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/app/_components/layout/DocsSearch";
 import Groups from "@/app/_components/layout/Groups";
 import { ThemeSwitcherButton } from "@/app/_components/layout/Header/components/ThemeSwitcherButton";
+import { SkipLink } from "@/app/_components/layout/Header/SkipLink";
 
 interface Props {
   docs: SerializedMdxFile[];
@@ -29,9 +30,12 @@ const Header: FC<Props> = (props) => {
     <header className={styles.header}>
       <div className={styles.headerContent}>
         <Flex align="center" gap="l">
-          <Link href="/" aria-label="Flow">
-            <FlowLogo className={styles.logo} />
-          </Link>
+          <div className={styles.brand}>
+            <Link href="/" aria-label="Flow">
+              <FlowLogo className={styles.logo} />
+            </Link>
+            <SkipLink />
+          </div>
           <HeaderNavigation
             className={styles.headerNavigation}
             aria-label="Header Navigation"

--- a/apps/docs/src/app/_components/layout/Header/SkipLink.module.scss
+++ b/apps/docs/src/app/_components/layout/Header/SkipLink.module.scss
@@ -1,0 +1,20 @@
+.skipLink {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  margin-top: var(--size-px--s);
+  z-index: 1;
+  white-space: nowrap;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+}
+
+.skipLink:focus-within {
+  width: auto;
+  height: auto;
+  max-width: none;
+  overflow: visible;
+  clip-path: none;
+}

--- a/apps/docs/src/app/_components/layout/Header/SkipLink.tsx
+++ b/apps/docs/src/app/_components/layout/Header/SkipLink.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { type FC } from "react";
+import { Button } from "@mittwald/flow-react-components";
+
+import styles from "./SkipLink.module.scss";
+
+export const SkipLink: FC = () => {
+  const handlePress = () => {
+    document.getElementById("main-content")?.focus();
+  };
+
+  return (
+    <Button
+      className={styles.skipLink}
+      color="secondary"
+      variant="soft"
+      size="s"
+      onPress={handlePress}
+    >
+      Zum Inhalt springen
+    </Button>
+  );
+};

--- a/apps/docs/src/app/layout.module.scss
+++ b/apps/docs/src/app/layout.module.scss
@@ -55,6 +55,11 @@
   row-gap: var(--size-px--m);
   flex-grow: 1;
   min-width: 0;
+
+  &:focus,
+  &:focus-visible {
+    outline: none;
+  }
 }
 
 .tabsContainer {

--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import "@mittwald/flow-react-components/all.css";
+import "@mittwald/flow-react-components/all-layered.css";
 import "./global.scss";
 import type { Metadata } from "next";
 import { type FC, type PropsWithChildren } from "react";
@@ -35,7 +35,9 @@ const RootLayout: FC<PropsWithChildren> = async (props) => {
                 <div className={styles.mainWrapper}>
                   <MainNavigation docs={docs.map((mdx) => mdx.serialize())} />
 
-                  <main className={styles.main}>{props.children}</main>
+                  <main className={styles.main} id="main-content" tabIndex={-1}>
+                    {props.children}
+                  </main>
                 </div>
                 <Footer />
               </div>


### PR DESCRIPTION
## Was

Fügt der Docs-App (`apps/docs`) einen barrierefreien „Zum Inhalt springen"-Skip-Link hinzu (WCAG 2.4.1 – Bypass Blocks) und stellt dabei auf die gelayerte Flow-CSS-Variante um.

## Änderungen

- **Skip Link** als **zweites fokussierbares Element** (nach dem Flow-Logo), umgesetzt mit der Flow-`Button`-Komponente (`color="secondary"`, `variant="soft"`).
  - Standardmäßig visuell versteckt **ohne Layout-Shift** (`position: absolute` + clip-path), sichtbar bei `:focus-within` **unter dem Logo**.
  - Aktivierung verschiebt den Fokus auf das neue `#main-content`-Ziel; das `<main>` erhält `tabIndex={-1}` und einen nicht sichtbaren Fokus-Outline.
  - Zentral im `Header` (Root-Layout) → auf allen Seiten verfügbar.
- **Gelayertes Flow-CSS**: Import `all.css` → `all-layered.css`. Dadurch gewinnen App-Styles ohne Spezifitäts-Tricks gegen `@layer flow.components`.
- **Doppelklassen entfernt**: `.skipLink`, `.header`, `.footer` (vorher `.x.x`). Nebeneffekt: der zuvor überstimmte `prefers-contrast`/`reduced-transparency`-Fallback im Header greift jetzt wieder.
- `.claude/launch.json` (lokale Preview-Config) zu `.gitignore` hinzugefügt.

## Test

Manuell im Browser verifiziert (Dev-Server):
- Skip Link ist 2. fokussierbares Element, versteckt ohne Layout-Shift, sichtbar bei Fokus unter dem Logo, Text nicht abgeschnitten.
- Fokus-Handoff auf `#main-content` funktioniert (kein sichtbarer Outline am Content).
- Light- & Dark-Mode geprüft; Header/Footer und eine Component-Seite ohne Regression nach der Layer-Umstellung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)