### PR TITLE
docs: capture recurring review conventions (JSX readability, rem/px, component tokens)

### DIFF
--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -5,7 +5,7 @@ Component patterns for the core package. Read the
 Definition of Done, workflow).
 
 > **Full pattern catalog:** [PATTERNS.md](./PATTERNS.md) lists every convention
-> (182 patterns) with per-pattern applicability (when to use / when not), a
+> (184 patterns) with per-pattern applicability (when to use / when not), a
 > canonical example each, and a decision cheat-sheet. This guide covers the
 > must-know core; look there when deciding between two approaches.
 

--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -81,6 +81,10 @@ Conventions:
   that hand-maintained registry, so a missing entry fails the typecheck.
 - Most components wrap `react-aria-components` primitives; expose ARIA props
   directly only where React Aria lacks the behavior.
+- **Keep the returned JSX readable.** Lift computed nodes (icon, label, tooltip
+  text) and non-trivial conditionals into named consts above the `return`; the
+  returned tree should stay scannable — no large inline ternaries or deep logic
+  in the markup. Split a growing tree into subcomponents.
 
 ## PropsContext — contextual composability
 

--- a/packages/components/PATTERNS.md
+++ b/packages/components/PATTERNS.md
@@ -124,6 +124,12 @@ and consistency enforced by tooling, not maintained by hand.
   `src/components/Button/Button.tsx:112`
   - ✓ root styling combines base, variants, state, and consumer classes.
   - ✗ a single invariant class → pass it directly.
+- **Readable JSX via extracted expressions** `[undocumented]` — lift computed
+  nodes (icon, label, tooltip text) and non-trivial conditionals into named
+  consts above the `return`; the returned tree stays scannable — no large inline
+  ternaries, no deep logic in the markup. `src/components/Button/Button.tsx:168`
+  - ✓ markup mixes conditional content or several computed values.
+  - ✗ a single self-evident inline expression → keep it inline.
 - **Helpers outside the component** `[undocumented]` — hookless pure
   helpers/constants live above the component const.
   `src/components/Button/Button.tsx:45`
@@ -442,10 +448,17 @@ and consistency enforced by tooling, not maintained by hand.
   colors/sizes/radii. `src/components/Button/Button.module.scss:8`
   - ✓ colors/spacing/type/radii/shadow/size.
   - ✗ a structural CSS keyword or genuine calculation → CSS directly.
+  - `rem` vs `px`: see [design-tokens/AGENTS.md](../design-tokens/AGENTS.md) —
+    text-proportional spacing/sizing → `size-rem`, fixed values → `size-px`.
 - **No invented base values** — compose existing tokens; add component tokens
   only with a design.
   - ✓ values composed from approved tokens.
   - ✗ a missing design decision → ask UX / add an approved component token.
+- **Own the decision in a component token** `[undocumented]` — reference a
+  component-namespaced token for a value that expresses this component's design
+  decision, even when a similar global token exists.
+  - ✓ a value is this component's design choice → component token.
+  - ✗ a genuinely systemic concept (separator, focus ring) → the shared token.
 - **Shared `focus` mixin** — `@use "@/styles/mixins/focus"`.
   `src/components/Button/Button.module.scss:32`
   - ✓ an interactive element needs the system focus ring.
@@ -948,3 +961,7 @@ Quick answers to the highest-frequency choices when authoring a component:
   otherwise one colocated file.
 - **Structure that's only spacing/alignment** → Flow layout primitives; a raw
   wrapper only for semantics or component-owned integration.
+- **JSX getting dense** → extract computed nodes/conditionals into named consts
+  before `return`; split a growing tree into subcomponents.
+- **Sizing/spacing token unit** → text-proportional → `size-rem`; fixed →
+  `size-px` (see design-tokens/AGENTS.md).

--- a/packages/components/PATTERNS.md
+++ b/packages/components/PATTERNS.md
@@ -124,10 +124,10 @@ and consistency enforced by tooling, not maintained by hand.
   `src/components/Button/Button.tsx:112`
   - ✓ root styling combines base, variants, state, and consumer classes.
   - ✗ a single invariant class → pass it directly.
