### PR TITLE
fix(CodeEditor): pin CodeMirror/Lezer singletons as direct deps

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -60,10 +60,13 @@
   "dependencies": {
     "@codemirror/language": "^6.12.4",
     "@codemirror/lint": "^6.9.7",
+    "@codemirror/state": "^6.7.1",
+    "@codemirror/view": "^6.43.6",
     "@fortawesome/fontawesome-svg-core": "^7.2.0",
     "@fortawesome/react-fontawesome": "^3.3.1",
     "@internationalized/string": "^3.2.9",
     "@internationalized/string-compiler": "^3.4.1",
+    "@lezer/common": "^1.5.2",
     "@lezer/highlight": "^1.2.3",
     "@mittwald/flow-icons": "workspace:*",
     "@mittwald/password-tools-js": "3.0.0-alpha.31",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -403,6 +403,12 @@ importers:
       '@codemirror/lint':
         specifier: ^6.9.7
         version: 6.9.7
+      '@codemirror/state':
+        specifier: ^6.7.1
+        version: 6.7.1
+      '@codemirror/view':
+        specifier: ^6.43.6
+        version: 6.43.6
       '@fortawesome/fontawesome-svg-core':
         specifier: ^7.2.0
         version: 7.3.1
@@ -415,6 +421,9 @@ importers:
       '@internationalized/string-compiler':
         specifier: ^3.4.1
         version: 3.4.1
+      '@lezer/common':
+        specifier: ^1.5.2
+        version: 1.5.2
       '@lezer/highlight':
         specifier: ^1.2.3
         version: 1.2.3


### PR DESCRIPTION
## What

Declare the CodeMirror/Lezer singleton packages as **direct dependencies** of `@mittwald/flow-react-components`:

```jsonc
"@codemirror/state": "^6.7.1",
"@codemirror/view":  "^6.43.6",
"@lezer/common":     "^1.5.2",
```

## Why

`@codemirror/state`/`@codemirror/view` (and `@lezer/common`, whose `NodeType`/`NodeProp` are compared by identity) require **exactly one instance** in the module graph. Until now they were only **transitive** deps (via `@uiw/react-codemirror` and the language/grammar packages), so they were **not part of Flow's published dependency contract**.

On a Flow update in a consumer (mStudio) these core packages were not pulled in lockstep, the singleton versions drifted apart, and CodeMirror/Lezer failed at runtime (the classic "single instance" footgun).

Declaring them directly puts their range into Flow's contract, so every Flow release carries the correct range and forces the consumer to re-resolve them.

## Notes

- Pinned to the versions that were already resolved transitively — **no duplicate versions introduced**, each still resolves to a single version in the lockfile.
- No code changes required; dependency declaration only.
- The remaining runtime members of the extension system (`@codemirror/autocomplete`, `@codemirror/commands`, `@codemirror/search`) could optionally be pinned too for consistency, but the strict single-instance requirement is on the three packages above.
- Out of scope (tracked in the issue): moving `CodeEditor` out of the core default export surface into a dedicated `./code-editor` integration entry — that is a breaking change for consumers.

Closes #2743

🤖 Generated with [Claude Code](https://claude.com/claude-code)