### PR TITLE
feat(PhoneNumberField): add phone number field based on libphonenumber-js

### DIFF
--- a/apps/docs/src/content/04-components/form-controls/phone-number-field/develop.mdx
+++ b/apps/docs/src/content/04-components/form-controls/phone-number-field/develop.mdx
@@ -1,0 +1,3 @@
+# Properties
+
+<PropertiesTables />

--- a/apps/docs/src/content/04-components/form-controls/phone-number-field/examples/default.tsx
+++ b/apps/docs/src/content/04-components/form-controls/phone-number-field/examples/default.tsx
@@ -1,0 +1,12 @@
+import {
+  FieldError,
+  Label,
+} from "@mittwald/flow-react-components";
+import { PhoneNumberField } from "@mittwald/flow-react-components/phone-tools";
+
+export default () => (
+  <PhoneNumberField>
+    <Label>Telefonnummer</Label>
+    <FieldError />
+  </PhoneNumberField>
+);

--- a/apps/docs/src/content/04-components/form-controls/phone-number-field/examples/defaultCountry.tsx
+++ b/apps/docs/src/content/04-components/form-controls/phone-number-field/examples/defaultCountry.tsx
@@ -1,0 +1,17 @@
+import {
+  FieldDescription,
+  FieldError,
+  Label,
+} from "@mittwald/flow-react-components";
+import { PhoneNumberField } from "@mittwald/flow-react-components/phone-tools";
+
+export default () => (
+  <PhoneNumberField defaultCountry="AT">
+    <Label>Telefonnummer</Label>
+    <FieldDescription>
+      Nummern ohne Vorwahl werden als österreichisch (+43)
+      interpretiert
+    </FieldDescription>
+    <FieldError />
+  </PhoneNumberField>
+);

--- a/apps/docs/src/content/04-components/form-controls/phone-number-field/examples/validation.tsx
+++ b/apps/docs/src/content/04-components/form-controls/phone-number-field/examples/validation.tsx
@@ -1,0 +1,12 @@
+import {
+  FieldError,
+  Label,
+} from "@mittwald/flow-react-components";
+import { PhoneNumberField } from "@mittwald/flow-react-components/phone-tools";
+
+export default () => (
+  <PhoneNumberField defaultValue="12345" isRequired>
+    <Label>Telefonnummer</Label>
+    <FieldError />
+  </PhoneNumberField>
+);

--- a/apps/docs/src/content/04-components/form-controls/phone-number-field/guidelines.mdx
+++ b/apps/docs/src/content/04-components/form-controls/phone-number-field/guidelines.mdx
@@ -1,0 +1,25 @@
+# Grundlagen
+
+Das PhoneNumberField ist eine Component zur Eingabe von Telefonnummern. Es
+akzeptiert Eingaben in beliebigem Format — mit oder ohne Leerzeichen, mit oder
+ohne Ländervorwahl — und normalisiert sie zu einem einheitlichen Wert. User
+müssen sich dadurch nicht an ein vorgegebenes Format halten. Für Eingaben, die
+keine Telefonnummern sind, sollte ein reguläres
+[TextField](/04-components/form-controls/text-field/overview) verwendet werden.
+
+## Best Practices
+
+Achte bei der Verwendung eines PhoneNumberFields darauf, dass ...
+
+- ein `<FieldError />` vorhanden ist, damit ungültige Nummern für den User
+  nachvollziehbar sind.
+- das `defaultCountry` zum Kontext passt, wenn die Zielgruppe überwiegend
+  außerhalb Deutschlands liegt.
+
+## Verwendung
+
+Verwende ein PhoneNumberField, um ...
+
+- Telefonnummern ohne Formatvorgaben zu erfassen.
+- Telefonnummern einheitlich (E.164) zu speichern.
+- Tippfehler durch die eingebaute Validierung frühzeitig sichtbar zu machen.

--- a/apps/docs/src/content/04-components/form-controls/phone-number-field/index.mdx
+++ b/apps/docs/src/content/04-components/form-controls/phone-number-field/index.mdx
@@ -1,0 +1,9 @@
+---
+component: PhoneNumberField
+description:
+  Das PhoneNumberField ermöglicht die Eingabe von Telefonnummern in beliebigem
+  Format. Eingaben werden automatisch normalisiert und validiert — Leerzeichen
+  und Ländervorwahl muss der User nicht in einem bestimmten Format eingeben.
+---
+
+<LiveCodeEditor editorDisabled stretch />

