### PR TITLE
fix(publish): authenticate via push:main and make the Rekor 409 patch effective

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,9 +7,7 @@ on:
         description: "Publish missing packages only, without a version bump"
         type: boolean
         default: false
-  pull_request_target:
-    types:
-      - closed
+  push:
     branches:
       - main
 
@@ -23,9 +21,19 @@ concurrency:
 
 jobs:
   publish:
-    if:
+    # Publish on manual dispatch, or on any push to main EXCEPT the release
+    # commit this workflow pushes itself (guarded below to avoid an infinite
+    # publish loop).
+    #
+    # The trigger is `push: main`, NOT `pull_request_target: closed`: npm's
+    # Trusted Publisher only accepts the OIDC token when its ref is
+    # refs/heads/main. pull_request_target runs carry refs/pull/<n>/merge, which
+    # npm rejects — the publish then falls back to an anonymous request and npm
+    # returns a misleading 404. A push to main carries refs/heads/main and
+    # authenticates correctly.
+    if: >-
       github.event_name == 'workflow_dispatch' ||
-      github.event.pull_request.merged == true
+      !startsWith(github.event.head_commit.message, 'chore(release):')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:

--- a/patches/@sigstore__sign@4.1.1.patch
+++ b/patches/@sigstore__sign@4.1.1.patch
@@ -1,18 +1,22 @@
 diff --git a/dist/witness/tlog/client.js b/dist/witness/tlog/client.js
-index 8d13c45124e0b8c6c7456ebfb514e65f5c2a79db..49e45ef1c75cef8cf1375e5fb738640a4ed0f1f1 100644
+index 8d13c45124e0b8c6c7456ebfb514e65f5c2a79db..bce4e13e4cafcf9d74ee151f210e37cb64a95543 100644
 --- a/dist/witness/tlog/client.js
 +++ b/dist/witness/tlog/client.js
