### PR TITLE
fix(remote-react-components): stabilize flaky cross-version iframe suite

### DIFF
--- a/.github/workflows/test-visual-scheduled.yml
+++ b/.github/workflows/test-visual-scheduled.yml
@@ -122,26 +122,20 @@ jobs:
         # Renders each installed old remote version through the current host over
         # the real iframe connection and compares its host HTML to an ephemeral
         # reference rendered from the current version. WebKit-only. The
-        # @quilted/threads handshake intermittently times out under CI ("Could not
-        # establish remote connection: Timeout reached") — a transient infra flake,
-        # not a diff. Retry the whole step (same idea as the visual job's Firefox
-        # hang retry): a real HTML divergence fails deterministically on every
-        # attempt, while a connection flake clears on a fresh run. Runs the package
-        # script directly (not `nx run`) so a retry doesn't re-trigger the
-        # non-cached network prepare above; the final attempt's `failures` output
-        # feeds the Slack alert.
-        run: |
-          for attempt in 1 2 3; do
-            echo "::group::Cross-version smoke tests (attempt $attempt/3)"
-            if corepack pnpm --filter @mittwald/flow-remote-react-components test:cross-version; then
-              echo "::endgroup::"
-              exit 0
-            fi
-            echo "::endgroup::"
-            echo "::warning::Cross-version smoke tests failed on attempt $attempt/3 (possibly a flaky remote-connection timeout), retrying..."
-          done
-          echo "::error::Cross-version smoke tests still failing after 3 attempts."
-          exit 1
+        # @quilted/threads handshake intermittently wedges a whole version's run
+        # under CI load ("Could not establish remote connection: Timeout reached")
+        # — a transient infra flake, not a diff, and only a fresh server pair
+        # recovers it. The runner now retries EACH version in-process with fresh
+        # servers (`attemptsPerVersion`), so a single flaky version no longer reds
+        # the run. That replaces the old "re-run the entire step 3x" loop, which
+        # never converged (a different version flaked each attempt) and tripled
+        # the runtime. A real HTML divergence still fails on every attempt. Runs
+        # the package script directly (not `nx run`) so it doesn't re-trigger the
+        # non-cached network prepare above; the `failures` output feeds the Slack
+        # alert.
+        run:
+          corepack pnpm --filter @mittwald/flow-remote-react-components
+          test:cross-version
 
       - name: Run in-process cross-version tests
         id: crossversion_inprocess

--- a/packages/remote-react-components/dev/cross-version/crossVersionRunner.ts
+++ b/packages/remote-react-components/dev/cross-version/crossVersionRunner.ts
@@ -82,6 +82,17 @@ export interface RunCrossVersionOptions {
    * this; the iframe harness renders its reference inline, so it omits it.
    */
   reference?: { refDirectory: string };
+  /**
+   * How many times to run a single version's suite before giving up (default 1
+   * = no retry). Each attempt is a FRESH vitest process, so it starts fresh
+   * Vite dev servers — the only thing observed to clear the iframe harness's
+   * per-server-instance @quilted/threads connection wedge ("Could not establish
+   * remote connection: Timeout reached"): every scenario for the wedged version
+   * times out together, and only a brand-new server pair recovers. A real HTML
+   * divergence fails deterministically on every attempt, so retrying costs time
+   * only on a genuine break (rare) — it never masks one.
+   */
+  attemptsPerVersion?: number;
 }
 
 const readManifest = (logPrefix: string): Manifest => {
@@ -166,6 +177,34 @@ const runSuite = (
   const failures = readFailures(jsonPath);
   rmSync(tempDirectory, { recursive: true, force: true });
   return { version: crossVersion, ok, failures };
+};
+
+/**
+ * Run one version's suite, retrying the whole (fresh-process, fresh-server) run
+ * up to `attemptsPerVersion` times. See `attemptsPerVersion` on the options for
+ * why a fresh run is what clears the connection wedge.
+ */
+const runSuiteWithRetries = (
+  crossVersion: string,
+  options: RunCrossVersionOptions,
+): VersionResult => {
+  const attempts = Math.max(1, options.attemptsPerVersion ?? 1);
+  const { logPrefix } = options.labels;
+
+  let result = runSuite(crossVersion, options);
+  for (let attempt = 2; attempt <= attempts && !result.ok; attempt++) {
+    console.log(
+      `${logPrefix} ${crossVersion} failed on attempt ${attempt - 1}/${attempts}; ` +
+        "retrying with a fresh server pair (a real diff fails on every attempt).",
+    );
+    result = runSuite(crossVersion, options);
+    if (result.ok) {
+      console.log(
+        `${logPrefix} ${crossVersion} passed on attempt ${attempt}/${attempts}.`,
+      );
+    }
+  }
+  return result;
 };
 
 const escapeWorkflowCommand = (value: string, property = false): string => {
@@ -319,7 +358,7 @@ export const runCrossVersion = (options: RunCrossVersionOptions): void => {
         console.log(
           `\n${logPrefix} ===== ${target.category} = ${target.version} =====`,
         );
-        return runSuite(target.version, options);
+        return runSuiteWithRetries(target.version, options);
       },
     ),
   }));