--- a/apps/docs/src/content/04-components/form-controls/phone-number-field/overview.mdx
+++ b/apps/docs/src/content/04-components/form-controls/phone-number-field/overview.mdx
@@ -1,0 +1,32 @@
+# Playground
+
+Verwende `<PhoneNumberField />`, um Telefonnummern einzugeben. Die Component
+basiert auf [libphonenumber-js](https://www.npmjs.com/package/libphonenumber-js)
+und wird über den Export `@mittwald/flow-react-components/phone-tools`
+bereitgestellt.
+
+Eingaben werden unabhängig von Leerzeichen und Formatierung verstanden. Über
+`onChange` liefert die Component gültige Nummern immer im E.164-Format (z. B.
+`+495772293100`); beim Verlassen des Felds wird die Anzeige international
+formatiert.
+
+<LiveCodeEditor stretch />
+
+---
+
+# Ländervorwahl
+
+Nummern ohne Ländervorwahl werden über `defaultCountry` interpretiert (Standard:
+`DE`). Nummern mit `+`-Präfix werden unabhängig davon automatisch erkannt.
+
+<LiveCodeEditor example="defaultCountry" editorCollapsed stretch />
+
+---
+
+# Validierung
+
+Ungültige Telefonnummern invalidieren das Feld automatisch. Mittels
+`<FieldError />` wird die Fehlermeldung angezeigt; eigene Validierungen können
+zusätzlich über `validate` ergänzt werden und erhalten die normalisierte Nummer.
+
+<LiveCodeEditor example="validation" editorCollapsed stretch />

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -30,6 +30,10 @@
       "types": "./dist/types/integrations/@mittwald/password-tools-js/index.d.ts",
       "import": "./dist/js/password-tools.mjs"
     },
+    "./phone-tools": {
+      "types": "./dist/types/integrations/libphonenumber-js/index.d.ts",
+      "import": "./dist/js/phone-tools.mjs"
+    },
     "./all.css": "./dist/css/all.css",
     "./all-layered.css": "./dist/css/all-layered.css",
     "./doc-properties": "./dist/assets/doc-properties.json"
@@ -94,6 +98,7 @@
     "html-react-parser": "^6.1.3",
     "intl-messageformat": "^11.2.8",
     "invariant": "^2.2.4",
+    "libphonenumber-js": "^1.13.8",
     "luxon": "^3.7.2",
     "mobx": "^6.16.1",
     "mobx-react-lite": "^4.1.1",

--- a/packages/components/src/components/PhoneNumberField/PhoneNumberField.browser.test.tsx
+++ b/packages/components/src/components/PhoneNumberField/PhoneNumberField.browser.test.tsx
@@ -1,0 +1,80 @@
+import PhoneNumberField from "@/components/PhoneNumberField";
+import { useState } from "react";
+import { render } from "vitest-browser-react";
+import { userEvent } from "vitest/browser";
+
+test("emits E.164 for a national number entered with spaces", async () => {
+  const onChange = vi.fn();
+  const dom = await render(
+    <PhoneNumberField aria-label="Phone" onChange={onChange} />,
+  );
+  const input = dom.getByRole("textbox");
+  await userEvent.type(input, "05772 293100");
+  expect(onChange).toHaveBeenLastCalledWith("+495772293100");
+});
+
+test("emits E.164 for a national number entered without spaces", async () => {
+  const onChange = vi.fn();
+  const dom = await render(
+    <PhoneNumberField aria-label="Phone" onChange={onChange} />,
+  );
+  const input = dom.getByRole("textbox");
+  await userEvent.type(input, "05772293100");
+  expect(onChange).toHaveBeenLastCalledWith("+495772293100");
+});
+
+test("detects the country from a + prefix regardless of defaultCountry", async () => {
+  const onChange = vi.fn();
+  const dom = await render(
+    <PhoneNumberField aria-label="Phone" onChange={onChange} />,
+  );
+  const input = dom.getByRole("textbox");
+  await userEvent.type(input, "+31 6 12345678");
+  expect(onChange).toHaveBeenLastCalledWith("+31612345678");
+});
+
+test("applies defaultCountry to national numbers", async () => {
+  const onChange = vi.fn();
+  const dom = await render(
+    <PhoneNumberField
+      aria-label="Phone"
+      defaultCountry="AT"
+      onChange={onChange}
+    />,
+  );
+  const input = dom.getByRole("textbox");
+  await userEvent.type(input, "0664 1234567");
+  expect(onChange).toHaveBeenLastCalledWith("+436641234567");
+});
+
+test("formats the display value on blur", async () => {
+  const dom = await render(<PhoneNumberField aria-label="Phone" />);
+  const input = dom.getByRole("textbox");
+  await userEvent.type(input, "05772293100");
+  await userEvent.tab();
+  expect(input).toHaveDisplayValue("+49 5772 293100");
+});
+
+test("keeps unparseable input untouched", async () => {
+  const onChange = vi.fn();
+  const dom = await render(
+    <PhoneNumberField aria-label="Phone" onChange={onChange} />,
+  );
+  const input = dom.getByRole("textbox");
+  await userEvent.type(input, "hello");
+  expect(onChange).toHaveBeenLastCalledWith("hello");
+  await userEvent.tab();
+  expect(input).toHaveDisplayValue("hello");
+});
+
+test("formats a controlled E.164 value for display", async () => {
+  const TestComponent = () => {
+    const [value, setValue] = useState("+495772293100");
+    return (
+      <PhoneNumberField aria-label="Phone" value={value} onChange={setValue} />
+    );
+  };
+  const dom = await render(<TestComponent />);
+  const input = dom.getByRole("textbox");
+  expect(input).toHaveDisplayValue("+49 5772 293100");
+});

