### PR TITLE
feat(components): warn on all remaining deprecated APIs via useWarnDeprecation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,9 @@ RemoteRoot + remote React components  ───►  RemoteRenderer + RemoteRecei
   developers.** Avoid breaking changes. When an API must change, keep the old
   path working and log usage with `useWarnDeprecation` (from
   `DeprecationWarningProvider`) so extension developers can be informed about
-  deprecation paths they still use.
+  deprecation paths they still use. `useWarnDeprecation` is the standard way to
+  flag any deprecated runtime path — see
+  [Deprecating an API](packages/components/AGENTS.md#deprecating-an-api).
 - Inside components that are part of the `flr-universal` export surface, compose
   other Flow components through their **views** (`@/views/*`) — views
   automatically switch to the remote counterpart in a remote context.

--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -149,8 +149,16 @@ Remote generation details:
   `pnpm nx build:remote-components components` and **commit** the results
   (view.ts, `src/views/*`, `remote-*/src/auto-generated/**`).
 - Props of these components are consumed by mStudio extension developers — no
-  breaking changes; deprecate instead. Why this matters:
+  breaking changes; deprecate instead (see
+  [Deprecating an API](#deprecating-an-api)). Why this matters:
   [docs/remote-ui.md](../../docs/remote-ui.md).
+
+## Deprecating an API
+
+Never break a shipped API — keep the old path working and warn at runtime with
+`useWarnDeprecation` (from `DeprecationWarningProvider`). This covers every kind
+of deprecated entry point: a prop, a whole component, a hook, or an integration
+export (`nextjs`, `password-tools`).
 
 ```tsx
 const warnDeprecation = useWarnDeprecation();
@@ -158,6 +166,17 @@ if ("action" in props) {
   warnDeprecation("The 'action' prop is deprecated. Use 'onAction' instead.");
 }
 ```
+
+- Warn a deprecated **prop** only when it is actually passed; warn a deprecated
+  **component** unconditionally at the top of its render.
+- `useWarnDeprecation` is a hook — it must run inside a render or another hook.
+  A class constructor works only when it is itself a `Model.useNew`-style
+  render-time hook (e.g. `List`), not when it is constructed conditionally (e.g.
+  `new ItemView(…)`); warn one level up in that case.
+- Messages are deduplicated per string; follow the shape
+  `The '<name>' <prop|component|function> is deprecated and will be removed in a future release. Use '<replacement>' instead.`
+- A type-only deprecation (e.g. a deprecated type alias) has no runtime path —
+  nothing to warn.
 
 ## Styling
 

--- a/packages/components/PATTERNS.md
+++ b/packages/components/PATTERNS.md
@@ -345,11 +345,13 @@ and consistency enforced by tooling, not maintained by hand.
   `@flr-generate` props.
   - ✓ generated props are serializable, least-privilege, backward-compatible.
   - ✗ host-only/non-serializable → ignore remotely or stay host-only.
-- **Deprecation warning hook (`useWarnDeprecation`)** — warn on legacy prop
-  usage, keep supporting it.
+- **Deprecation warning hook (`useWarnDeprecation`)** — warn on any deprecated
+  runtime path (prop, whole component, or hook/alias), keep supporting it.
   `src/components/CartesianChart/CartesianChart.tsx:59`
-  - ✓ a shipped remote prop/API must keep working while guiding to its
-    replacement.
+  - ✓ any shipped API (remote prop, non-remote component, integration export)
+    must keep working while guiding to its replacement.
+  - ✗ a deprecation with no runtime entry point (a type-only alias) — nothing to
+    warn; or a spot with no render/hook context (warn one level up instead).
   - ✗ unshipped/internal API → change directly.
 - **Controlled remote adapter** `[undocumented]` — shared hooks bridge
   serialized value/callbacks. `src/lib/remote/useControlledHostValueProps.ts:23`

--- a/packages/components/src/components/List/model/List.ts
+++ b/packages/components/src/components/List/model/List.ts
@@ -21,6 +21,7 @@ import { ListSettingsStore } from "./ListSettingsStore";
 import { ListViewMode } from "./ListViewMode";
 import { useSettings } from "@/components/SettingsProvider/SettingsProvider";
 import { DateRangeFilter } from "@/components/List/model/filter/DateRangeFilter";
+import { useWarnDeprecation } from "@/components/DeprecationWarningProvider";
 
 export class List<T = unknown, TMeta = unknown> {
   public readonly filters: (
@@ -70,6 +71,13 @@ export class List<T = unknown, TMeta = unknown> {
       emptySearchResultView,
       ...componentProps
     } = shape;
+
+    const warnDeprecation = useWarnDeprecation();
+    if (itemView?.fallback !== undefined) {
+      warnDeprecation(
+        "The 'fallback' prop is deprecated and will be removed in a future release. Use 'loadingView' instead.",
+      );
+    }
 
     this.settingsStorageDefaults = settingsStorageDefaults;
     const generalSettingsStore = useSettings();

--- a/packages/components/src/components/List/setupComponents/ListLoaderAsyncResource.ts
+++ b/packages/components/src/components/List/setupComponents/ListLoaderAsyncResource.ts
@@ -1,5 +1,6 @@
 import type { AsyncResourceFactoryDataLoaderShape } from "@/components/List/model/loading/types";
 import type { ComponentType } from "react";
+import { useWarnDeprecation } from "@/components/DeprecationWarningProvider";
 
 type Props<T> = Omit<
   AsyncResourceFactoryDataLoaderShape<T>,
@@ -9,7 +10,14 @@ type Props<T> = Omit<
 };
 
 /** @deprecated Use ListLoaderHooks instead */
-export const ListLoaderAsyncResource = <T>(ignoredProps: Props<T>) => null;
+export const ListLoaderAsyncResource = <T>(ignoredProps: Props<T>) => {
+  const warnDeprecation = useWarnDeprecation();
+  warnDeprecation(
+    "The 'ListLoaderAsyncResource' component is deprecated and will be removed in a future release. Use 'ListLoaderHooks' instead.",
+  );
+
+  return null;
+};
 
 export const TypedListLoaderAsyncResource = <T>() =>
   ListLoaderAsyncResource as ComponentType<Props<T>>;

--- a/packages/components/src/components/Select/Select.tsx
+++ b/packages/components/src/components/Select/Select.tsx
@@ -14,6 +14,7 @@ import type { PropsWithClassName } from "@/lib/types/props";
 import { useOverlayController } from "@/lib/controller";
 import { useFieldComponent } from "@/lib/hooks/useFieldComponent";
 import { UiComponentTunnelExit } from "../UiComponentTunnel/UiComponentTunnelExit";
+import { useWarnDeprecation } from "@/components/DeprecationWarningProvider";
 
 export interface SelectProps
   extends
@@ -27,7 +28,7 @@ export interface SelectProps
     PropsWithClassName {
   /** Handler that is called when the selected value changes. */
   onChange?: (value: Key | Key[] | null) => void;
-  /** @deprecated */
+  /** @deprecated Use `onChange` instead. */
   onSelectionChange?: (value: Key | Key[] | null) => void;
   /** Whether the component is read only. */
   isReadOnly?: boolean;
@@ -44,6 +45,13 @@ export const Select = flowComponent("Select", (props) => {
     ref,
     ...rest
   } = props;
+
+  const warnDeprecation = useWarnDeprecation();
+  if (onSelectionChange !== undefined) {
+    warnDeprecation(
+      "The 'onSelectionChange' prop is deprecated and will be removed in a future release. Use 'onChange' instead.",
+    );
+  }
 
   const {
     FieldErrorView,

--- a/packages/components/src/integrations/@mittwald/password-tools-js/usePasswordCreationFieldValidation.ts
+++ b/packages/components/src/integrations/@mittwald/password-tools-js/usePasswordCreationFieldValidation.ts
@@ -2,6 +2,7 @@ import type { PolicyGenericDeclaration } from ".";
 import { defaultPasswordCreationPolicy, Policy } from ".";
 import { useMemo, useRef } from "react";
 import type { Validate } from "react-hook-form";
+import { useWarnDeprecation } from "@/components/DeprecationWarningProvider";
 
 export const usePasswordCreationFieldValidation = (
   genericValidationPolicy: PolicyGenericDeclaration = defaultPasswordCreationPolicy,
@@ -41,5 +42,13 @@ export const usePasswordCreationFieldValidation = (
 };
 
 /** @deprecated Use `usePasswordCreationFieldValidation` instead. */
-export const generatePasswordCreationFieldValidation =
-  usePasswordCreationFieldValidation;
+export const generatePasswordCreationFieldValidation = (
+  genericValidationPolicy: PolicyGenericDeclaration = defaultPasswordCreationPolicy,
+): Validate<string, unknown> => {
+  const warnDeprecation = useWarnDeprecation();
+  warnDeprecation(
+    "The 'generatePasswordCreationFieldValidation' function is deprecated and will be removed in a future release. Use 'usePasswordCreationFieldValidation' instead.",
+  );
+
+  return usePasswordCreationFieldValidation(genericValidationPolicy);
+};

--- a/packages/components/src/integrations/nextjs/components/Link/Link.tsx
+++ b/packages/components/src/integrations/nextjs/components/Link/Link.tsx
@@ -1,5 +1,6 @@
 import type { ComponentProps, FC, Ref } from "react";
 import NextLink from "next/link";
+import { useWarnDeprecation } from "@/components/DeprecationWarningProvider";
 
 interface Props extends Omit<ComponentProps<"a">, "ref"> {
   ref?: Ref<HTMLAnchorElement>;
@@ -9,6 +10,11 @@ interface Props extends Omit<ComponentProps<"a">, "ref"> {
 /** @deprecated Use RouterProvider instead */
 export const Link: FC<Props> = (props) => {
   const { href, isDisabled, ...rest } = props;
+
+  const warnDeprecation = useWarnDeprecation();
+  warnDeprecation(
+    "The 'Link' component is deprecated and will be removed in a future release. Use 'RouterProvider' instead.",
+  );
 
   return <NextLink href={href ?? "#"} aria-disabled={isDisabled} {...rest} />;
 };

--- a/packages/components/src/integrations/nextjs/components/LinkProvider/LinkProvider.tsx
+++ b/packages/components/src/integrations/nextjs/components/LinkProvider/LinkProvider.tsx
@@ -1,12 +1,20 @@
 import type { FC, PropsWithChildren } from "react";
 import { Link } from "@/integrations/nextjs/components/Link";
 import { LinkContextProvider } from "@/components/Link/context";
+import { useWarnDeprecation } from "@/components/DeprecationWarningProvider";
 
 /** @deprecated Use RouterProvider instead */
-export const LinkProvider: FC<PropsWithChildren> = (props) => (
-  <LinkContextProvider value={{ linkComponent: Link }}>
-    {props.children}
-  </LinkContextProvider>
-);
+export const LinkProvider: FC<PropsWithChildren> = (props) => {
+  const warnDeprecation = useWarnDeprecation();
+  warnDeprecation(
+    "The 'LinkProvider' component is deprecated and will be removed in a future release. Use 'RouterProvider' instead.",
+  );
+
+  return (
+    <LinkContextProvider value={{ linkComponent: Link }}>
+      {props.children}
+    </LinkContextProvider>
+  );
+};
 
 export default LinkProvider;


### PR DESCRIPTION
## What

Several deprecated APIs were marked `@deprecated` in JSDoc and still supported at runtime, but emitted **no** deprecation warning — so consumers had no signal they were on a legacy path. This wires `useWarnDeprecation` into every deprecated API that has a render/hook entry point:

| API | Kind | Where |
| --- | --- | --- |
| `Select.onSelectionChange` | prop | warns when set; JSDoc now points to `onChange` |
| `ItemViewShape.fallback` | List item prop | warned in the `List` render-time constructor |
| `ListLoaderAsyncResource` | component | warns on render → `ListLoaderHooks` |
| nextjs `Link` | component | warns on render → `RouterProvider` |
| nextjs `LinkProvider` | component | warns on render → `RouterProvider` |
| `generatePasswordCreationFieldValidation` | hook alias | wrapped to warn, then delegates to `usePasswordCreationFieldValidation` |

All messages follow the established shape: `The '<name>' <prop|component|function> is deprecated and will be removed in a future release. Use '<replacement>' instead.`

## Why

`useWarnDeprecation` is a general-purpose deprecation mechanism (plain React context + `console.warn` + optional `onWarning` callback) — **not** tied to flr-remote or `@flr-generate`. It had only ever been applied to a handful of extension-facing props, leaving equivalent non-remote/integration deprecations silent. This closes those gaps.

### Notable detail — `ItemViewShape.fallback`

The warning sits in the `List` model constructor, not the `ItemView` constructor. `List` runs during render (it already calls `useSettings()` and `Model.useNew` hooks), so a hook is valid there. `ItemView` is constructed **conditionally** (`itemView ? new ItemView(…) : undefined`), which would violate the rules of hooks — so we warn one level up where the shape enters render.

## Docs

The hook was documented exclusively under the `@flr-generate` / remote sections, which reads as if it only applies to extension-facing props. Clarified in the root & components `AGENTS.md` and `PATTERNS.md` that it is general-purpose, plus the render/hook-context constraint that dictated the `List` placement above.

## Not changed

Type-only deprecations (`CartesianGridProps`, `CartesianChartEmptyViewProps`) stay unwarned — no runtime path to warn on.

## Verification

- ✅ `pnpm nx test:compile components` (tsc)
- ✅ `eslint` on all touched files (0 errors)
- ✅ `prettier --check` (incl. markdown)
- ✅ `pnpm nx test:unit components` — 156 passed

No `@flr-generate` prop *types* changed, so no generated code needed regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)