### PR TITLE
docs(release): tighten /prepare-release command

### DIFF
--- a/.claude/commands/prepare-release.md
+++ b/.claude/commands/prepare-release.md
@@ -30,19 +30,25 @@ requires `--from`/`--to` overrides before doing anything else.
    explain that the model may not be live yet and that the maintainer must pass
    `--from`/`--to` overrides.
 
-2. **Version-independent preconditions.**
+2. **Guard — `<from>` must contain all of `<to>` (forward-merge complete).**
+   Before doing anything else, verify `origin/<to>` has **no** commits missing
+   from `origin/<from>` (`git log origin/<from>..origin/<to>` is empty — i.e.
+   `next` already carries every forward-change from `main`). If `origin/<to>` is
+   ahead, **hard-stop**: releasing `<from>` would silently drop those commits.
+   The maintainer must forward-merge `<to>` into `<from>` (or land the open sync
+   PR) first, then re-run. This guard gates the whole command.
+
+3. **Version-independent preconditions.**
    - **Hard-stop** (abort and explain) if:
      - `origin/<from>` has no commits ahead of `origin/<to>` (nothing to
        release).
    - **Warn + ask to proceed** (show the problem, wait for an explicit yes) if:
      - the working tree is dirty;
-     - the forward-merge is behind (`origin/<to>` has commits not on
-       `origin/<from>`);
      - CI on `origin/<from>` is not green (check via `gh run list` /
        `gh pr checks`). Warn only — this repo has known flaky visual/timer
        tests, so red CI is not a hard-stop.
 
-3. **Determine the target version.**
+4. **Determine the target version.**
    - Read the version from `lerna.json` on `origin/<from>`.
    - Primary: strip the prerelease id (`-next.N` / `-alpha.N`) → `x.y.0`.
    - Fallback: if that is not unambiguous, recompute the bump from the
@@ -50,23 +56,25 @@ requires `--from`/`--to` overrides before doing anything else.
      breaking change → major).
    - `--version` overrides both.
 
-4. **Version-dependent preconditions** (now that `x.y.0` is known).
+5. **Version-dependent preconditions** (now that `x.y.0` is known).
    - **Hard-stop** (abort and explain) if any hold:
      - a `release/*` branch or an open release PR for the same version already
        exists;
      - the computed `x.y.0` already exists as a git tag or as a published npm
        version of `@mittwald/flow-react-components`.
 
-5. **Collect raw material.** List the Conventional Commits in
+6. **Collect raw material.** List the Conventional Commits in
    `origin/<to>..origin/<from>`. Group by type, capture scope and PR number
    (e.g. `(#1234)`), and count the commits.
 
-6. **Draft the curated notes.** Follow `.claude/templates/release-notes.md`
+7. **Draft the curated notes.** Follow `.claude/templates/release-notes.md`
    **exactly**: copy its structure, obey its authoring rules, and delete its
    authoring comments and any empty section from your output. Minor/major only —
-   no Fixes section. Include `## Migrations` only for a major.
+   no Fixes section. Include `## Migrations` **only if there is something to
+   migrate** (breaking changes with concrete migration steps); otherwise omit
+   the whole section.
 