-- **Readable JSX via extracted expressions** `[undocumented]` — lift computed
-  nodes (icon, label, tooltip text) and non-trivial conditionals into named
-  consts above the `return`; the returned tree stays scannable — no large inline
-  ternaries, no deep logic in the markup. `src/components/Button/Button.tsx:168`
+- **Readable JSX via extracted expressions** — lift computed nodes (icon, label,
+  tooltip text) and non-trivial conditionals into named consts above the
+  `return`; the returned tree stays scannable — no large inline ternaries, no
+  deep logic in the markup. `src/components/Button/Button.tsx:168`
   - ✓ markup mixes conditional content or several computed values.
   - ✗ a single self-evident inline expression → keep it inline.
 - **Helpers outside the component** `[undocumented]` — hookless pure

--- a/packages/design-tokens/AGENTS.md
+++ b/packages/design-tokens/AGENTS.md
@@ -3,11 +3,18 @@
 Design tokens for mittwald Flow. See the [root AGENTS.md](../../AGENTS.md).
 
 - The YAML files are the **source of truth**, defined together with UX —
-  **design authority**. **Base tokens** (top-level files: colors, font,
-  size, border, …) are taboo — never add or change them on your own.
-  Adding **component tokens** for a new component (category files like
-  `src/actions/button.yml`) is fine — model them on existing components
-  and ask when unsure.
+  **design authority**. **Base tokens** (top-level files: colors, font, size,
+  border, …) are taboo — never add or change them on your own. Adding
+  **component tokens** for a new component (category files like
+  `src/actions/button.yml`) is fine — model them on existing components and ask
+  when unsure.
+- **`rem` vs `px` for size tokens.** Use `{size-rem.*}` for anything that should
+  scale with the user's font size — spacing that must stay proportional to text
+  (heading-to-text, icon-to-text, label gaps) and controls sized relative to
+  text (checkbox, radio, slider, rating). Use `{size-px.*}` for values that stay
+  fixed regardless of font size — border widths, focus-ring offsets, a
+  component's general inner padding. In doubt: does it sit next to text and need
+  to keep visual balance as the text grows? → `rem`.
 - `node build-tokens.js` (nx target `build`) compiles them with
   [style-dictionary](https://styledictionary.com/) to `dist/css/*` (CSS
   variables; theme variants keyed by `data-theme`) and `dist/json/*`.


### PR DESCRIPTION
## What

Adds three conventions to the docs that recur most often in my PR reviews but weren't written down yet. Distilled from an analysis of ~340 of my inline review comments across `mittwald/flow`.

- **PATTERNS.md §1 — "Readable JSX via extracted expressions"**: lift computed nodes (icon, label, tooltip text) and non-trivial conditionals into named consts above the `return`; keep the returned tree scannable, no large inline ternaries. (My single most-repeated review theme, ~25×.)
- **design-tokens/AGENTS.md — `rem` vs `px` for size tokens**: text-proportional spacing/sizing → `{size-rem.*}`, fixed values → `{size-px.*}`. Cross-referenced from PATTERNS.md §6. (Real gap — both scales exist but the choice was undocumented; ~20×.)
- **PATTERNS.md §6 — "Own the decision in a component token"**: use a component-namespaced token for a component's own design decision vs. a systemic shared token.

Also: cheat-sheet entries for both, and the pattern count bumped 182 → 184.

## Why

These points were being enforced by hand in review over and over. Writing them down (and, separately, moving the automatable ones to lint) is Flow's guiding principle §8 — "enforce consistency with tooling, not discipline" — applied to the review process itself.

## Scope / notes

- Docs only — no code or generated artifacts touched. Prettier-formatted.
- The **automatable** half of the analysis (missing React `key`s, `useEffect` deps, non-null assertions, logical CSS properties) is intentionally **not** in this PR — it belongs in the lint config, tracked as a separate task. Notably `eslint-plugin-react`/`-react-hooks` aren't installed today, which is why several of those nits only ever got caught by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)