### PR TITLE
ci: add forward-merge cascade + next publishing (ADR 0004)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,24 @@
 .yarn -diff
+
+# Forward-merge cascade drivers (ADR 0004 §3).
+#
+# When a lower release line is merged up into a higher one (`main → next`, and
+# `next → major line`), version/changelog differences are mechanical noise, not
+# real conflicts. These attributes let them resolve automatically so only a
+# genuine code conflict reaches a human via the sync PR (ADR 0004 §4).
+#
+# IMPORTANT: a `merge=<driver>` attribute is inert on its own — the driver must
+# ALSO be registered in the runner's git config. `.github/workflows/forward-
+# merge.yml` does this before every merge:
+#   git config merge.ours.driver true
+#   git config merge.package-json.driver \
+#     "node .github/scripts/merge-package-json.cjs %O %A %B %L %P"
+
+# `next` keeps its own CHANGELOG.md; lerna regenerates its entries from the
+# merged commits, and per-package changelogs are only the machine record.
+**/CHANGELOG.md merge=ours
+
+# `package.json`: keep the higher line's `version` field but merge every other
+# change (e.g. genuine dependency bumps) with a normal 3-way merge. A blanket
+# `merge=ours` is rejected — it would silently drop those. See the driver.
+**/package.json merge=package-json

--- a/.github/scripts/merge-package-json.cjs
+++ b/.github/scripts/merge-package-json.cjs
@@ -1,0 +1,101 @@
+// JSON-aware merge driver for `package.json` during the forward-merge cascade
+// (ADR 0004 §3). When a lower release line is merged up into a higher one
+// (`main → next`, `next → major line`), the two lines legitimately carry
+// different `version` fields across ~15 `package.json` files. That divergence
+// is mechanical noise, not a real conflict: the higher line keeps its own
+// version (it is re-derived by `publish-next.yml` anyway), while every *other*
+// change from the lower line (e.g. a genuine dependency bump) must still merge
+// normally. A blanket `merge=ours` is wrong — it would silently drop those.
+//
+// git invokes a merge driver as configured in `.gitattributes` +
+// `merge.package-json.driver`. This script is wired up as:
+//   node .github/scripts/merge-package-json.cjs %O %A %B %L %P
+//     %O = common-ancestor ("base") version of the file
+//     %A = "our" version — the branch being merged INTO (e.g. `next`);
+//          the merge RESULT must be written back here
+//     %B = "their" version — the branch being merged IN (e.g. `main`)
+//     %L = conflict marker length, %P = pathname (diagnostics only)
+// The driver must exit 0 on a clean merge and non-zero to signal an unresolved
+// conflict (which escalates to the sync PR — ADR 0004 §4).
+//
+// This is a `.cjs` on purpose: the repo's eslint config treats `**/*.cjs` as
+// out-of-scope Node tooling, so no lint config is needed for it to pass the
+// gate; `prettier` still formats it.
+
+const { spawnSync } = require("node:child_process");
+const { readFileSync, writeFileSync } = require("node:fs");
+
+const [
+  ,
+  ,
+  basePath,
+  oursPath,
+  theirsPath,
+  markerSize = "7",
+  pathName = "package.json",
+] = process.argv;
+
+function versionOf(file) {
+  try {
+    return JSON.parse(readFileSync(file, "utf8")).version;
+  } catch {
+    return undefined;
+  }
+}
+
+// The higher line's own version wins. If we cannot read it, fall back to a
+// plain 3-way merge below (the version line then merges like any other).
+const oursVersion = versionOf(oursPath);
+
+// Normalise the top-level `version` string in all three inputs to our value, so
+// a pure version divergence never produces a conflict and the merged result
+// already carries the higher line's version. `prettier-plugin-pkgsort` keeps
+// `version` near the top of every `package.json`, so the first match is the
+// top-level field. Any *other* divergence is left untouched and merges below.
+function normaliseVersion(file) {
+  if (oursVersion === undefined) {
+    return;
+  }
+  const raw = readFileSync(file, "utf8");
+  const replaced = raw.replace(
+    /("version"\s*:\s*)"[^"]*"/,
+    `$1${JSON.stringify(oursVersion)}`,
+  );
+  writeFileSync(file, replaced);
+}
+
+for (const file of [basePath, oursPath, theirsPath]) {
+  normaliseVersion(file);
+}
+
+// Line-based 3-way merge. `git merge-file` writes the result in place into
+// `oursPath` and exits with the number of remaining conflict hunks (0 = clean),
+// or a negative/large status on error.
+const result = spawnSync(
+  "git",
+  [
+    "merge-file",
+    `--marker-size=${markerSize}`,
+    "-L",
+    "next (ours)",
+    "-L",
+    "base",
+    "-L",
+    "main (theirs)",
+    oursPath,
+    basePath,
+    theirsPath,
+  ],
+  { stdio: "inherit" },
+);
+
+if (result.error || result.status === null) {
+  console.error(
+    `merge-package-json: git merge-file failed to run for ${pathName}`,
+  );
+  process.exit(1);
+}
+
+// status 0 → clean merge (exit 0); status > 0 → unresolved conflict hunks
+// remain → signal a conflict so the workflow opens the sync PR (ADR 0004 §4).
+process.exit(result.status === 0 ? 0 : 1);

