### PR TITLE
fix(ComboBox): commit browser autofill values as selection

### DIFF
--- a/packages/components/src/components/ComboBox/ComboBox.browser.test.tsx
+++ b/packages/components/src/components/ComboBox/ComboBox.browser.test.tsx
@@ -1,0 +1,189 @@
+import { ComboBox } from "@/components/ComboBox";
+import { Label } from "@/components/Label";
+import { Option } from "@/components/Option";
+import { render } from "vitest-browser-react";
+import { userEvent } from "vitest/browser";
+import { autofillAnimationName } from "./components/AutofillSelectionHandler";
+
+const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+  window.HTMLInputElement.prototype,
+  "value",
+)!.set!;
+
+/**
+ * Simulates browser autofill: the value is written directly to the DOM
+ * (bypassing React, like real autofill does) and the marker animation defined
+ * on :autofill / :-webkit-autofill is dispatched.
+ */
+const simulateAutofill = (input: HTMLInputElement, value: string) => {
+  nativeInputValueSetter.call(input, value);
+  input.dispatchEvent(
+    new AnimationEvent("animationstart", {
+      animationName: autofillAnimationName,
+      bubbles: true,
+    }),
+  );
+};
+
+const renderComboBox = async (
+  props: Partial<React.ComponentProps<typeof ComboBox>> = {},
+) => {
+  const dom = await render(
+    <ComboBox aria-label="Planet" {...props}>
+      <Label>Planet</Label>
+      <Option value="tatooine">Tatooine</Option>
+      <Option value="naboo">Naboo</Option>
+      <Option value="hoth">Hoth</Option>
+    </ComboBox>,
+  );
+  const input = dom.getByRole("combobox").element() as HTMLInputElement;
+  return { dom, input };
+};
+
+test("ComboBox selects matching option on autofill (exact match)", async () => {
+  const onSelectionChange = vi.fn();
+  const { input } = await renderComboBox({ onSelectionChange });
+
+  simulateAutofill(input, "Tatooine");
+
+  await vi.waitFor(() => {
+    expect(onSelectionChange).toHaveBeenCalledWith("tatooine");
+    expect(input).toHaveDisplayValue("Tatooine");
+  });
+});
+
+test("ComboBox closes the menu again after committing an autofill", async () => {
+  const { input } = await renderComboBox();
+
+  simulateAutofill(input, "Tatooine");
+
+  await vi.waitFor(() => {
+    expect(input).toHaveDisplayValue("Tatooine");
+  });
+  await vi.waitFor(() => {
+    expect(input).toHaveAttribute("aria-expanded", "false");
+  });
+});
+
+test("ComboBox matches autofilled value case-insensitively and trimmed", async () => {
+  const onSelectionChange = vi.fn();
+  const { input } = await renderComboBox({ onSelectionChange });
+
+  simulateAutofill(input, "  tAtOoInE ");
+
+  await vi.waitFor(() => {
+    expect(onSelectionChange).toHaveBeenCalledWith("tatooine");
+  });
+});
+
+test("ComboBox matches autofilled value against option values", async () => {
+  const onSelectionChange = vi.fn();
+  const { input } = await renderComboBox({ onSelectionChange });
+
+  simulateAutofill(input, "naboo");
+
+  await vi.waitFor(() => {
+    expect(onSelectionChange).toHaveBeenCalledWith("naboo");
+  });
+});
+
+test("ComboBox matches unique prefix of an option text", async () => {
+  const onSelectionChange = vi.fn();
+  const { input } = await renderComboBox({ onSelectionChange });
+
+  simulateAutofill(input, "Tat");
+
+  await vi.waitFor(() => {
+    expect(onSelectionChange).toHaveBeenCalledWith("tatooine");
+  });
+});
+
+test("ComboBox keeps unmatched autofill value without selecting", async () => {
+  const onSelectionChange = vi.fn();
+  const { input } = await renderComboBox({ onSelectionChange });
+
+  simulateAutofill(input, "Alderaan");
+
+  await vi.waitFor(() => {
+    expect(input).toHaveDisplayValue("Alderaan");
+    expect(input).toHaveAttribute("aria-expanded", "false");
+  });
+  expect(onSelectionChange).not.toHaveBeenCalled();
+});
+
+test("ComboBox submits autofilled value in a form", async () => {
+  const onSelectionChange = vi.fn();
+  const dom = await render(
+    <form>
+      <ComboBox
+        aria-label="Planet"
+        name="planet"
+        onSelectionChange={onSelectionChange}
+      >
+        <Label>Planet</Label>
+        <Option value="tatooine">Tatooine</Option>
+        <Option value="naboo">Naboo</Option>
+      </ComboBox>
+    </form>,
+  );
+  const input = dom.getByRole("combobox").element() as HTMLInputElement;
+
+  simulateAutofill(input, "Tatooine");
+
+  await vi.waitFor(() => {
+    expect(onSelectionChange).toHaveBeenCalledWith("tatooine");
+    const form = input.closest("form")!;
+    const formData = new FormData(form);
+    expect(formData.get("planet")).toBe("tatooine");
+  });
+});
+
+test("ComboBox ignores autofill when a selection already exists", async () => {
+  const onSelectionChange = vi.fn();
+  const { input } = await renderComboBox({
+    onSelectionChange,
+    defaultSelectedKey: "naboo",
+  });
+
+  simulateAutofill(input, "Tatooine");
+
+  // Give the handler time to (incorrectly) react
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  expect(onSelectionChange).not.toHaveBeenCalled();
+});
+
+test("ComboBox ignores empty autofill values", async () => {
+  const onSelectionChange = vi.fn();
+  const { input } = await renderComboBox({ onSelectionChange });
+
+  simulateAutofill(input, "");
+
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  expect(onSelectionChange).not.toHaveBeenCalled();
+});
+
+test("ComboBox ignores foreign animations", async () => {
+  const onSelectionChange = vi.fn();
+  const { input } = await renderComboBox({ onSelectionChange });
+
+  nativeInputValueSetter.call(input, "Tatooine");
+  input.dispatchEvent(
+    new AnimationEvent("animationstart", {
+      animationName: "some-other-animation",
+      bubbles: true,
+    }),
+  );
+
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  expect(onSelectionChange).not.toHaveBeenCalled();
+});
+
+test("ComboBox still supports regular typing and selection", async () => {
+  const onSelectionChange = vi.fn();
+  const { dom, input } = await renderComboBox({ onSelectionChange });
+
+  await userEvent.type(input, "Naboo");
+  await userEvent.click(dom.getByRole("option", { name: "Naboo" }));
+
+  expect(onSelectionChange).toHaveBeenCalledWith("naboo");
+});