--- a/packages/components/src/components/PhoneNumberField/PhoneNumberField.tsx
+++ b/packages/components/src/components/PhoneNumberField/PhoneNumberField.tsx
@@ -1,0 +1,96 @@
+import { flowComponent } from "@/lib/componentFactory/flowComponent";
+import { TextField, type TextFieldProps } from "@/components/TextField";
+import {
+  parsePhoneNumberFromString,
+  type CountryCode,
+} from "libphonenumber-js";
+import { type FocusEvent, useRef, useState } from "react";
+import locales from "./locales/*.locale.json";
+import { useLocalizedStringFormatter } from "@/components/TranslationProvider";
+
+export interface PhoneNumberFieldProps extends Omit<
+  TextFieldProps,
+  "type" | "showCharacterCount"
+> {
+  /**
+   * The country used to interpret phone numbers entered without a country
+   * calling code. Numbers entered with a "+" prefix are detected
+   * automatically.
+   *
+   * @default "DE"
+   */
+  defaultCountry?: CountryCode;
+}
+
+export const PhoneNumberField = flowComponent("PhoneNumberField", (props) => {
+  const {
+    defaultCountry = "DE",
+    value,
+    defaultValue,
+    onChange,
+    onBlur,
+    validate,
+    children,
+    ...rest
+  } = props;
+
+  const translation = useLocalizedStringFormatter(locales, "PhoneNumberField");
+
+  const parse = (input: string) =>
+    parsePhoneNumberFromString(input, defaultCountry);
+
+  const toDisplayValue = (input: string) => {
+    const phoneNumber = parse(input);
+    return phoneNumber?.isValid() ? phoneNumber.formatInternational() : input;
+  };
+
+  const toNormalizedValue = (input: string) => {
+    const phoneNumber = parse(input);
+    return phoneNumber?.isValid() ? phoneNumber.number : input;
+  };
+
+  const [displayValue, setDisplayValue] = useState(() =>
+    toDisplayValue(value ?? defaultValue ?? ""),
+  );
+
+  const emittedValue = useRef(value);
+
+  if (value !== undefined && value !== emittedValue.current) {
+    emittedValue.current = value;
+    setDisplayValue(toDisplayValue(value));
+  }
+
+  const handleChange = (input: string) => {
+    setDisplayValue(input);
+    const normalized = toNormalizedValue(input);
+    emittedValue.current = normalized;
+    onChange?.(normalized);
+  };
+
+  const handleBlur = (event: FocusEvent<HTMLInputElement>) => {
+    setDisplayValue((current) => toDisplayValue(current));
+    onBlur?.(event);
+  };
+
+  const handleValidate = (input: string) => {
+    if (input !== "" && !parse(input)?.isValid()) {
+      return translation.format("invalid");
+    }
+    return validate?.(toNormalizedValue(input));
+  };
+
+  return (
+    <TextField
+      {...rest}
+      type="tel"
+      value={displayValue}
+      onChange={handleChange}
+      onBlur={handleBlur}
+      validate={handleValidate}
+    >
+      {children}
+    </TextField>
+  );
+});
+
+export default PhoneNumberField;

