### PR TITLE
fix(components): track doc-properties output in status-registry nx hash

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,8 +67,8 @@ compiles YAML → `dist/css` (CSS variables) and `dist/json`.
 
 ## Repository map
 
-nx + pnpm workspace monorepo. Node `>=24`, pnpm pinned via `packageManager`
-(use corepack). Several packages ship their own `AGENTS.md` — **always read the
+nx + pnpm workspace monorepo. Node `>=24`, pnpm pinned via `packageManager` (use
+corepack). Several packages ship their own `AGENTS.md` — **always read the
 nearest `AGENTS.md` before working in a package.**
 
 | Path                                    | Package                                  | Role                                                                                       |
@@ -154,7 +154,14 @@ JSDoc? Regenerate (or simply `pnpm build`) and commit the results.
   `inputs`/`outputs` (caching, affected detection) in the package's
   `project.json` or in `nx.json` targetDefaults. When adding a script or a new
   generated artifact, wire these up — otherwise caching serves stale results and
-  `nx affected` misses work.
+  `nx affected` misses work. **A gitignored file cannot be an `inputs` glob** —
+  nx hashes only files in its workspace file map (git-tracked / non-ignored), so
+  a path like `{projectRoot}/dist/…` silently contributes nothing to the hash
+  and the task serves stale cache on upstream changes. To make a task's hash
+  track a **dependency task's output**, use
+  `{ "dependentTasksOutputFiles": "**/*", "transitive": false }` (nx hashes its
+  own task outputs) — `dependsOn` alone only orders execution, it does not fold
+  the dependency's hash into the dependent.
 - **Git hooks** (simple-git-hooks): `post-checkout` and `post-merge` run
   `pnpm install && pnpm clean` — expect installs after switching branches.
   `pre-commit` runs `pnpm lint`.

--- a/packages/components/project.json
+++ b/packages/components/project.json
@@ -68,7 +68,7 @@
         "{projectRoot}/src/components/public.ts",
         "{projectRoot}/src/index/flr-universal.ts",
         "{projectRoot}/src/integrations/**/index.ts",
-        "{projectRoot}/dist/assets/doc-properties.json"
+        { "dependentTasksOutputFiles": "**/*", "transitive": false }
       ],
       "outputs": [
         "{projectRoot}/src/status/component-status.json",


### PR DESCRIPTION
## Problem

Editing a component's component-level JSDoc (e.g. adding `@flowStatus new`) and running `pnpm nx build:status-registry components` **without** `--skip-nx-cache` regenerated a **stale** `src/status/component-status.json`: the ADR 0003 status registry did not reflect the new tags. Invalidation was inconsistent — some component edits picked up, others didn't.

A contributor could therefore commit a stale registry, and CI's "Check all generated code is committed" (`git diff --exit-code`) gate could behave inconsistently.

## Root cause

`build:status-registry` declared `{projectRoot}/dist/assets/doc-properties.json` in its `inputs` to re-run whenever its dependency `build:docs-properties` regenerated that file. But `dist/` is **gitignored**, and **nx only hashes files in its workspace file map (git-tracked / non-ignored)** — so the glob matched **zero files** and contributed nothing to the task hash. Same-project `dependsOn` only orders execution; it does **not** fold the dependency task's hash into the dependent.

So `build:docs-properties` re-ran correctly (its `components-src` input covers `src/**`) and regenerated `doc-properties.json`, but `build:status-registry`'s hash never changed → stale cache hit. The apparent inconsistency was because edits that *also* touched a tracked input like `public.ts` / `flr-universal.ts` (adding a new component) happened to change the hash.

This is the same class of bug as the earlier `!src/auto-generated/**` fix: an input that should drive invalidation is invisible to nx's hasher.

## Fix

Replace the gitignored path with nx's purpose-built mechanism for consuming a dependency task's output:

```diff
-        "{projectRoot}/dist/assets/doc-properties.json"
+        { "dependentTasksOutputFiles": "**/*", "transitive": false }
```

nx **can** hash its own task outputs, so the registry hash now precisely tracks `doc-properties.json`'s content (via the `build:docs-properties` dependency). `transitive: false` scopes it to the direct dependency's output. This is strictly better than re-listing the source files — it re-runs only when the consumed output actually changes.

Also documented the gitignored-input gotcha in the AGENTS.md nx-wiring bullet (JSON can't carry a comment) so the intuitive-but-broken `dist/…` path isn't reintroduced.

## Verification

- **Edit JSDoc** → `build:status-registry` re-runs, registry updates (`isNew: true`) ✓
- **No-op run** → 8/8 cached, no perpetual re-runs ✓
- **Revert** → nx restores the correct original cached output ✓
- **Forced `--skip-nx-cache` regen** → zero diff in generated files (CI `git diff --exit-code` gate stays green) ✓
- 149 status-registry / unit tests pass; both changed files prettier-clean ✓

No generated files changed — only the target's cache-input wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)