### PR TITLE
feat(components): reusable slim scrollbar mixin

### DIFF
--- a/packages/components/src/components/Chat/Chat.module.scss
+++ b/packages/components/src/components/Chat/Chat.module.scss
@@ -1,9 +1,13 @@
+@use "@/styles/mixins/scrollbar";
+
 .chat {
   display: flex;
   flex-direction: column;
   width: 100%;
 
   .messageThreadContainer {
+    @include scrollbar.scrollbar;
+
     overflow: auto;
     padding-bottom: var(--chat--spacing);
     padding-right: var(--size-px--m);

--- a/packages/components/src/components/CodeBlock/CodeBlock.module.scss
+++ b/packages/components/src/components/CodeBlock/CodeBlock.module.scss
@@ -1,3 +1,5 @@
+@use "@/styles/mixins/scrollbar";
+
 .codeBlock {
   display: block;
   font-size: var(--code-block--font-size);
@@ -13,6 +15,8 @@
     border-radius: var(--code-block--corner-radius);
 
     > pre {
+      @include scrollbar.scrollbar;
+
       overflow-x: auto;
       padding: var(--code-block--padding);
 

--- a/packages/components/src/components/CodeEditor/CodeEditor.module.scss
+++ b/packages/components/src/components/CodeEditor/CodeEditor.module.scss
@@ -1,4 +1,5 @@
 @use "@/styles/mixins/formControl";
+@use "@/styles/mixins/scrollbar";
 
 .codeEditor {
   outline: none;
@@ -34,6 +35,10 @@
 
     & :global(.cm-editor) {
       outline: none;
+
+      & :global(.cm-scroller) {
+        @include scrollbar.scrollbar;
+      }
 
       & :global(.cm-lineNumbers .cm-gutterElement) {
         min-width: var(--code-editor--gutter-element-min-width);

--- a/packages/components/src/components/LayoutCard/LayoutCard.module.scss
+++ b/packages/components/src/components/LayoutCard/LayoutCard.module.scss
@@ -1,4 +1,8 @@
+@use "@/styles/mixins/scrollbar";
+
 .layoutCard {
+  @include scrollbar.scrollbar;
+
   align-self: normal;
   background-color: var(--layout-card--background-color);
   box-shadow: var(--layout-card--box-shadow);

--- a/packages/components/src/components/LayoutCard/stories/Default.stories.tsx
+++ b/packages/components/src/components/LayoutCard/stories/Default.stories.tsx
@@ -46,3 +46,15 @@ export const WithTabs: Story = {
     </LayoutCard>
   ),
 };
+
+export const Scrolling: Story = {
+  render: (props) => (
+    <LayoutCard {...props} style={{ height: 300, overflowY: "auto" }}>
+      <Section>
+        <Text>
+          {dummyText.long} {dummyText.long} {dummyText.long}
+        </Text>
+      </Section>
+    </LayoutCard>
+  ),
+};

--- a/packages/components/src/components/MarkdownEditor/MarkdownEditor.module.scss
+++ b/packages/components/src/components/MarkdownEditor/MarkdownEditor.module.scss
@@ -1,4 +1,5 @@
 @use "@/styles/mixins/formControl";
+@use "@/styles/mixins/scrollbar";
 
 .markdownEditor {
   display: grid;
@@ -49,6 +50,8 @@
 
   textarea,
   .markdown {
+    @include scrollbar.scrollbar;
+
     grid-area: content;
     padding-block: calc(
       var(--form-control--padding-y) - var(--form-control--border-width)

--- a/packages/components/src/components/Modal/Modal.module.scss
+++ b/packages/components/src/components/Modal/Modal.module.scss
@@ -1,3 +1,5 @@
+@use "@/styles/mixins/scrollbar";
+
 @mixin size($size) {
   &.size-#{$size} {
     [role="dialog"] {
@@ -75,6 +77,8 @@
 
   .content,
   .columnLayout {
+    @include scrollbar.scrollbar;
+
     overflow: hidden auto;
     min-height: var(--modal--content-min-height);
     padding: var(--modal--padding);
@@ -189,6 +193,8 @@
   .modal {
     > div {
       > div {
+        @include scrollbar.scrollbar;
+
         margin-top: auto;
         padding: unset;
         width: 100%;
@@ -209,6 +215,8 @@
 
     [role="dialog"],
     [role="dialog"] > form {
+      @include scrollbar.scrollbar;
+
       width: inherit;
       overflow: hidden auto;
       max-height: unset;

--- a/packages/components/src/components/Popover/Popover.module.scss
+++ b/packages/components/src/components/Popover/Popover.module.scss
@@ -1,3 +1,5 @@
+@use "@/styles/mixins/scrollbar";
+
 .popover {
   background-color: var(--popover--background-color);
   box-shadow: var(--popover--box-shadow);
@@ -14,6 +16,8 @@
   max-width: 100dvw;
 
   :where(.content) {
+    @include scrollbar.scrollbar;
+
     overflow-y: auto;
 
     &:focus-visible {

--- a/packages/components/src/components/Table/Table.module.scss
+++ b/packages/components/src/components/Table/Table.module.scss
@@ -1,4 +1,8 @@
+@use "@/styles/mixins/scrollbar";
+
 .tableContainer {
+  @include scrollbar.scrollbar;
+
   width: 100%;
   overflow-x: auto;
 }

--- a/packages/components/src/components/TextArea/TextArea.module.scss
+++ b/packages/components/src/components/TextArea/TextArea.module.scss
@@ -1,6 +1,9 @@
 @use "@/styles/mixins/formControl";
+@use "@/styles/mixins/scrollbar";
 
 .input {
+  @include scrollbar.scrollbar;
+
   resize: none;
   min-width: 100%;
 

--- a/packages/components/src/styles/mixins/scrollbar.scss
+++ b/packages/components/src/styles/mixins/scrollbar.scss
@@ -1,0 +1,20 @@
+@mixin scrollbar {
+  // Standards-based (Firefox, Safari >= 18.2, Chromium >= 121)
+  scrollbar-width: thin;
+  scrollbar-color: var(--scrollbar--thumb-color) var(--scrollbar--track-color);
+
+  // Fine-grained styling for WebKit / Blink
+  &::-webkit-scrollbar {
+    width: var(--scrollbar--size);
+    height: var(--scrollbar--size);
+  }
+
+  &::-webkit-scrollbar-track {
+    background-color: var(--scrollbar--track-color);
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: var(--scrollbar--thumb-color);
+    border-radius: var(--scrollbar--corner-radius);
+  }
+}

--- a/packages/design-tokens/src/scrollbar.yml
+++ b/packages/design-tokens/src/scrollbar.yml
@@ -1,0 +1,9 @@
+scrollbar:
+  thumb-color:
+    value: "{dark.color.200}"
+  track-color:
+    value: "transparent"
+  size:
+    value: "{size-px.s}"
+  corner-radius:
+    value: "{corner-radius.round}"


### PR DESCRIPTION
## What

Adds a slim, reusable custom scrollbar as an SCSS mixin and applies it to the scroll containers of several components. Motivation: the default browser scrollbar is bulky and hurts the visual design, especially in fixed-size, vertically scrollable containers like `LayoutCard`.

## How

- **New design tokens** (`packages/design-tokens/src/scrollbar.yml`), modelled on `focus.yml`: `thumb-color` (`dark.color.200` — the adaptive black/white-alpha token), transparent `track-color`, `size` (8px), `corner-radius` (pill). → CSS variables `--scrollbar--*`.
- **New mixin** `@/styles/mixins/scrollbar` (`@include scrollbar.scrollbar;`). Cross-browser: standards-based via `scrollbar-width`/`scrollbar-color` (Firefox, Safari 18.2+, Chromium 121+) **and** `::-webkit-scrollbar` pseudo-elements (Safari/older WebKit). Deliberately sets **no** `overflow` — it only styles the existing scrollbar (vertical and horizontal).
- The thumb uses the adaptive `dark` alpha token, so it flips automatically per theme: **25% black on light, 25% white on dark** — a translucent overlay that stays visible against whatever it sits on.

## Applied to

| Component | Scroll container |
| --- | --- |
| LayoutCard | `.layoutCard` |
| Table | `.tableContainer` |
| Popover | `:where(.content)` — covers **Select / ComboBox / ContextMenu** option overlays |
| CodeEditor | CodeMirror `.cm-scroller` |
| CodeBlock | `.withChildren > pre` (horizontal scroll of long code lines) |
| MarkdownEditor | `textarea, .markdown` |
| TextArea | `.input` |
| Chat | `.messageThreadContainer` (= MessageThread) |
| Modal | 3 scroll regions (`overflow: hidden auto`) |

Plus a `Scrolling` demo story in LayoutCard.

## Verified

Locally in Storybook, light and dark: the LayoutCard `Scrolling` story overflows correctly and renders the slim thumb; on TextArea the thumb resolves to `rgba(0,0,0,0.25)` in light and `rgba(255,255,255,0.25)` in dark (adaptive).

## Notes for review

- **`Popover` is broader** than the three named overlays — any popover with scrollable content (tooltips, contextual help) also gets the slim scrollbar. Consistent and intended, but called out.
- **No hover state.** `scrollbar-color` (the standards path used by Chromium/Firefox) has no per-thumb hover state, so a hover effect would only ever work in WebKit. It was intentionally left out to keep behaviour consistent across engines.
- No breaking changes to `@flr-generate` props; no generated artefacts affected (the token `dist` is git-ignored and rebuilt in the pipeline).
- Several visible components affected → the `update-screenshots` label is applied to regenerate the visual-regression baselines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)