### PR TITLE
fix(remote): rebuild dist when @flr-generate components change

### DIFF
--- a/packages/remote-elements/project.json
+++ b/packages/remote-elements/project.json
@@ -12,11 +12,7 @@
           "target": "build:remote-components"
         }
       ],
-      "inputs": [
-        "default",
-        "{projectRoot}/src/**/*",
-        "!{projectRoot}/src/auto-generated/**/*"
-      ]
+      "inputs": ["default", "{projectRoot}/src/**/*"]
     }
   }
 }

--- a/packages/remote-react-components/project.json
+++ b/packages/remote-react-components/project.json
@@ -5,11 +5,7 @@
   "sourceRoot": "packages/remote-react-components/src",
   "targets": {
     "build": {
-      "inputs": [
-        "default",
-        "{projectRoot}/src/**/*",
-        "!{projectRoot}/src/auto-generated/**/*"
-      ],
+      "inputs": ["default", "{projectRoot}/src/**/*"],
       "dependsOn": [
         "^build",
         {

--- a/packages/remote-react-renderer/project.json
+++ b/packages/remote-react-renderer/project.json
@@ -5,11 +5,7 @@
   "sourceRoot": "packages/remote-react-renderer/src",
   "targets": {
     "build": {
-      "inputs": [
-        "default",
-        "{projectRoot}/src/**/*",
-        "!{projectRoot}/src/auto-generated/**/*"
-      ],
+      "inputs": ["default", "{projectRoot}/src/**/*"],
       "dependsOn": [
         "^build",
         {


### PR DESCRIPTION
## Problem

Adding / removing / changing an `@flr-generate` component was **not reflected** when running `pnpm nx run remote-dom-demo:dev`, surfacing as a runtime/build error like:

> `X is not exported from @mittwald/flow-remote-react-components`

The demo imports the **built `dist/js/*.mjs`** of the remote packages (via the pnpm workspace symlink → `exports`; there is no `transpilePackages`). So a component change only reaches the demo if the remote package's `dist` is rebuilt — and it wasn't.

## Root cause

The `build` targets of `remote-elements`, `remote-react-components` and `remote-react-renderer` declared:

```jsonc
"inputs": ["default", "{projectRoot}/src/**/*", "!{projectRoot}/src/auto-generated/**/*"]
```

A new/changed `@flr-generate` component's **only footprint** in these packages is under `src/auto-generated/` (written by the `components:build:remote-components` generator). With that path excluded from the cache key — and **no `^`-prefixed input**, since `dependsOn` enforces only run-order, not hash invalidation in nx — the consumer `build` hash never changed. nx served a **stale `dist`**, so the demo saw the old exports.

This also matches the two observed workflows:
- **Server running:** `dev` builds deps once at start; a live `next dev` never re-triggers `^build` (expected).
- **After restart:** even a fresh restart hit the stale cache — the real bug.

## Fix

Remove the `!{projectRoot}/src/auto-generated/**/*` exclusion from all three packages' `build.inputs`, so generated changes invalidate the build.

## Evidence / verification

Reproduced end-to-end with a real new `@flr-generate` component:

- **Before:** `components:build:docs-properties` and `components:build:remote-components` re-ran and regenerated all three `src/auto-generated/` trees, but `remote-react-components:build` was a **cache hit** and the export was **absent from `dist`**. Control: touching a non-generated file made the build re-run and the export *did* reach `dist` → pure invalidation defect.
- **After:** a single `nx build` correctly rebuilt all three dists with the new component (`RemoteZzProbeElement.mjs`, `ZzProbe.mjs`, renderer map entry).
- **No churn:** a no-op rebuild stays **15/15 cached**.
- Generated file **content is unchanged**, so the CI `git diff --exit-code` check is unaffected.

### Why not `transpilePackages`?

Making the demo consume source would hide (not fix) the underlying nx bug — every other consumer (other package builds, `test:compile`, other apps) would still get stale dist. This input fix addresses the root cause repo-wide and is minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)