-@@ -24,7 +24,12 @@ class TLogClient {
-     rekor;
-     fetchOnConflict;
-     constructor(options) {
--        this.fetchOnConflict = options.fetchOnConflict ?? false;
-+        // mittwald patch: default fetchOnConflict to true so a Rekor 409
-+        // ("equivalent entry already exists") is treated as success by fetching
-+        // the existing transparency-log entry instead of throwing
-+        // TLOG_CREATE_ENTRY_ERROR. Keeps npm provenance intact while making
-+        // publishes resilient to sigstore-js's non-idempotent tlog upload retry.
-+        this.fetchOnConflict = options.fetchOnConflict ?? true;
-         this.rekor = new rekor_1.Rekor({
-             baseURL: options.rekorBaseURL,
-             retry: options.retry,
+@@ -37,8 +37,15 @@ class TLogClient {
+             entry = await this.rekor.createEntry(proposedEntry);
+         }
+         catch (err) {
+-            // If the entry already exists, fetch it (if enabled)
+-            if (entryExistsError(err) && this.fetchOnConflict) {
++            // mittwald patch: handle a Rekor 409 ("equivalent entry already
++            // exists") UNCONDITIONALLY. sigstore's config.js hard-codes
++            // fetchOnConflict:false when building the Rekor witness, which made
++            // npm publishes fatal whenever sigstore-js's non-idempotent tlog
++            // upload re-submitted an entry that already landed. Dropping the
++            // `&& this.fetchOnConflict` gate treats the 409 as success by
++            // fetching the existing transparency-log entry — npm provenance
++            // stays fully intact.
++            if (entryExistsError(err)) {
+                 // Grab the UUID of the existing entry from the location header
+                 /* istanbul ignore next */
+                 const uuid = err.location.split('/').pop() || '';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ patchedDependencies:
     hash: df15ead5d86def314ee16ab6a48f9e4faa765b52aa161b10d28480768ebd60a4
     path: patches/@quilted__threads@3.3.1.patch
   '@sigstore/sign@4.1.1':
-    hash: 5bb79cca71f032efca7666bd106a1c8cc8b642c4c65d0ea0d40fbfba68545331
+    hash: 6ae6ce79a0d5087118f5c3569ba3256c50c873f0e5f829338045aa4983088864
     path: patches/@sigstore__sign@4.1.1.patch
   acorn:
     hash: 58efcb9f21acd585fce3c5eb984c015e7a1e052b0e1841ed2ac082540f7df40f
@@ -13104,7 +13104,7 @@ snapshots:
 
   '@sigstore/protobuf-specs@0.5.1': {}
 
-  '@sigstore/sign@4.1.1(patch_hash=5bb79cca71f032efca7666bd106a1c8cc8b642c4c65d0ea0d40fbfba68545331)':
+  '@sigstore/sign@4.1.1(patch_hash=6ae6ce79a0d5087118f5c3569ba3256c50c873f0e5f829338045aa4983088864)':
     dependencies:
       '@gar/promise-retry': 1.0.3
       '@sigstore/bundle': 4.0.0
@@ -19068,7 +19068,7 @@ snapshots:
       '@sigstore/bundle': 4.0.0
       '@sigstore/core': 3.2.1
       '@sigstore/protobuf-specs': 0.5.1
-      '@sigstore/sign': 4.1.1(patch_hash=5bb79cca71f032efca7666bd106a1c8cc8b642c4c65d0ea0d40fbfba68545331)
+      '@sigstore/sign': 4.1.1(patch_hash=6ae6ce79a0d5087118f5c3569ba3256c50c873f0e5f829338045aa4983088864)
       '@sigstore/tuf': 4.0.2
       '@sigstore/verify': 3.1.1
     transitivePeerDependencies:


### PR DESCRIPTION
Follow-up to #2716. That PR got publishing **past** the provenance 409 crash — which then revealed two further problems that were being masked. Both are fixed here.

## 1. npm auth 404 → switch trigger to `push: main`

The workflow authenticates to npm purely via **OIDC Trusted Publishers** (no `NPM_TOKEN`; removed deliberately in `bc5aaa28b`). npm only honours the OIDC token when its ref is `refs/heads/main`. A **`pull_request_target`** run carries `refs/pull/<n>/merge`, which npm's Trusted Publisher rejects — the publish then falls back to an anonymous request and npm returns a **misleading 404** on `PUT`.

**Proven, not guessed:**
- `workflow_dispatch` on `main` → `design-tokens@955` and `ext-bridge@955` **published cleanly** (auth OK).
- the `pull_request_target` merge run → **404** on the first package.

Fix: trigger on **`push: branches: [main]`** instead of `pull_request_target: closed`, with an `if:` guard so the `chore(release):` commit this workflow pushes itself doesn't re-trigger an infinite publish loop.

## 2. The Rekor 409 patch was inert → drop the gate

`sigstore@4.1.1/dist/config.js` **hard-codes `fetchOnConflict: false`** when building the Rekor witness. The previous patch only changed the *default* (`?? true`), and `??` doesn't override an explicit `false` — so the 409 still threw (confirmed: `flow-icons-pro` crashed the dispatch run with `TLOG_CREATE_ENTRY_ERROR` despite the patched module being loaded).

The patch now drops the `&& this.fetchOnConflict` gate in `@sigstore/sign`, so a Rekor 409 (`equivalent entry already exists`) is handled **unconditionally**: the existing transparency-log entry is fetched and the publish succeeds. **npm provenance stays fully enabled.**

## Verification

- Patch active in the installed tree: `sigstore@4.1.1` → patched `@sigstore/sign` with the gate dropped (`if (entryExistsError(err))`); lockfile records the new patch hash.
- `publish.yml` valid YAML; trigger = `workflow_dispatch` + `push:main`; guard logic checked for all three cases (dispatch / normal push / release-commit push).
- Prettier clean.
- **Not locally testable:** the `push:main` auth path and loop guard only exercise on a real merge to main — this PR merging is the test.

## Note on current npm state

The dispatch run partially published `design-tokens@955`/`ext-bridge@955` before crashing on the 409. This self-heals: the next full run bumps all packages to the next version and `from-package` skips whatever's already on npm. Intermediate versions (`947`–`954`) remain permanent npm gaps — harmless for `latest`/range consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)