### PR TITLE
ci(publish): survive Rekor 409 and stop the version ratchet

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,30 +67,51 @@ jobs:
       - name: Build 🔨
         run: pnpm build
 
+      # Bump versions, write changelogs, commit and tag — but do NOT push and do
+      # NOT create the GitHub release yet. Pushing the release commit before the
+      # npm publish succeeded is what let a failed publish "ratchet" main ahead of
+      # npm (versions bumped in git, nothing on npm). The push + release are
+      # deferred to after a successful publish below.
       - name: Version 🏷️
         if: ${{ !inputs.only_publish }}
         run: |
           pnpm lerna version \
             --force-publish \
             --conventional-commits --conventional-prerelease="*" \
-            --create-release github \
             --message "chore(release): bump version to %v" \
             --yes \
+            --no-push \
             --tag-version-prefix ""
 
+      # Provenance stays enabled (npm Trusted Publisher OIDC). A Rekor 409
+      # ("equivalent entry already exists") is no longer fatal: @sigstore/sign is
+      # patched (patches/@sigstore__sign@4.1.1.patch) to default fetchOnConflict
+      # to true, so it fetches the existing transparency-log entry and the publish
+      # succeeds. No retry loop — re-signing only re-collided with itself.
       - name: Publish 🚀
+        run: pnpm lerna publish from-package --yes --no-private --concurrency 1
+
+      # Only reached when the publish above succeeded. Now it is safe to advance
+      # main and cut the GitHub release.
+      - name: Push release commit & tag, create GitHub release 🚀
+        if: ${{ !inputs.only_publish }}
         run: |
-          for attempt in 1 2 3; do
-            echo "::group::Publish attempt ${attempt}/3"
-            if pnpm lerna publish from-package --yes --no-private --concurrency 1; then
-              echo "::endgroup::"
-              exit 0
-            fi
-            echo "::endgroup::"
-            if [ "${attempt}" -lt 3 ]; then
-              echo "Publish attempt ${attempt} failed, retrying in 30s…"
-              sleep 30
-            fi
-          done
-          echo "::error::All publish attempts failed" >&2
-          exit 1
+          tag="$(git describe --tags --abbrev=0)"
+          echo "Pushing release commit and tag ${tag} to main"
+          git push origin HEAD:main
+          git push origin "refs/tags/${tag}"
+
+          # Release notes = this version's section of the root changelog
+          # (everything between this version's header and the previous one).
+          awk '/^# \[/ { c++; if (c == 2) exit } c >= 1' CHANGELOG.md > release-notes.md
+
+          # Mark as pre-release when the version carries a semver pre-release id
+          # (e.g. 0.2.0-alpha.N), matching lerna's own --create-release behaviour.
+          prerelease=""
+          case "${tag}" in *-*) prerelease="--prerelease" ;; esac
+
+          gh release create "${tag}" \
+            --title "${tag}" \
+            --notes-file release-notes.md \
+            ${prerelease}
+          rm -f release-notes.md

