### PR TITLE
fix: declare a uniform Node engines floor (>=24) and pin react-hook-form peer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ compiles YAML → `dist/css` (CSS variables) and `dist/json`.
 
 ## Repository map
 
-nx + pnpm workspace monorepo. Node `>=20.19`, pnpm pinned via `packageManager`
+nx + pnpm workspace monorepo. Node `>=24`, pnpm pinned via `packageManager`
 (use corepack). Several packages ship their own `AGENTS.md` — **always read the
 nearest `AGENTS.md` before working in a package.**
 

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -13,6 +13,9 @@
   "files": [
     "dist"
   ],
+  "engines": {
+    "node": ">=24.0.0"
+  },
   "scripts": {
     "build": "node build-tokens.js",
     "clean": "rimraf dist"

--- a/packages/icons-pro/package.json
+++ b/packages/icons-pro/package.json
@@ -15,6 +15,9 @@
   "files": [
     "dist"
   ],
+  "engines": {
+    "node": ">=24.0.0"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "build:icons": "tsx src/dev/generate.ts",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -15,6 +15,9 @@
   "files": [
     "dist"
   ],
+  "engines": {
+    "node": ">=24.0.0"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "build:icons": "tsx src/dev/generate.ts",

--- a/packages/react-tunnel/package.json
+++ b/packages/react-tunnel/package.json
@@ -22,6 +22,9 @@
   "files": [
     "dist"
   ],
+  "engines": {
+    "node": ">=24.0.0"
+  },
   "scripts": {
     "build": "vite build --config vite.build.config.ts",
     "clean": "rimraf dist",

--- a/packages/remote-react-components/package.json
+++ b/packages/remote-react-components/package.json
@@ -88,7 +88,7 @@
     "@internationalized/date": "^3.12.2",
     "@mittwald/ext-bridge": "workspace:*",
     "react": "^19.2.0",
-    "react-hook-form": "*"
+    "react-hook-form": "^7.65.0"
   },
   "peerDependenciesMeta": {
     "@internationalized/date": {

--- a/packages/remote-react-renderer/package.json
+++ b/packages/remote-react-renderer/package.json
@@ -62,7 +62,7 @@
     "@mittwald/flow-react-components": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "react-hook-form": "*"
+    "react-hook-form": "^7.65.0"
   },
   "peerDependenciesMeta": {
     "react-hook-form": {

--- a/packages/stylesheet/package.json
+++ b/packages/stylesheet/package.json
@@ -12,6 +12,9 @@
   "files": [
     "dist"
   ],
+  "engines": {
+    "node": ">=24.0.0"
+  },
   "scripts": {
     "build": "node build.js",
     "clean": "rimraf dist"


### PR DESCRIPTION
## What

Tightens package metadata ahead of the 1.0.0 semver contract (RFC #2711). The supported **Node floor stays `>=24`** (the actively supported/tested Node LTS) — this PR only makes that floor *uniform* and fixes two contract gaps.

- **`engines.node: ">=24.0.0"` added** to the five publishable packages that had **no** `engines` field: `design-tokens`, `icons`, `icons-pro`, `react-tunnel`, `stylesheet`. All 12 publishable packages (and the root) now declare the same floor — a uniform, machine-checkable contract.
- **`react-hook-form` peer pinned `"*"` → `"^7.65.0"`** in `remote-react-components` and `remote-react-renderer`, matching the range `flow-react-components` already declares. `"*"` guarantees nothing for a 1.0.0 peer contract.
- **AGENTS.md** stale `Node >=20.19` → `>=24`.

No behavioural change; lockfile untouched (`engines` additions don't affect it, and the `react-hook-form` peer spec isn't recorded in any importer block).

## Policy this supports (to be recorded in RFC #2711)

Decided in a design session; **no ADR** per request — the semver contract in #2711 will capture it:

- **Node floor = the actively supported Node LTS** (currently `>=24`); floor bumped **lazily**, only on concrete need.
- **Routing (EOL-coupled):** dropping a Node version *still in its LTS/maintenance window* → **major**; dropping an *already-EOL* version → may ship in a **minor**.
- **Node-entry packages are stricter:** for `ext-bridge` and `remote-core` (real Node runtime via a `node` export condition), *any* raise of the required Node floor → **major**, regardless of EOL.
- **React peers (separate policy):** *widening* the accepted range (e.g. `^19 || ^20`) → minor; *raising the minimum* / dropping a React major → **major**.
- **Enforcement:** `engines` stays advisory (no `engine-strict`). A **CI guard** that fails a PR raising `engines.node` or narrowing a peer range without a breaking-change marker is a **follow-up** (tracked in #2711), not part of this PR.

Refs #2711

🤖 Generated with [Claude Code](https://claude.com/claude-code)