--- a/packages/remote-react-components/dev/cross-version/run.ts
+++ b/packages/remote-react-components/dev/cross-version/run.ts
@@ -10,6 +10,13 @@ import { runCrossVersion } from "./crossVersionRunner";
 runCrossVersion({
   vitestConfig: "e2e/cross-version/vitest.config.ts",
   tempPrefix: "flow-cross-version-",
+  // The real iframe @quilted/threads handshake intermittently wedges a whole
+  // version's run under CI load (every scenario times out together); only a
+  // fresh server pair recovers it. Retry each version in-process with fresh
+  // servers so one flaky version no longer reds the run — this replaces the
+  // old coarse "re-run the ENTIRE suite 3x" CI loop, which never converged
+  // because a different version flaked on each attempt.
+  attemptsPerVersion: 3,
   labels: {
     logPrefix: "[cross-version]",
     errorTitlePrefix: "cross-version",

--- a/packages/remote-react-components/e2e/cross-version/setupGlobal.test.ts
+++ b/packages/remote-react-components/e2e/cross-version/setupGlobal.test.ts
@@ -1,0 +1,92 @@
+import type { TestProject } from "vitest/node";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Vitest browser mode runs the cross-version `globalSetup` once PER PROJECT, and
+// even a single-instance browser config yields two projects (root + the `webkit`
+// instance), so `setup` fires twice in the same process. Without memoization
+// that starts FOUR Vite dev servers where two suffice, and the two redundant
+// servers force-optimizing heavy dep graphs on the 2-core CI runner starve the
+// iframe @quilted/threads handshake past its timeout. These tests lock in the
+// shared-server-pair + ref-counted-teardown behavior that prevents that.
+
+const { createCrossVersionServer } = vi.hoisted(() => ({
+  createCrossVersionServer: vi.fn(),
+}));
+
+vi.mock("./createServer", () => ({ createCrossVersionServer }));
+
+// `current` short-circuits resolveCrossVersionServerPackage before it reads the
+// (absent in unit runs) cross-version manifest.
+process.env.FLOW_CROSS_VERSION = "current";
+
+interface FakeServer {
+  port: number;
+  stop: ReturnType<typeof vi.fn>;
+}
+
+const callSetup = async (setup: (project: TestProject) => Promise<unknown>) => {
+  const provide = vi.fn();
+  const teardown = (await setup({
+    provide,
+  } as unknown as TestProject)) as () => Promise<void>;
+  return { provide, teardown };
+};
+
+describe("cross-version globalSetup", () => {
+  let stops: ReturnType<typeof vi.fn>[];
+
+  beforeEach(async () => {
+    vi.resetModules();
+    stops = [];
+    let nextPort = 5173;
+    createCrossVersionServer.mockReset();
+    createCrossVersionServer.mockImplementation(
+      async (): Promise<FakeServer> => {
+        const stop = vi.fn(() => Promise.resolve());
+        stops.push(stop);
+        return { port: nextPort++, stop };
+      },
+    );
+  });
+
+  it("starts only one server pair when setup runs once per project", async () => {
+    const { setup } = await import("./setupGlobal");
+
+    const first = await callSetup(setup);
+    const second = await callSetup(setup);
+
+    // One pair (reference + candidate) shared across both project setups — NOT
+    // one pair per setup call.
+    expect(createCrossVersionServer).toHaveBeenCalledTimes(2);
+    // Both projects are handed the very same ports.
+    expect(second.provide.mock.calls).toEqual(first.provide.mock.calls);
+  });
+
+  it("stops the servers only after the last project tears down", async () => {
+    const { setup } = await import("./setupGlobal");
+
+    const first = await callSetup(setup);
+    const second = await callSetup(setup);
+
+    await first.teardown();
+    // Other project still using the servers — must stay up.
+    expect(stops.every((stop) => stop.mock.calls.length === 0)).toBe(true);
+
+    await second.teardown();
+    // Last teardown stops each server exactly once.
+    expect(stops.map((stop) => stop.mock.calls.length)).toEqual([1, 1]);
+  });
+
+  it("re-creates servers for a fresh run after teardown", async () => {
+    const { setup } = await import("./setupGlobal");
+
+    const first = await callSetup(setup);
+    const second = await callSetup(setup);
+    await first.teardown();
+    await second.teardown();
+
+    // A later run (e.g. a per-version retry) must not reuse the stopped pair.
+    await callSetup(setup);
+    expect(createCrossVersionServer).toHaveBeenCalledTimes(4);
+  });
+});

--- a/packages/remote-react-components/e2e/cross-version/setupGlobal.ts
+++ b/packages/remote-react-components/e2e/cross-version/setupGlobal.ts
@@ -16,20 +16,67 @@ const candidateVersion = resolveCrossVersionServerPackage(
   process.env[CROSS_VERSION_ENV],
 ).version;
 
-export async function setup({ provide }: TestProject) {
-  const referenceServer = await createCrossVersionServer("current");
+interface SharedServers {
+  currentPort: number;
+  oldPort: number;
+  stop: () => Promise<void>;
+}
 
+// Vitest browser mode runs this file's `setup` ONCE PER PROJECT, and a
+// single-instance browser config still yields two projects (the root project
+// plus the `webkit` instance project), so `setup` fires twice in the same
+// process. Naively that starts FOUR Vite dev servers (two current + two old)
+// where two suffice — and on the 2-core CI runner those redundant servers all
+// force-optimize their (heavy, for the oldest versions) dep graphs at once,
+// starving the runner enough to push the iframe @quilted/threads handshake past
+// its timeout ("Could not establish remote connection: Timeout reached"). We
+// memoize the server pair so both `setup` calls share ONE pair, and ref-count
+// the teardowns so the servers stop only after the last project tears down.
+let sharedServersPromise: Promise<SharedServers> | undefined;
+let refCount = 0;
+
+const startServers = async (): Promise<SharedServers> => {
+  const referenceServer = await createCrossVersionServer("current");
   try {
     const candidateServer = await createCrossVersionServer(candidateVersion);
-
-    provide("crossVersionCurrentPort", referenceServer.port);
-    provide("crossVersionOldPort", candidateServer.port);
-
-    return async () => {
-      await Promise.all([candidateServer.stop(), referenceServer.stop()]);
+    return {
+      currentPort: referenceServer.port,
+      oldPort: candidateServer.port,
+      stop: async () => {
+        await Promise.all([candidateServer.stop(), referenceServer.stop()]);
+      },
     };
   } catch (error) {
     await referenceServer.stop();
     throw error;
   }
+};
+
+export async function setup({ provide }: TestProject) {
+  refCount++;
+  // `??=` memoizes the in-flight promise, so concurrent project setups share
+  // the same server pair instead of racing two independent startups.
+  sharedServersPromise ??= startServers();
+
+  let servers: SharedServers;
+  try {
+    servers = await sharedServersPromise;
+  } catch (error) {
+    // A failed startup must not stay cached, or a retry would await the same
+    // rejected promise forever.
+    refCount--;
+    sharedServersPromise = undefined;
+    throw error;
+  }
+
+  provide("crossVersionCurrentPort", servers.currentPort);
+  provide("crossVersionOldPort", servers.oldPort);
+
+  return async () => {
+    refCount--;
+    if (refCount === 0) {
+      sharedServersPromise = undefined;
+      await servers.stop();
+    }
+  };
 }


### PR DESCRIPTION
## What

Fixes the frequently-red scheduled **cross-version** iframe smoke-test job (`test-visual-scheduled.yml`).

## Why it was flaky

The job failed ~40% of runs with `Could not establish remote connection: Timeout reached`. Investigation of the CI logs showed this is **not** an HTML/backwards-compat diff — the in-process harness passed every scenario in the same runs. It's the real `@quilted/threads` iframe handshake wedging a whole version's run under CI load: each run a *random* older/heavier version timed out on all its scenarios at once (60s each), and only a **fresh server pair** recovered it. The existing 3× whole-suite shell retry never converged, because a different version flaked on each attempt.

Two root causes:

1. **Double `globalSetup` → 4 Vite servers instead of 2.** Vitest browser mode runs `globalSetup` once *per project*, and a single-instance browser config still yields two projects (root + the `webkit` instance), so `setup()` fired twice and started **four** dev servers where two suffice. On the 2-core runner the two redundant servers force-optimizing heavy dep graphs starved the handshake past its timeout.
2. **Retry granularity mismatch.** Retrying the *entire* suite couldn't converge against a per-version, per-server-instance wedge.

## What changed

- **`e2e/cross-version/setupGlobal.ts`** — memoize a single server pair across both project setups and ref-count teardown, so exactly **2** servers start (verified in CI: 8 `serving version` logs for 4 versions, down from 16).
- **`dev/cross-version/crossVersionRunner.ts` + `run.ts`** — retry each version with **fresh servers** (`attemptsPerVersion: 3`) — the only thing observed to clear the wedge. A real diff still fails deterministically on every attempt, so retrying never masks a genuine break.
- **`test-visual-scheduled.yml`** — drop the coarse 3× whole-suite shell loop (retry now lives per-version in the runner); this also stops tripling the runtime.
- **`e2e/cross-version/setupGlobal.test.ts`** — new regression test locking in the shared-pair + ref-counted-teardown behavior.

## Verification

Dispatched run on this branch: [`cross-version` job green](https://github.com/mittwald/flow/actions/runs/30456641571) — 2 servers per iteration, 4/4 versions pass, **0** connection timeouts, **0** retries needed (halving contention alone cleared it this run; the per-version retry remains as a backstop). `test:compile`, ESLint, Prettier and the new regression test all pass locally.

**Caveat:** a single green run isn't statistical proof the flake is eliminated, but the *cause* (4→2 servers) is deterministically confirmed, and the retry covers the residual risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)