### PR TITLE
ci(dependabot): auto-update only minor/patch, ignore all major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,9 @@
 version: 2
+# Only minor/patch updates are proposed automatically. Major bumps are ignored
+# across all ecosystems and upgraded deliberately by hand — majors tend to carry
+# breaking changes (build/runtime/API) that warrant a considered upgrade rather
+# than an auto-PR. To take a specific major, bump it manually (or temporarily
+# remove/relax the matching ignore).
 updates:
   - package-ecosystem: npm
     directory: "/"
@@ -8,6 +13,9 @@ updates:
     groups:
       dev-dependencies:
         dependency-type: development
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
@@ -16,19 +24,20 @@ updates:
       actions:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: docker
     directory: "/apps/docs"
     schedule:
       interval: weekly
-    # Stay on the Node 24 LTS base image; take 24.x patches but not the jump to
-    # a non-LTS major (25/26). Bump the major deliberately once 26 goes LTS.
     ignore:
-      - dependency-name: "node"
+      - dependency-name: "*"
         update-types: ["version-update:semver-major"]
   - package-ecosystem: docker
     directory: "/packages/components"
     schedule:
       interval: weekly
     ignore:
-      - dependency-name: "node"
+      - dependency-name: "*"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Dependabot kept proposing major bumps that either break the build (e.g. #2694 fumadocs-mdx 14→15) or that we deliberately don't want yet (node 24→26). 

This adds a `version-update:semver-major` ignore (`dependency-name: "*"`) to **every** ecosystem (npm, github-actions, docker), so Dependabot only opens **minor/patch** PRs automatically. Majors are upgraded by hand when we choose (bump manually, or temporarily relax the ignore).

**Trade-off to note:** this also silences *action* majors — so a future Actions-runtime migration (like the node20→node24 one we just did) won't arrive as an auto-PR; we'll handle it manually (GitHub's deprecation warnings still flag it). Easy to carve GitHub Actions back out if you'd rather keep those current.

Replaces the earlier node-only docker pin with the blanket rule.