--- a/.github/workflows/forward-merge.yml
+++ b/.github/workflows/forward-merge.yml
@@ -1,0 +1,225 @@
+name: Forward-merge main into next
+
+# Forward-merge cascade (ADR 0004). Keeps the higher release line a superset of
+# the lower one BY CONSTRUCTION: every change on `main` is merged up into `next`
+# as a TRUE merge commit (never rebase/squash/cherry-pick), so `main` stays an
+# ancestor of `next` and routine merges never re-collide (ADR 0004 §1).
+#
+# The workflow is idempotent: it merges the CURRENT `main` tip into `next`, not
+# "a specific commit" (ADR 0004 §2). A `fix:` push and the later
+# `chore(release):` push both trigger a run; both converge on "next contains
+# main's tip", and the churn-only run collapses to an empty merge with no push
+# (ADR 0004 §6/§7).
+#
+# Version/changelog divergence between the lines is absorbed by the
+# `.gitattributes` merge drivers (registered below, ADR 0004 §3). Only a genuine
+# code conflict escalates to the `sync/main-to-next` PR (ADR 0004 §4). Any other
+# failure opens an issue (ADR 0004 §10).
+#
+# The push to `next` triggers `publish-next.yml`, which re-derives the version
+# and publishes the `next` prerelease (ADR 0004 §6). This workflow itself stays
+# version-free — it merges and pushes, nothing more.
+
+on:
+  push:
+    branches:
+      - main
+  # First-class manual recovery/force path (ADR 0004 §2): a manual run merges
+  # the current `main` tip into `next` exactly like an automatic one.
+  workflow_dispatch:
+
+permissions:
+  contents: write # push the merge commit / sync branch
+  pull-requests: write # open the sync PR
+  issues: write # open the failure issue (ADR 0004 §10)
+
+# One shared concurrency group per TARGET branch, used by every workflow that
+# pushes to `next` (this one and `publish-next.yml`) — serializes all writers of
+# `next` and removes non-fast-forward races by design (ADR 0004 §5).
+concurrency:
+  group: mutate-next
+  cancel-in-progress: false
+
+env:
+  GH_TOKEN: ${{ secrets.PUBLISH_PAT }}
+  REPO: ${{ github.repository }}
+
+jobs:
+  forward-merge:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      # Self-gating (mirrors commit-guard.yml): the cascade only exists once the
+      # `next` collection branch does, i.e. after the 1.0.0 cut. Until then this
+      # workflow is dormant, so pushes to `main` on the `0.2.0-alpha.*` line do
+      # not fail.
+      - name: Check whether the `next` branch exists yet
+        id: guard
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --heads \
+               "https://github.com/${REPO}.git" next >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::'next' branch does not exist yet — forward-merge dormant (pre-1.0.0-cut). Skipping."
+          fi
+
+      - name: Checkout `next` ⬇️
+        if: steps.guard.outputs.exists == 'true'
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: next
+          fetch-depth: 0
+          token: ${{ secrets.PUBLISH_PAT }}
+
+      # A pinned Node just for the JSON merge driver (`.github/scripts/merge-
+      # package-json.cjs`); no dependency install — the merge is version-free.
+      - name: Setup Node 🎛️
+        if: steps.guard.outputs.exists == 'true'
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24
+
+      - name: Git identity 🪪
+        if: steps.guard.outputs.exists == 'true'
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+
+      # A `merge=<driver>` attribute is inert unless the driver is registered in
+      # the runner's git config too (ADR 0004 §3, Consequences).
+      - name: Register merge drivers 🔧
+        if: steps.guard.outputs.exists == 'true'
+        run: |
+          set -euo pipefail
+          git config merge.ours.driver true
+          git config merge.package-json.driver \
+            "node .github/scripts/merge-package-json.cjs %O %A %B %L %P"
+
+      - name: Forward-merge and push (or open sync PR) 🔀
+        id: merge
+        if: steps.guard.outputs.exists == 'true'
+        run: |
+          set -euo pipefail
+
+          open_sync_pr() {
+            # Real (non-version) conflict → sync PR (ADR 0004 §4). Never lands on
+            # `main`: conflict-resolution commits go on `sync/main-to-next`.
+            local branch="sync/main-to-next"
+
+            # Create/update the sync branch at main's tip. Idempotent: an already
+            # open PR only gets its branch fast-forwarded, never a duplicate PR.
+            git push --force origin "origin/main:refs/heads/${branch}"
+
+            local open_pr
+            open_pr="$(gh pr list --repo "$REPO" --head "$branch" \
+              --base next --state open --json number --jq '.[].number')"
+            if [ -n "$open_pr" ]; then
+              echo "::notice::Sync PR #${open_pr} already open — branch fast-forwarded to main."
+              return 0
+            fi
+
+            # Labels must exist before use; create idempotently.
+            gh label create sync --repo "$REPO" --color BFD4F2 \
+              --description "Forward-merge / promotion sync PR" 2>/dev/null || true
+            gh label create automated --repo "$REPO" --color EDEDED \
+              --description "Opened by automation" 2>/dev/null || true
+
+            local body
+            body="$(printf '%s\n' \
+              'The automated forward-merge of `main` into `next` hit a real code conflict (ADR 0004 §4). The version/changelog churn is handled automatically by the merge drivers, so this is a genuine same-line conflict that needs a human.' \
+              '' \
+              'How to resolve: resolve the conflict on this `sync/main-to-next` branch (locally or in the web editor) and merge it AS A TRUE MERGE COMMIT — a squash/rebase merge would break the superset invariant (ADR 0004 §1) and is blocked by branch protection on `next`.')"
+
+            gh pr create --repo "$REPO" --base next --head "$branch" \
+              --title "chore(sync): resolve forward-merge conflict (main into next)" \
+              --label sync --label automated \
+              --body "$body"
+
+            # Request review from CODEOWNERS (the Frontend Core Team). Kept
+            # non-fatal: the PR must exist even if a reviewer request is rejected
+            # (e.g. the automation identity is itself one of the owners).
+            gh pr edit "$branch" --repo "$REPO" \
+              --add-reviewer mfal,Lisa18289,ins0,maaaathis,Jan-Eimertenbrink \
+              || echo "::warning::Could not request all CODEOWNERS reviewers."
+          }
+
+          git fetch --no-tags origin main
+          MAIN_SHA="$(git rev-parse origin/main)"
+          SHORT_SHA="$(git rev-parse --short origin/main)"
+          NEXT_BEFORE="$(git rev-parse HEAD)"
+          MERGE_MSG="chore(sync): forward-merge main into next (${SHORT_SHA})"
+
+          echo "Merging main (${SHORT_SHA}) into next ($(git rev-parse --short HEAD))"
+
+          # True merge commit with an explicit conventional message (ADR 0004
+          # §1, §8) — `chore(sync):` is valid-conventional and non-releasing.
+          if git merge --no-ff -m "$MERGE_MSG" "$MAIN_SHA"; then
+            echo "Merge succeeded."
+          elif [ -n "$(git ls-files --unmerged)" ]; then
+            echo "::warning::Merge conflict — escalating to the sync PR."
+            git merge --abort
+            open_sync_pr
+            exit 0
+          else
+            echo "::error::git merge failed without a conflict."
+            exit 1
+          fi
+
+          # Empty forward-merge (ADR 0004 §6/§7): if the merge brought in no code
+          # delta (only version/changelog churn the drivers absorbed), the tree
+          # is unchanged. Drop the empty merge and skip the push, so no spurious
+          # `next` re-publish is triggered.
+          if git diff --quiet "$NEXT_BEFORE" HEAD; then
+            echo "No code delta after merge — skipping push (nothing to re-publish)."
+            git reset --hard "$NEXT_BEFORE"
+            exit 0
+          fi
+
+          # Push with one fetch-before-push retry on non-fast-forward (ADR 0004
+          # §5, belt-and-suspenders on top of the shared concurrency group).
+          if git push origin HEAD:next; then
+            echo "Pushed forward-merge to next."
+            exit 0
+          fi
+
+          echo "::warning::Push rejected (non-fast-forward) — refetching next and retrying once."
+          git fetch --no-tags origin next
+          if git merge --no-ff -m "$MERGE_MSG" origin/next; then
+            git push origin HEAD:next
+            echo "Pushed forward-merge to next after retry."
+            exit 0
+          fi
+
+          if [ -n "$(git ls-files --unmerged)" ]; then
+            echo "::warning::Conflict against a concurrent next writer — escalating to the sync PR."
+            git merge --abort
+            open_sync_pr
+            exit 0
+          fi
+          echo "::error::Retry re-merge/push failed."
+          exit 1
+
+      # A conflict is the expected non-error path (handled above, exits 0). Any
+      # genuine failure (retry exhausted, workflow error) must not let `next`
+      # silently fall behind `main` — open an issue and ping CODEOWNERS (ADR
+      # 0004 §10).
+      - name: Open an issue on failure 🚨
+        if: failure() && steps.guard.outputs.exists == 'true'
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          gh label create automated --repo "$REPO" --color EDEDED \
+            --description "Opened by automation" 2>/dev/null || true
+          body="$(printf '%s\n' \
+            'The automated forward-merge of main into next failed for a reason OTHER THAN a merge conflict (ADR 0004 §10). next may now be falling behind main.' \
+            '' \
+            "Run: ${RUN_URL}" \
+            '' \
+            '/cc @mfal @Lisa18289 @ins0 @maaaathis @Jan-Eimertenbrink')"
+          gh issue create --repo "$REPO" --label automated \
+            --title "Forward-merge main into next failed" \
+            --body "$body" \
+            || echo "::warning::Could not open the failure issue."