--- a/package.json
+++ b/package.json
@@ -71,8 +71,9 @@
   },
   "pnpm": {
     "patchedDependencies": {
+      "@quilted/threads@3.3.1": "patches/@quilted__threads@3.3.1.patch",
       "acorn": "patches/acorn.patch",
-      "@quilted/threads@3.3.1": "patches/@quilted__threads@3.3.1.patch"
+      "@sigstore/sign@4.1.1": "patches/@sigstore__sign@4.1.1.patch"
     },
     "onlyBuiltDependencies": [
       "@bundled-es-modules/glob",

--- a/patches/@sigstore__sign@4.1.1.patch
+++ b/patches/@sigstore__sign@4.1.1.patch
@@ -1,0 +1,18 @@
+diff --git a/dist/witness/tlog/client.js b/dist/witness/tlog/client.js
+index 8d13c45124e0b8c6c7456ebfb514e65f5c2a79db..49e45ef1c75cef8cf1375e5fb738640a4ed0f1f1 100644
+--- a/dist/witness/tlog/client.js
++++ b/dist/witness/tlog/client.js
+@@ -24,7 +24,12 @@ class TLogClient {
+     rekor;
+     fetchOnConflict;
+     constructor(options) {
+-        this.fetchOnConflict = options.fetchOnConflict ?? false;
++        // mittwald patch: default fetchOnConflict to true so a Rekor 409
++        // ("equivalent entry already exists") is treated as success by fetching
++        // the existing transparency-log entry instead of throwing
++        // TLOG_CREATE_ENTRY_ERROR. Keeps npm provenance intact while making
++        // publishes resilient to sigstore-js's non-idempotent tlog upload retry.
++        this.fetchOnConflict = options.fetchOnConflict ?? true;
+         this.rekor = new rekor_1.Rekor({
+             baseURL: options.rekorBaseURL,
+             retry: options.retry,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ patchedDependencies:
   '@quilted/threads@3.3.1':
     hash: df15ead5d86def314ee16ab6a48f9e4faa765b52aa161b10d28480768ebd60a4
     path: patches/@quilted__threads@3.3.1.patch
+  '@sigstore/sign@4.1.1':
+    hash: 5bb79cca71f032efca7666bd106a1c8cc8b642c4c65d0ea0d40fbfba68545331
+    path: patches/@sigstore__sign@4.1.1.patch
   acorn:
     hash: 58efcb9f21acd585fce3c5eb984c015e7a1e052b0e1841ed2ac082540f7df40f
     path: patches/acorn.patch
@@ -12791,7 +12794,7 @@ snapshots:
 
   '@sigstore/protobuf-specs@0.5.1': {}
 
-  '@sigstore/sign@4.1.1':
+  '@sigstore/sign@4.1.1(patch_hash=5bb79cca71f032efca7666bd106a1c8cc8b642c4c65d0ea0d40fbfba68545331)':
     dependencies:
       '@gar/promise-retry': 1.0.3
       '@sigstore/bundle': 4.0.0
@@ -18322,7 +18325,7 @@ snapshots:
       '@sigstore/bundle': 4.0.0
       '@sigstore/core': 3.2.1
       '@sigstore/protobuf-specs': 0.5.1
-      '@sigstore/sign': 4.1.1
+      '@sigstore/sign': 4.1.1(patch_hash=5bb79cca71f032efca7666bd106a1c8cc8b642c4c65d0ea0d40fbfba68545331)
       '@sigstore/tuf': 4.0.2
       '@sigstore/verify': 3.1.1
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 patchedDependencies:
   "@quilted/threads@3.3.1": "patches/@quilted__threads@3.3.1.patch"
   "acorn": "patches/acorn.patch"
+  "@sigstore/sign@4.1.1": "patches/@sigstore__sign@4.1.1.patch"
 
 packages:
   - "apps/*"


### PR DESCRIPTION
## Problem

npm publishing has been broken for ~20h. Every run passes **Version 🏷️** but fails **Publish 🚀** at npm provenance signing:

```
TLOG_CREATE_ENTRY_ERROR (409) an equivalent entry already exists in the transparency log
```

Sigstore is healthy ([status.sigstore.dev](https://status.sigstore.dev) all green). The root cause is that sigstore-js' Rekor tlog upload is **not idempotent** ([cosign#3356](https://github.com/sigstore/cosign/issues/3356)): when Rekor is slow, its internal retry (`@gar/promise-retry`, visible in the stack trace) re-submits a request that already landed server-side, and the duplicate comes back as a fatal `409`. The workflow-level 3× retry loop never helped — each attempt re-signs and re-collides with itself.

Result: npm froze at `alpha.946` (`flow-remote-core` even at `945`) while git ratcheted on to `alpha.951`, because **Version** pushes the bump + tag + GitHub release *before* **Publish** runs.

## Fixes

- **Patch `@sigstore/sign`** (`patches/@sigstore__sign@4.1.1.patch`) to default `fetchOnConflict` to `true`. sigstore-js already has this escape hatch — on a 409 it then fetches the existing transparency-log entry and the publish succeeds. **npm provenance stays fully enabled.**
- **Drop the publish retry loop** — it only re-triggered the collision.
- **Defer advancing `main` until publish succeeds:** `lerna version` now runs with `--no-push` (no `--create-release`); a new step pushes the release commit + tag and creates the GitHub release *only after* a successful publish. A failed publish no longer leaves `main` ahead of npm.

## Verification

- Patch applies and links through to the publish path: `sigstore@4.1.1` → patched `@sigstore/sign` with `fetchOnConflict ?? true`; registered in `pnpm-lock.yaml`.
- `publish.yml` is valid YAML with correct step order; changelog-notes extractor and prerelease detection checked against the real `CHANGELOG.md`; Prettier clean.
- Not locally testable: the real publish run (needs CI + npm OIDC + a live Rekor 409). **This PR merging is itself the test.**

## Follow-up (not in this PR)

npm stays at `946`/`945` while tags + GitHub releases `947–951` are orphaned. After merge the next run bumps to `952` and publishes cleanly, but `947–951` remain permanent npm gaps — harmless for `latest`/range consumers. Recommend accepting the gap; not deleting the orphan tags/releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)