### PR TITLE
ci(dependabot): keep the Docker Node base on the 24 LTS line

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,15 @@ updates:
     directory: "/apps/docs"
     schedule:
       interval: weekly
+    # Stay on the Node 24 LTS base image; take 24.x patches but not the jump to
+    # a non-LTS major (25/26). Bump the major deliberately once 26 goes LTS.
+    ignore:
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: docker
     directory: "/packages/components"
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Dependabot opened #2689 and #2690 to bump `node:24-alpine` → `node:26-alpine`. Node 24 is the current LTS and the runtime CI builds/tests on; **26 is a non-LTS Current release until Oct 2026**.

This ignores **semver-major** bumps of `node` in the docker ecosystem, so 24.x patches keep flowing but the major jump is deferred to a deliberate change (once 26 goes LTS). Closes #2689, closes #2690.