-7. **Assemble the PR body** by filling this frame (replace every `{{…}}`):
+8. **Assemble the PR body** by filling this frame (replace every `{{…}}`):
 
    ```markdown
    ## Release {{VERSION}}
@@ -87,15 +95,6 @@ requires `--from`/`--to` overrides before doing anything else.
 
    <!-- release-notes:end -->
 
-   ### Maintainer checklist
-
-   - [ ] Release notes are curated (user-facing wording, grouped, highlights
-         first)
-   - [ ] Breaking changes surfaced + have a MIGRATION.md entry / codemod where
-         needed
-   - [ ] Target version `{{VERSION}}` is correct
-   - [ ] Forward-merge state clean (no open sync PR main → next)
-
    <details>
    <summary>Raw commits ({{COMMIT_COUNT}}) — reference only, not published</summary>
 
@@ -112,23 +111,23 @@ requires `--from`/`--to` overrides before doing anything else.
    insert blank lines adjacent to the markers, and that whitespace is not
    content.
 
-8. **Preview + confirm.** Show the full assembled PR body plus the plan (branch
+9. **Preview + confirm.** Show the full assembled PR body plus the plan (branch
    `release/x.y.0`, `from → to`, `current → target` version). Ask for explicit
    confirmation **before any push or PR creation**. If declined, stop and change
    nothing on the remote.
 
-9. **Freeze branch + Draft PR** (only after confirmation):
-   - Create `release/x.y.0` from `origin/<from>` and push it to `origin`.
-   - Open a **Draft** PR into `<to>`:
-     ```bash
-     gh pr create --draft --base <to> --head release/x.y.0 \
-       --title "Release x.y.0" --body-file <path-to-body>
-     ```
+10. **Freeze branch + Draft PR** (only after confirmation):
+    - Create `release/x.y.0` from `origin/<from>` and push it to `origin`.
+    - Open a **Draft** PR into `<to>`:
+      ```bash
+      gh pr create --draft --base <to> --head release/x.y.0 \
+        --title "Release x.y.0" --body-file <path-to-body>
+      ```
 
-10. **Summary.** Print the PR URL, the target version, and the maintainer's next
-    steps: curate the notes in the PR, tick the checklist, mark Draft → Ready,
-    and merge — after which CI versions, builds, publishes under `latest`, and
-    creates the GitHub release from the marker block.
+11. **Summary.** Print the PR URL, the target version, and the maintainer's next
+    steps: curate the notes in the PR, mark Draft → Ready, and merge — after
+    which CI versions, builds, publishes under `latest`, and creates the GitHub
+    release from the marker block.
 
 ## You do NOT
 

--- a/.claude/templates/release-notes.md
+++ b/.claude/templates/release-notes.md
@@ -48,6 +48,7 @@
 
 ## Migrations
 
-<!-- MAJOR releases only — delete this whole section for a minor.
-     Per breaking change: what changed, why, and the concrete migration step.
-     Link MIGRATION.md and any codemod under packages/codemods. -->
+<!-- Only when there is something to migrate — delete this whole section if
+     there are no breaking changes with migration steps (typically the case for
+     a minor). Per breaking change: what changed, why, and the concrete
+     migration step. Link MIGRATION.md and any codemod under packages/codemods. -->


### PR DESCRIPTION
Adjusts the new `/prepare-release` command (added in #2723) based on maintainer feedback.

## What changed

- **Guard before the command starts.** A new hard-stop as the first real step (right after fetch): `origin/next` must contain all of `origin/main`'s forward-changes (`git log origin/next..origin/main` empty). If `main` is ahead, the command aborts — releasing `next` would otherwise silently drop those commits. Previously this was only a soft "warn + ask to proceed" buried in the preconditions.
- **No checklist.** The `### Maintainer checklist` block is removed from the generated PR body (and the "tick the checklist" mention in the summary step).
- **Conditional Migrations section.** `## Migrations` is now included only when there is actually something to migrate (breaking changes with concrete migration steps), instead of on every major release. Template comment in `release-notes.md` aligned accordingly.

Steps are renumbered 1–11 to reflect the inserted guard.

## Why

- The forward-merge guard prevents a real footgun: cutting a release from `next` while `main` has un-merged commits would lose them from the release.
- The checklist added noise to every generated PR body.
- Migrations only make sense when there's a breaking change to migrate.

## Reviewer notes

- The forward-merge guard is intentionally a **hard-stop** (no override), since an incomplete forward-merge means real commit loss. Happy to soften it to warn-and-confirm if preferred.
- Prettier-clean; no code paths affected — command/template markdown only.