--- a/.github/workflows/forward-merge.yml
+++ b/.github/workflows/forward-merge.yml
@@ -108,17 +108,23 @@ jobs:
             # `main`: conflict-resolution commits go on `sync/main-to-next`.
             local branch="sync/main-to-next"
 
-            # Create/update the sync branch at main's tip. Idempotent: an already
-            # open PR only gets its branch fast-forwarded, never a duplicate PR.
-            git push --force origin "origin/main:refs/heads/${branch}"
-
+            # If a sync PR is already open, a maintainer may be resolving the
+            # conflict on that branch RIGHT NOW. Never touch the branch in that
+            # case — a force-push would silently discard their resolution
+            # commits. Bail out and let the existing PR carry the resolution;
+            # once it merges, the next run re-evaluates against the new `next`.
             local open_pr
             open_pr="$(gh pr list --repo "$REPO" --head "$branch" \
               --base next --state open --json number --jq '.[].number')"
             if [ -n "$open_pr" ]; then
-              echo "::notice::Sync PR #${open_pr} already open — branch fast-forwarded to main."
+              echo "::notice::Sync PR #${open_pr} already open — leaving its branch untouched (a maintainer may be resolving it)."
               return 0
             fi
+
+            # No open sync PR → safe to (re)create the branch at main's tip. Any
+            # commits here are stale (a previously closed/merged sync attempt),
+            # so resetting to main is correct.
+            git push --force origin "origin/main:refs/heads/${branch}"
 
             # Labels must exist before use; create idempotently.
             gh label create sync --repo "$REPO" --color BFD4F2 \

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -1,0 +1,131 @@
+name: Publish next collection line to NPM
+
+# Symmetric sibling of publish.yml for the `next` collection line (ADR 0004 §6,
+# RFC #2711). Where publish.yml publishes `main` as dist-tag `latest`
+# (`X.Y.Z`), this publishes `next` as dist-tag `next` (`X.Y.0-next.N`).
+#
+# It is triggered by every push to `next` — including the `chore(sync):` merge
+# commits that forward-merge.yml pushes. A forward-merged fix therefore produces
+# a new `next` prerelease, so `flow@next` ⊇ `flow@latest` on npm, not merely in
+# git. The version is RE-DERIVED here, which is why the exact string the merge
+# driver produced (ADR 0004 §3) is irrelevant. The churn-only forward-merge
+# collapses to an empty merge with no push (ADR 0004 §6), so it never reaches
+# this workflow — the double trigger collapses to exactly one meaningful
+# publish.
+
+on:
+  workflow_dispatch:
+    inputs:
+      only_publish:
+        description: "Publish missing packages only, without a version bump"
+        type: boolean
+        default: false
+  push:
+    branches:
+      - next
+
+permissions:
+  id-token: write
+  contents: write
+
+# Shared per-target-branch concurrency group (ADR 0004 §5): the SAME group as
+# forward-merge.yml, so every writer of `next` is serialized and there are no
+# non-fast-forward races.
+concurrency:
+  group: mutate-next
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    # Publish on manual dispatch, or on any push to `next` EXCEPT the release
+    # commit this workflow pushes itself (guarded below to avoid an infinite
+    # publish loop). The `chore(sync):` forward-merge commits are NOT skipped —
+    # re-publishing on a forward-merged fix is the whole point (ADR 0004 §6).
+    #
+    # As in publish.yml, the trigger is `push: next`, NOT
+    # `pull_request_target: closed`: npm's Trusted Publisher only accepts the
+    # OIDC token when its ref is a branch ref (refs/heads/next).
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      !startsWith(github.event.head_commit.message, 'chore(release):')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      PUBLISH_PAT: ${{ secrets.PUBLISH_PAT }}
+      GH_TOKEN: ${{ secrets.PUBLISH_PAT }}
+
+    steps:
+      - name: Checkout ⬇️
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: next
+          fetch-depth: 0
+          token: ${{ secrets.PUBLISH_PAT }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Setup Node 🎛️
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24
+          registry-url: "https://registry.npmjs.org"
+          cache: pnpm
+
+      - name: Git Identity 🪪
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+
+      - name: pnpm Install 📦️
+        run: pnpm install --frozen-lockfile
+
+      - name: Setup NX 1/2 🎛️
+        uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
+
+      - name: Setup NX 2/2 🎛
+        run: |
+          git fetch --no-tags origin main
+          git branch --track main origin/main
+
+      - name: Build 🔨
+        run: pnpm build
+
+      # Bump versions, write changelogs, commit and tag — but do NOT push and do
+      # NOT create the GitHub release yet (same deferral as publish.yml: pushing
+      # the release commit before npm publish succeeded would ratchet `next`
+      # ahead of npm). `--conventional-prerelease` + `--preid next` derives the
+      # `X.Y.0-next.N` line (ADR 0004 §6).
+      - name: Version 🏷️
+        if: ${{ !inputs.only_publish }}
+        run: |
+          pnpm lerna version \
+            --force-publish \
+            --conventional-commits --conventional-prerelease="*" \
+            --preid next \
+            --message "chore(release): bump version to %v" \
+            --yes \
+            --no-push \
+            --tag-version-prefix ""
+
+      # Publish under the `next` dist-tag (ADR 0004 §6) — the distinguishing
+      # difference from publish.yml, which publishes `latest`. Provenance/OIDC
+      # and the @sigstore/sign Rekor-409 patch behave exactly as in publish.yml.
+      - name: Publish 🚀
+        run: pnpm lerna publish from-package --yes --no-private --concurrency 1 --dist-tag next
+
+      # Only reached when the publish above succeeded. Now it is safe to advance
+      # `next` with the release commit and tag.
+      #
+      # NOTE: deliberately NO GitHub Release here. Per RFC #2711 the curated
+      # GitHub Release is canonical only at PROMOTION (`next → main`); cutting a
+      # prerelease Release per `X.Y.0-next.N` would just be noise. The npm
+      # publish (dist-tag `next`) above and the git tag below are the record of
+      # each `next` prerelease.
+      - name: Push release commit & tag 🚀
+        if: ${{ !inputs.only_publish }}
+        run: |
+          tag="$(git describe --tags --abbrev=0)"
+          echo "Pushing release commit and tag ${tag} to next"
+          git push origin HEAD:next
+          git push origin "refs/tags/${tag}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,8 +15,11 @@ permissions:
   id-token: write
   contents: write
 
+# Shared per-target-branch concurrency group (ADR 0004 §5): every writer of
+# `main` (this workflow, and the promotion back-merge once the 1.0.0 model is
+# live) serializes on `mutate-main`, removing non-fast-forward races by design.
 concurrency:
-  group: publish-${{ github.ref }}
+  group: mutate-main
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
Implements the forward-merge cascade and the `next` publishing line from **ADR 0004** (part of the 1.0.0 release model, RFC #2711, tracking #2738).

## What this adds
- **`.github/workflows/forward-merge.yml`** — on `push: main` (and `workflow_dispatch`), merges `main` into `next` as a true `--no-ff` merge commit. The clean path pushes the merge commit directly to `next` (PR-free, ADR §8); only on a genuine conflict does it open/update the `sync/main-to-next` PR for a human to resolve (§4). Shared `mutate-next` concurrency with one fetch-before-push retry (§5); opens an issue on non-conflict failures (§10).
- **`.github/scripts/merge-package-json.cjs`** — JSON-aware `package.json` merge driver: keeps `next`'s `version`, 3-way-merges every other change (real dep bumps survive), escalates a genuine same-line conflict.
- **`.gitattributes`** — registers `CHANGELOG.md merge=ours` and `package.json merge=package-json` (§3); the workflow wires the drivers into git config at run time.
- **`.github/workflows/publish-next.yml`** — symmetric to `publish.yml`: on `push: next`, versions `X.Y.0-next.N` and publishes under dist-tag `next` (§6). No per-prerelease GitHub Release (the curated Release is canonical only at promotion, RFC #2711) — npm publish + git tag remain.
- **`.github/workflows/publish.yml`** — only change: concurrency group moved to the shared `mutate-main` (ADR §5 mandates this).

## Behavior decisions (per ADR 0004, confirmed with maintainer)
- **Self-gating:** dormant until the `next` branch exists (mirrors `commit-guard.yml`), so it stays inert until the 1.0.0 cut.
- **Empty/churn-only merge:** if the merge tree equals `next`'s tree, it resets and skips the push (no empty push).
- **No generators/build in the cascade** — merges and pushes, nothing more (§6). Generator/build gating stays in the publish/CI path.
- Conflict-PR head `sync/main-to-next` falls under the existing commit-guard routing exemption, so the routing guard won't block it.

## Validation
Prettier `--check` (in-scope files), YAML parse of all three workflows, `bash -n` on every `run:` block, a merge-driver unit test, and an end-to-end `git merge` in a throwaway repo (kept `next`'s version, took main's dep bump, `CHANGELOG` via `merge=ours`).

Closes part of #2738.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