--- a/packages/components/src/components/ComboBox/ComboBox.browser.test.tsx
+++ b/packages/components/src/components/ComboBox/ComboBox.browser.test.tsx
@@ -162,6 +162,17 @@ test("ComboBox ignores empty autofill values", async () => {
   expect(onSelectionChange).not.toHaveBeenCalled();
 });
 
+test("ComboBox ignores whitespace-only autofill values", async () => {
+  const onSelectionChange = vi.fn();
+  const { input } = await renderComboBox({ onSelectionChange });
+
+  simulateAutofill(input, "   ");
+
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  expect(onSelectionChange).not.toHaveBeenCalled();
+  expect(input).toHaveAttribute("aria-expanded", "false");
+});
+
 test("ComboBox ignores foreign animations", async () => {
   const onSelectionChange = vi.fn();
   const { input } = await renderComboBox({ onSelectionChange });

--- a/packages/components/src/components/ComboBox/ComboBox.module.scss
+++ b/packages/components/src/components/ComboBox/ComboBox.module.scss
@@ -8,6 +8,9 @@
  * animation whose animationstart event is handled in AutofillSelectionHandler.
  * Remove together with the handler once the upstream issue is fixed.
  */
+/* stylelint-disable-next-line keyframes-name-pattern --
+   the name is kebab-case; :global() keeps it un-hashed so it can be
+   compared against event.animationName in AutofillSelectionHandler */
 @keyframes :global(flow-combobox-autofill-start) {
   from {
     --flow--combobox--autofill-detected: 1;

--- a/packages/components/src/components/ComboBox/ComboBox.module.scss
+++ b/packages/components/src/components/ComboBox/ComboBox.module.scss
@@ -1,5 +1,19 @@
 @use "@/styles/mixins/formControl";
 
+/*
+ * Autofill workaround (https://github.com/mittwald/flow/issues/2173):
+ * react-aria fully controls the ComboBox input value, so browser autofill
+ * never triggers a selection (https://github.com/adobe/react-spectrum/issues/9057).
+ * The :autofill / :-webkit-autofill pseudo classes start a no-op marker
+ * animation whose animationstart event is handled in AutofillSelectionHandler.
+ * Remove together with the handler once the upstream issue is fixed.
+ */
+@keyframes :global(flow-combobox-autofill-start) {
+  from {
+    --flow--combobox--autofill-detected: 1;
+  }
+}
+
 .comboBox {
   .input {
     order: 2;
@@ -13,6 +27,18 @@
       padding-right: calc(
         var(--button--padding-icon-only) * 2 + var(--icon--size--s)
       );
+    }
+
+    /* Separate rules on purpose: an unsupported selector in a selector
+       list would invalidate the entire rule in older browsers. */
+    input:-webkit-autofill {
+      animation-name: flow-combobox-autofill-start;
+      animation-duration: 1ms;
+    }
+
+    input:autofill {
+      animation-name: flow-combobox-autofill-start;
+      animation-duration: 1ms;
     }
 
     .toggle {

--- a/packages/components/src/components/ComboBox/ComboBox.tsx
+++ b/packages/components/src/components/ComboBox/ComboBox.tsx
@@ -16,6 +16,8 @@ import { useOverlayController } from "@/lib/controller";
 import type { OptionsProps } from "@/components/Options/Options";
 import { useFieldComponent } from "@/lib/hooks/useFieldComponent";
 import { UiComponentTunnelExit } from "@/components/UiComponentTunnel/UiComponentTunnelExit";
+import { useObjectRef } from "@react-aria/utils";
+import { AutofillSelectionHandler } from "./components/AutofillSelectionHandler";
 
 export interface ComboBoxProps
   extends
@@ -49,6 +51,8 @@ export const ComboBox = flowComponent("ComboBox", (props) => {
   } = useFieldComponent(props, "ComboBox");
 
   const stringFormatter = useLocalizedStringFormatter(locales, "ComboBox");
+
+  const inputRef = useObjectRef(ref);
 
   const rootClassName = clsx(fieldProps.className, styles.comboBox, className);
 
@@ -87,8 +91,9 @@ export const ComboBox = flowComponent("ComboBox", (props) => {
     >
       <PropsContextProvider props={propsContext}>
         <FieldErrorCaptureContext>
+          <AutofillSelectionHandler inputRef={inputRef} />
           <div className={styles.input}>
-            <Aria.Input placeholder={placeholder} ref={ref} />
+            <Aria.Input placeholder={placeholder} ref={inputRef} />
             <Button
               className={styles.toggle}
               aria-label={stringFormatter.format("showOptions")}

--- a/packages/components/src/components/ComboBox/components/AutofillSelectionHandler.tsx
+++ b/packages/components/src/components/ComboBox/components/AutofillSelectionHandler.tsx
@@ -1,0 +1,158 @@
+import type { RefObject } from "react";
+import { useContext, useEffect, useRef } from "react";
+import { ComboBoxStateContext } from "react-aria-components";
+import type { CollectionLike } from "../lib/autofillMatching";
+import { collectItemNodes, findMatchingKey } from "../lib/autofillMatching";
+
+/**
+ * Name of the marker animation defined in ComboBox.module.scss. The animation
+ * is attached to the input via the :autofill / :-webkit-autofill pseudo
+ * classes, so its animationstart event tells us that the browser has autofilled
+ * the input.
+ */
+export const autofillAnimationName = "flow-combobox-autofill-start";
+
+interface Props {
+  inputRef: RefObject<HTMLInputElement | null>;
+}
+
+/**
+ * Workaround for browser autofill being ignored by the ComboBox
+ * (https://github.com/mittwald/flow/issues/2173).
+ *
+ * React-aria fully controls the input value of its ComboBox, so values written
+ * by the browser's autofill never lead to a selection and are dropped during
+ * validation and form submission
+ * (https://github.com/adobe/react-spectrum/issues/9057).
+ *
+ * Autofill is detected via two mechanisms:
+ *
+ * 1. An animationstart event of a marker animation attached to the :autofill /
+ *    :-webkit-autofill pseudo classes (Chrome, Edge, Safari)
+ * 2. As a fallback, trusted native input events on an unfocused input, which
+ *    cannot originate from user typing (Firefox)
+ *
+ * Committing the value is a two-step process, because react-aria's
+ * ComboBoxState only exposes the _displayed_ collection, which stays empty
+ * until the menu has been opened for the first time (the state freezes a
+ * "lastCollection" snapshot while closed). Therefore:
+ *
+ * 1. On detection, the raw value is synced into the react-aria state and the menu
+ *    is opened programmatically (trigger "manual", which makes the state expose
+ *    the full, unfiltered collection).
+ * 2. Once the collection is available, the value is matched against the options.
+ *    On a match, setSelectedKey() commits the selection; react-aria then syncs
+ *    the input text and closes the menu on its own. Without a match, the menu
+ *    is closed again and the raw text is kept, so validation can flag the value
+ *    instead of silently dropping it.
+ *
+ * This component can be removed once the upstream issue is resolved.
+ */
+export const AutofillSelectionHandler = ({ inputRef }: Props) => {
+  const state = useContext(ComboBoxStateContext);
+  const pendingAutofillValue = useRef<string | null>(null);
+
+  // Step 1: detect autofill, sync raw value, open the menu
+  useEffect(() => {
+    const input = inputRef.current;
+    if (!input || !state) {
+      return;
+    }
+
+    const handleAutofill = () => {
+      const value = input.value;
+      if (!value || input.disabled || input.readOnly) {
+        return;
+      }
+      if (state.selectedKey !== null && state.selectedKey !== undefined) {
+        // Do not override a selection made by the user
+        return;
+      }
+
+      // Keep the react-aria state in sync with the DOM, so the value is
+      // never silently lost
+      state.setInputValue(value);
+
+      const directMatch = findMatchingKey(
+        state.collection as CollectionLike,
+        value,
+      );
+      if (directMatch !== null) {
+        // Collection already populated (menu was open before)
+        state.setSelectedKey(directMatch);
+        return;
+      }
+
+      // The displayed collection is still empty. Open the menu with
+      // trigger "manual" so react-aria exposes the full collection, then
+      // finish in the effect below.
+      pendingAutofillValue.current = value;
+      state.open(null, "manual");
+    };
+
+    const handleAnimationStart = (event: AnimationEvent) => {
+      if (event.animationName !== autofillAnimationName) {
+        return;
+      }
+      // The autofilled value is not always readable synchronously
+      requestAnimationFrame(handleAutofill);
+    };
+
+    const handleInput = (event: Event) => {
+      if (!event.isTrusted) {
+        return;
+      }
+      if (document.activeElement === input) {
+        // Regular typing is handled by react-aria itself
+        return;
+      }
+      handleAutofill();
+    };
+
+    input.addEventListener("animationstart", handleAnimationStart);
+    input.addEventListener("input", handleInput);
+
+    return () => {
+      input.removeEventListener("animationstart", handleAnimationStart);
+      input.removeEventListener("input", handleInput);
+    };
+  }, [state, inputRef]);
+
+  // Step 2: once the collection is available, match and commit
+  useEffect(() => {
+    if (!state) {
+      return;
+    }
+    const pendingValue = pendingAutofillValue.current;
+    if (pendingValue === null || !state.isOpen) {
+      return;
+    }
+
+    const collection = state.collection as CollectionLike;
+    const items = collectItemNodes(
+      collection,
+      collection.getChildren?.bind(collection),
+    );
+    if (items.length === 0) {
+      // Collection not built yet (or there are no options at all); the
+      // effect re-runs when the collection updates
+      return;
+    }
+
+    pendingAutofillValue.current = null;
+
+    const matchingKey = findMatchingKey(collection, pendingValue);
+    if (matchingKey !== null) {
+      // react-aria closes the menu and syncs the input text on its own
+      state.setSelectedKey(matchingKey);
+    } else {
+      // No matching option: close the menu again and keep the raw text,
+      // so required/validation logic sees the value instead of an empty
+      // input (close() resets the input, therefore re-sync afterwards)
+      state.close();
+      state.setInputValue(pendingValue);
+    }
+  });
+
+  return null;
+};

--- a/packages/components/src/components/ComboBox/components/AutofillSelectionHandler.tsx
+++ b/packages/components/src/components/ComboBox/components/AutofillSelectionHandler.tsx
@@ -61,7 +61,7 @@ export const AutofillSelectionHandler = ({ inputRef }: Props) => {
 
     const handleAutofill = () => {
       const value = input.value;
-      if (!value || input.disabled || input.readOnly) {
+      if (!value.trim() || input.disabled || input.readOnly) {
         return;
       }
       if (state.selectedKey !== null && state.selectedKey !== undefined) {

--- a/packages/components/src/components/ComboBox/lib/autofillMatching.test.ts
+++ b/packages/components/src/components/ComboBox/lib/autofillMatching.test.ts
@@ -1,0 +1,40 @@
+import type { CollectionNodeLike } from "./autofillMatching";
+import { findMatchingKey } from "./autofillMatching";
+
+const item = (key: string, textValue: string): CollectionNodeLike => ({
+  key,
+  type: "item",
+  textValue,
+});
+
+const planets: CollectionNodeLike[] = [
+  item("tatooine", "Tatooine"),
+  item("naboo", "Naboo"),
+  item("coruscant", "Coruscant"),
+  item("corellia", "Corellia"),
+];
+
+test.each([
+  ["exact text match", "Tatooine", "tatooine"],
+  ["case-insensitive and trimmed", "  tAtOoInE ", "tatooine"],
+  ["key match", "naboo", "naboo"],
+  ["unique prefix match", "Nab", "naboo"],
+  ["exact text preferred over prefix", "Coruscant", "coruscant"],
+  ["ambiguous prefix (Coruscant/Corellia)", "Cor", null],
+  ["unknown value", "Alderaan", null],
+  ["empty value", "", null],
+  ["whitespace-only value", "   ", null],
+])("%s: %j resolves to %j", (_label, input, expected) => {
+  expect(findMatchingKey(planets, input)).toBe(expected);
+});
+
+test("finds items nested in sections", () => {
+  const nested: CollectionNodeLike[] = [
+    {
+      key: "section-outer-rim",
+      type: "section",
+      childNodes: [item("tatooine", "Tatooine")],
+    },
+  ];
+  expect(findMatchingKey(nested, "Tatooine")).toBe("tatooine");
+});

--- a/packages/components/src/components/ComboBox/lib/autofillMatching.ts
+++ b/packages/components/src/components/ComboBox/lib/autofillMatching.ts
@@ -36,7 +36,9 @@ export const collectItemNodes = (
 const getChildrenAccessor = (collection: CollectionLike) =>
   collection.getChildren ? collection.getChildren.bind(collection) : undefined;
 
-const normalize = (value: string): string => value.trim().toLocaleLowerCase();
+// toLowerCase (not toLocaleLowerCase) keeps matching independent of the
+// user's locale (e.g. Turkish dotless-i casing rules)
+const normalize = (value: string): string => value.trim().toLowerCase();
 
 /**
  * Tries to resolve a string value (e.g. filled in by browser autofill) to an

--- a/packages/components/src/components/ComboBox/lib/autofillMatching.ts
+++ b/packages/components/src/components/ComboBox/lib/autofillMatching.ts
@@ -1,0 +1,84 @@
+import type { Key } from "react-aria-components";
+
+export interface CollectionNodeLike {
+  key: Key;
+  type: string;
+  textValue?: string;
+  childNodes?: Iterable<CollectionNodeLike>;
+}
+
+/**
+ * React-aria's BaseCollection nodes throw on childNodes access and expose
+ * children via getChildren(key) instead, while plain node objects (and older
+ * collection implementations) carry a childNodes iterable.
+ */
+export interface CollectionLike extends Iterable<CollectionNodeLike> {
+  getChildren?: (key: Key) => Iterable<CollectionNodeLike>;
+}
+
+export const collectItemNodes = (
+  nodes: Iterable<CollectionNodeLike>,
+  getChildren?: (key: Key) => Iterable<CollectionNodeLike>,
+  result: CollectionNodeLike[] = [],
+): CollectionNodeLike[] => {
+  for (const node of nodes) {
+    if (node.type === "item") {
+      result.push(node);
+    }
+    const children = getChildren ? getChildren(node.key) : node.childNodes;
+    if (children) {
+      collectItemNodes(children, getChildren, result);
+    }
+  }
+  return result;
+};
+
+const getChildrenAccessor = (collection: CollectionLike) =>
+  collection.getChildren ? collection.getChildren.bind(collection) : undefined;
+
+const normalize = (value: string): string => value.trim().toLocaleLowerCase();
+
+/**
+ * Tries to resolve a string value (e.g. filled in by browser autofill) to an
+ * option key.
+ *
+ * Matching order:
+ *
+ * 1. Exact (case-insensitive) match on the option text
+ * 2. Exact (case-insensitive) match on the option key
+ * 3. Unique (case-insensitive) prefix match on the option text
+ */
+export const findMatchingKey = (
+  collection: CollectionLike,
+  rawValue: string,
+): Key | null => {
+  const value = normalize(rawValue);
+  if (!value) {
+    return null;
+  }
+
+  const items = collectItemNodes(collection, getChildrenAccessor(collection));
+
+  const exactTextMatch = items.find(
+    (item) => normalize(item.textValue ?? "") === value,
+  );
+  if (exactTextMatch) {
+    return exactTextMatch.key;
+  }
+
+  const exactKeyMatch = items.find(
+    (item) => normalize(String(item.key)) === value,
+  );
+  if (exactKeyMatch) {
+    return exactKeyMatch.key;
+  }
+
+  const prefixMatches = items.filter((item) =>
+    normalize(item.textValue ?? "").startsWith(value),
+  );
+  if (prefixMatches.length === 1 && prefixMatches[0]) {
+    return prefixMatches[0].key;
+  }
+
+  return null;
+};


### PR DESCRIPTION
Fixes #2173

## Problem

Browser autofill (Chrome, Edge, Safari, Firefox) writes a value into the ComboBox input, but react-aria fully controls the input value, so no selection is ever committed. As a result:

- The autofilled value is ignored during validation and form submission
- A **required** ComboBox can be submitted with no value at all

This is a known upstream bug in react-aria (adobe/react-spectrum#9057, linked by @Lisa18289 in #2173). Since there is no timeline for an upstream fix and the impact is rated *Major*, this PR ships a self-contained workaround inside Flow.

## How it works

### Detection (two mechanisms)

1. **Marker animation** (Chrome/Edge/Safari): A no-op `@keyframes` animation is attached to the input via the `:autofill` / `:-webkit-autofill` pseudo classes. Its `animationstart` event reliably signals autofill, even when no input event is fired.
2. **Unfocused input event fallback** (Firefox): A trusted native `input` event on an input that is *not* `document.activeElement` cannot originate from user typing and is treated as autofill.

### Committing (two-step, and why)

`ComboBoxState.collection` only exposes the *displayed* collection. While the menu has never been opened, react-stately freezes an (initially empty) `lastCollection` snapshot, so matching directly against `state.collection` fails in exactly the main autofill scenario (form is autofilled before the user ever touches the dropdown). Verified against `useComboBoxState` in react-stately 3.48.

Therefore `AutofillSelectionHandler` works in two steps:

1. On detection: sync the raw value via `setInputValue()` (nothing is ever silently lost), then call `state.open(null, "manual")`. The `"manual"` trigger sets `showAllItems` internally, so the state exposes the full, unfiltered collection.
2. Once the collection is available (second effect): match the value against the options.
   - **Match** →%