### PR TITLE
test(ContextMenu): fix flaky loading-spinner suspend test

### DIFF
--- a/packages/components/src/components/ContextMenu/ContextMenu.browser.test.tsx
+++ b/packages/components/src/components/ContextMenu/ContextMenu.browser.test.tsx
@@ -5,6 +5,7 @@ import MenuItem from "@/components/MenuItem";
 import { usePromise } from "@mittwald/react-use-promise";
 import { sleep } from "@/lib/promises/sleep";
 import { Button, ContextMenuTrigger } from "@/components/public";
+import { duration } from "@/components/Action/models/ActionState";
 
 const expectIconInDom = (iconName: string) => {
   expect(
@@ -47,12 +48,21 @@ test("Loading spinner is shown in trigger if content suspends", async () => {
   const menuItem = page.getByText("Menu Item");
 
   await userEvent.click(trigger);
-  await vitest.advanceTimersByTimeAsync(1500);
+
+  // The trigger only shows the spinner after the suspended menu content
+  // registers via a Suspense-fallback effect (setIsContentSuspended) and the
+  // pending-wait timer (duration.pending) has elapsed. Flush the suspend
+  // registration first – without advancing the clock – so the pending timer is
+  // scheduled at a known point, then advance past it. Advancing in a single
+  // step races the fallback effect and makes the spinner assertion flaky.
+  await vitest.advanceTimersByTimeAsync(0);
+  await rerender(testUi);
+  await vitest.advanceTimersByTimeAsync(duration.pending);
   await rerender(testUi);
   expectIconInDom("loader-2");
   expect(menuItem).not.toBeInTheDocument();
 
-  await vitest.advanceTimersByTimeAsync(1500);
+  await vitest.advanceTimersByTimeAsync(2000);
   await rerender(testUi);
   expect(menuItem).toBeInTheDocument();
 });


### PR DESCRIPTION
## What

Fixes the intermittently failing browser test `Loading spinner is shown in trigger if content suspends` in `ContextMenu.browser.test.tsx`.

Symptom in CI: `× Loading spinner is shown in trigger if content suspends` → `VitestBrowserElementError: Cannot find element with locator: getByRole('img', { includeHidden: true })`. Reproduced locally at roughly a 10% failure rate.

## Why it was flaky

The trigger's spinner appears via a **two-hop async chain**:

1. The suspended menu content commits a Suspense fallback (`OverlayContentSuspendWatcher`), whose `useEffect` calls `setIsContentSuspended(true)`.
2. That triggers `useIsPendingWithWait`, which schedules a `setTimeout(duration.pending = 1000ms)`. Only when that fires does the trigger render `loader-2`.

The test advanced fake timers in a single `advanceTimersByTimeAsync(1500)` immediately after the click. That advance **races the fallback effect**: if the suspend registers mid-advance (fake clock already past ~500ms), the 1000ms pending-wait timer is scheduled too late to fire within the advanced window, so no spinner renders and the assertion fails.

The `Action` pending-state tests are not flaky because there `isPending` is set synchronously on click — no extra effect hop.

## Fix

Flush the suspend registration first **without moving the clock** (`advanceTimersByTimeAsync(0)` + `rerender`), so the pending-wait timer is scheduled at a known point, then advance past `duration.pending`. This mirrors the stable pattern already used by the `Action` tests. Test-only change; no production code touched.

## Verification

- Before: ~10% failure rate (2/15, and 1/30 with instrumentation).
- After: **40/40 runs green** (`vitest run --project=browser --browser.name=webkit ContextMenu.browser`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)