### PR TITLE
docs(adr): mark ADR 0003 and 0004 as accepted

### DIFF
--- a/docs/adr/0003-component-lifecycle-status.md
+++ b/docs/adr/0003-component-lifecycle-status.md
@@ -1,7 +1,7 @@
 # ADR 0003 – Component lifecycle status
 
-- **Status:** Proposed
-- **Date:** 2026-07-27
+- **Status:** Accepted
+- **Date:** 2026-07-27 (accepted 2026-07-29)
 - **Deciders:** Flow team (m.falkenberg@mittwald.de)
 - **Affects:** `@mittwald/flow-react-components`, `apps/docs`,
   Storybook, and a future breaking-change guard (see

--- a/docs/adr/0004-forward-merge-main-into-next.md
+++ b/docs/adr/0004-forward-merge-main-into-next.md
@@ -1,7 +1,7 @@
 # ADR 0004 – Forward-merge `main` into `next`
 
-- **Status:** Proposed
-- **Date:** 2026-07-27
+- **Status:** Accepted
+- **Date:** 2026-07-27 (accepted 2026-07-29)
 - **Deciders:** Flow team (m.falkenberg@mittwald.de)
 - **Affects:** `.github/workflows/` (a new `forward-merge.yml` and a symmetric
   `publish-next.yml`), the `next` branch protection, `.gitattributes`, and the


### PR DESCRIPTION
Marks the two release-model ADRs as **Accepted**, per team decision.

- **ADR 0003 – Component lifecycle status** (#2722): `Proposed → Accepted`.
- **ADR 0004 – Forward-merge `main`→`next`** (#2727): `Proposed → Accepted`.

No content changes — status/date lines only. Both are sub-decisions of the
accepted 1.0.0 release model (#2711) and are tracked in #2738.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