--- a/packages/components/src/components/PhoneNumberField/index.ts
+++ b/packages/components/src/components/PhoneNumberField/index.ts
@@ -1,0 +1,6 @@
+export {
+  type PhoneNumberFieldProps,
+  PhoneNumberField,
+} from "./PhoneNumberField";
+
+export { default } from "./PhoneNumberField";

--- a/packages/components/src/components/PhoneNumberField/locales/de-DE.locale.json
+++ b/packages/components/src/components/PhoneNumberField/locales/de-DE.locale.json
@@ -1,0 +1,3 @@
+{
+  "invalid": "Bitte gib eine gültige Telefonnummer ein."
+}

--- a/packages/components/src/components/PhoneNumberField/locales/en-US.locale.json
+++ b/packages/components/src/components/PhoneNumberField/locales/en-US.locale.json
@@ -1,0 +1,3 @@
+{
+  "invalid": "Please enter a valid phone number."
+}

--- a/packages/components/src/components/PhoneNumberField/stories/Default.stories.tsx
+++ b/packages/components/src/components/PhoneNumberField/stories/Default.stories.tsx
@@ -1,0 +1,78 @@
+import { FieldDescription } from "@/components/FieldDescription";
+import { FieldError } from "@/components/FieldError";
+import { Label } from "@/components/Label";
+import { Text } from "@/components/Text";
+import { action } from "storybook/actions";
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { PhoneNumberField } from "../index";
+
+const meta: Meta<typeof PhoneNumberField> = {
+  title: "Form Controls/PhoneNumberField",
+  component: PhoneNumberField,
+  args: {
+    isDisabled: false,
+    isReadOnly: false,
+    isRequired: false,
+    defaultCountry: "DE",
+  },
+  render: (props) => (
+    <PhoneNumberField onChange={action("onChange")} {...props}>
+      <Label>Phone number</Label>
+      <FieldError />
+    </PhoneNumberField>
+  ),
+};
+
+export default meta;
+
+type Story = StoryObj<typeof PhoneNumberField>;
+
+export const Default: Story = {};
+
+export const WithDefaultValue: Story = {
+  render: (props) => (
+    <PhoneNumberField {...props} defaultValue="+495772293100">
+      <Label>Phone number</Label>
+      <FieldError />
+    </PhoneNumberField>
+  ),
+};
+
+export const WithFieldDescription: Story = {
+  render: (props) => (
+    <PhoneNumberField {...props}>
+      <Label>Phone number</Label>
+      <FieldDescription>
+        National numbers are interpreted as German (+49)
+      </FieldDescription>
+      <FieldError />
+    </PhoneNumberField>
+  ),
+};
+
+export const WithControlledValue: Story = {
+  render: (props) => {
+    const [value, setValue] = useState("");
+
+    return (
+      <>
+        <PhoneNumberField {...props} value={value} onChange={setValue}>
+          <Label>Phone number</Label>
+          <FieldError />
+        </PhoneNumberField>
+        <Text>Value: {value}</Text>
+      </>
+    );
+  },
+};
+
+export const OtherDefaultCountry: Story = {
+  args: { defaultCountry: "AT" },
+  render: (props) => (
+    <PhoneNumberField {...props}>
+      <Label>Phone number (AT)</Label>
+      <FieldError />
+    </PhoneNumberField>
+  ),
+};

--- a/packages/components/src/components/propTypes/index.ts
+++ b/packages/components/src/components/propTypes/index.ts
@@ -50,6 +50,7 @@ import type { PopoverProps, PopoverTriggerProps } from "@/components/Popover";
 import type { ContextMenuSectionProps } from "@/components/ContextMenu/components/ContextMenuSection";
 import type { ListItemViewContentProps, ListProps } from "@/components/List";
 import type { PasswordCreationFieldProps } from "@/components/PasswordCreationField";
+import type { PhoneNumberFieldProps } from "@/components/PhoneNumberField";
 import type { SearchFieldProps } from "@/components/SearchField";
 import type { BadgeProps } from "@/components/Badge";
 import type { DatePickerProps } from "@/components/DatePicker";
@@ -161,6 +162,7 @@ export interface FlowComponentPropsTypes {
   Popover: PopoverProps;
   PopoverTrigger: PopoverTriggerProps;
   PasswordCreationField: PasswordCreationFieldProps;
+  PhoneNumberField: PhoneNumberFieldProps;
   ProgressBar: ProgressBarProps;
   Radio: RadioProps;
   RadioButton: RadioButtonProps;
@@ -255,6 +257,7 @@ const propsContextSupportingComponentsMap: Record<
   Popover: true,
   PopoverTrigger: true,
   PasswordCreationField: true,
+  PhoneNumberField: true,
   ProgressBar: true,
   RadioButton: true,
   RadioGroup: true,

--- a/packages/components/src/integrations/libphonenumber-js/index.ts
+++ b/packages/components/src/integrations/libphonenumber-js/index.ts
@@ -1,0 +1,3 @@
+export type { CountryCode } from "libphonenumber-js";
+
+export * from "@/components/PhoneNumberField";

--- a/packages/components/vite.build.config.ts
+++ b/packages/components/vite.build.config.ts
@@ -26,6 +26,7 @@ export default mergeConfig(
           "react-hook-form": "./src/integrations/react-hook-form/index.ts",
           "password-tools":
             "./src/integrations/@mittwald/password-tools-js/index.ts",
+          "phone-tools": "./src/integrations/libphonenumber-js/index.ts",
           globals: "./src/styles/index.ts",
         },
         formats: ["es"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -499,6 +499,9 @@ importers:
       invariant:
         specifier: ^2.2.4
         version: 2.2.4
+      libphonenumber-js:
+        specifier: ^1.13.8
+        version: 1.13.8
       luxon:
         specifier: ^3.7.2
         version: 3.7.2
@@ -7150,6 +7153,9 @@ packages:
     resolution: {integrity: sha512-fAEts7UCM2r1xhI82Dv9PK4gFGZoyD7Z5sfIwBQKoO/f67VNVDC0DeH3uH1Yi+T4kwt5iBuCKkZ5XcpxfvsGHQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
+  libphonenumber-js@1.13.8:
+    resolution: {integrity: sha512-80xal1m93rADejw2pMp2MSzFhHCPLEspjHxnH2UtqI+DgAmElsbmLMiqk9niwH9NWAfjsRtaJI+qBrOEmRx9nQ==}
+
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
     engines: {node: '>= 12.0.0'}
@@ -13768,9 +13774,9 @@ snapshots:
       obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@25.9.3)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(msw@2.7.3(@types/node@25.9.3)(typescript@6.0.3))(vite@7.3.5(@types/node@25.9.3)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(stylus@0.62.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@types/node@25.9.3)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(msw@2.7.3(@types/node@25.9.3)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(less@4.6.6)(sass@1.101.0)(stylus@0.62.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
     optionalDependencies:
-      '@vitest/browser': 4.1.9(msw@2.7.3(@types/node@25.9.3)(typescript@6.0.3))(vite@7.3.5(@types/node@25.9.3)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(stylus@0.62.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/browser': 4.1.9(msw@2.7.3(@types/node@25.9.3)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(less@4.6.6)(sass@1.101.0)(stylus@0.62.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -16338,6 +16344,8 @@ snapshots:
       ssri: 13.0.1
     transitivePeerDependencies:
       - supports-color
+
+  libphonenumber-js@1.13.8: {}
 
   lightningcss-android-arm64@1.32.0:
     optional: true


### PR DESCRIPTION
Closes #2678

Adds a `PhoneNumberField` component based on [libphonenumber-js](https://www.npmjs.com/package/libphonenumber-js) (1.13.8), exposed through a new `phone-tools` export entry (mirroring `password-tools`, so the ~80 kB metadata is only paid by consumers who use it).

## Behavior

- Input is accepted in any format — `05772 293100`, `05772293100` and `+49 5772 293 100` are all understood
- `onChange` emits valid numbers as E.164 (`+495772293100`), unparseable input is passed through as-is so custom validation still sees it
- Country is detected from a `+` prefix; national numbers are interpreted via `defaultCountry` (default `DE`)
- Built-in validation with localized error message (de/en); consumer `validate` receives the normalized value
- Display value is formatted to international format on blur

The component wraps the existing `TextField` (with `type=tel`), so labels, descriptions, errors and buttons work as usual.

## Included

- Component + locales + stories + browser tests
- Docs page under Form Controls incl. examples
- `phone-tools` export entry (package.json + vite build config)

## Deliberately not (yet) included

- **As-you-type formatting**: formatting currently happens on blur. Live formatting requires careful caret handling (editing mid-number must not jump the cursor) — worth doing as a follow-up.
- **Remote capability (`@flr-generate`)**: can be added once the API is settled; would also need a remote-dom-demo page.

## Notes for review

- Browser tests could not be run locally (Windows dev env issue with the locale glob import affects all existing browser tests too, e.g. TextField) — relying on CI here. The parsing/formatting expectations in the tests were verified against the real library via Node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)