### PR TITLE
docs: add contributor guide routing + PR template (release-model)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+<!--
+  Thanks for contributing to Flow! Full guide:
+  https://github.com/mittwald/flow/blob/main/CONTRIBUTE.md
+-->
+
+## What & why
+
+<!-- What does this change do, and why? Link related issues (e.g. Closes #123). -->
+
+## Base branch & title
+
+This repo **squash-merges**, so your **PR title becomes the release commit** —
+it must be a valid [Conventional Commit](https://www.conventionalcommits.org/)
+(e.g. `fix(Button): correct focus ring`). A CI guard lints the title _and_ that
+it matches the base branch. Pick the base by change type
+([details](https://github.com/mittwald/flow/blob/main/CONTRIBUTE.md#choosing-the-base-branch)):
+
+- `fix:` / `docs:` / `chore:` / `refactor:` / … → base **`main`**
+- `feat:` (new feature) → base **`next`**
+- Breaking change (`feat!:` / `BREAKING CHANGE:`) → base **the major line**
+
+> Before the 1.0.0 cut the `next` / major lines don't exist yet, so everything
+> targets `main` and the routing guard stays dormant.
+
+## Checklist
+
+- [ ] PR title is a Conventional Commit and matches the base branch above
+- [ ] `pnpm lint` is clean and `pnpm affected:test` passes (browser tests if
+      behavior changed)
+- [ ] **Generated code is committed** (`git diff` is empty after the relevant
+      `build:*` targets)
+- [ ] User-facing strings added to **both** `de-DE` and `en-US` locale files
+- [ ] Docs updated if a public API changed; intentional visual changes get
+      updated snapshots / the `update-screenshots` label

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -25,6 +25,7 @@ coding agents, but great reference docs for humans too.
 - [Testing](#testing)
 - [Code style](#code-style)
 - [Commit conventions](#commit-conventions)
+- [Choosing the base branch](#choosing-the-base-branch)
 - [Opening a pull request](#opening-a-pull-request)
 - [Releases](#releases)
 - [Getting help](#getting-help)
@@ -606,9 +607,69 @@ chore(docs): migrate site URL and redirect pages
 `feat` and `fix` are user-facing and drive releases; use `chore`/`docs`/`ci` for
 everything that isn't. Write messages for the changelog reader.
 
+The commit **type** also decides **where your PR lands** — see
+[Choosing the base branch](#choosing-the-base-branch).
+
+## Choosing the base branch
+
+Flow runs a two-line release model (accepted in
+[RFC #2711](https://github.com/mittwald/flow/issues/2711); forward-merge
+mechanics in [ADR 0004](docs/adr/0004-forward-merge-main-into-next.md), the
+semver contract in [ADR 0005](docs/adr/0005-semver-contract.md)). Which branch
+your PR targets depends on the kind of change:
+
+| Your change                                          | Conventional type                | Base branch    |
+| ---------------------------------------------------- | -------------------------------- | -------------- |
+| Bug fix                                              | `fix:`                           | `main`         |
+| Docs, chore, refactor, tests, CI, build, style, perf | `docs:` / `chore:` / `refactor:` | `main`         |
+| New feature                                          | `feat:`                          | `next`         |
+| Breaking change                                      | `feat!:` / `BREAKING CHANGE:`    | the major line |
+
+- **`main`** is the Stable line (npm dist-tag `latest`). Fixes and all
+  non-releasing changes land here and ship fast — a fix never has to wait behind
+  an unreleased feature.
+- **`next`** is the Collection branch (dist-tag `next`): `main` plus accumulated
+  features, released together with a curated changelog when a maintainer
+  promotes it. Feature work goes here.
+- **The major line** is an on-demand branch that collects breaking changes
+  toward the next major. Breaking changes are rare by policy — **deprecate,
+  don't break** (keep the old path, warn via `useWarnDeprecation`); see
+  [ADR 0005](docs/adr/0005-semver-contract.md) for exactly what counts as
+  breaking.
+
+You never forward-port a change by hand: every push to `main` is automatically
+merged up into `next` (and `next` into the major line when it exists), so the
+higher lines always contain the lower ones.
+
+### The routing is enforced
+
+`.github/workflows/commit-guard.yml` runs on every PR and turns the rules above
+into a gate. Because this repo **squash-merges** — the PR title becomes the
+release commit — it lints the **PR title**, not the individual commits:
+
+- **Conventional PR title.** The title must be a valid Conventional Commit of a
+  known type (`feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`,
+  `build`, `ci`, `chore`, `revert`); a scope is optional.
+- **Routing.** A `feat:` title is rejected on `main` (features belong on
+  `next`), and a breaking change (a `!` in the title, or `BREAKING CHANGE:` in
+  the body) is rejected on **both** `main` and `next` (it belongs on the major
+  line).
+
+Target the wrong branch and the check fails with a message like
+`PR title is a 'feat' — features target 'next', not 'main'.`; fix it by
+retitling the PR or changing its base.
+
+> **Before the 1.0.0 cut**, the `next` and major lines don't exist yet, so
+> **everything targets `main`** and the routing check self-disables (it stays
+> dormant while there is no `next` branch). Once the lines exist, promotion and
+> sync branches — `next`, a major line (e.g. `2.x`), and `sync/*` — are exempt
+> so release PRs are never blocked.
+
 ## Opening a pull request
 
-1. Branch off `main`: `git checkout -b fix/button-focus-ring`.
+1. Branch off the right base for your change (see
+   [Choosing the base branch](#choosing-the-base-branch)) — for a fix that's
+   `main`: `git checkout -b fix/button-focus-ring main`.
 2. Make your change, following the conventions above.
 3. Before pushing, make sure the checklist passes:
    - [ ] `pnpm lint` is clean
@@ -619,21 +680,36 @@ everything that isn't. Write messages for the changelog reader.
    - [ ] intentional visual changes: snapshots updated (`test:visual:update`
          locally and/or the `update-screenshots` label)
    - [ ] docs updated if you changed a public API
-4. Push to your fork and open a PR against `mittwald/flow`'s `main` branch.
+4. Push to your fork and open a PR against `mittwald/flow`, targeting the base
+   branch you chose in step 1.
 
 CI (`.github/workflows/test.yml`) runs lint, unit tests, and browser tests
 (WebKit) on every PR, and verifies all generated code is committed. A preview
 deployment of docs + Storybook is built for each PR so reviewers can see your
 changes live.
 
-PRs are **squash-merged**, so the PR title becomes the commit on `main` — give
-it a Conventional-Commits-style title.
+PRs are **squash-merged**, so the **PR title becomes the release commit** — it
+must be a valid Conventional Commit. `.github/workflows/commit-guard.yml` lints
+both the title and that it matches the base branch (see
+[Choosing the base branch](#choosing-the-base-branch)).
 
 ## Releases
 
-You don't need to do anything to release. When a PR is merged into `main`,
-Lerna-Lite (via `.github/workflows/publish.yml`) versions the packages based on
-the Conventional Commits, generates the changelogs, and publishes to npm.
+You don't need to do anything to release. Flow uses **fixed versioning** — all
+`@mittwald/flow-*` packages share one version — and Lerna-Lite derives the bump
+and changelog from your Conventional Commits.
+
+- A `fix:` merged into `main` publishes to npm under dist-tag `latest` (via
+  `.github/workflows/publish.yml`) and is forward-merged into `next`.
+- Features accumulate on `next`, published continuously as `X.Y.0-next.N` under
+  dist-tag `next`. A maintainer promotes them to a stable Minor — with a curated
+  changelog — via a `next → main` Release-PR, when there's enough to be worth
+  releasing.
+
+See [RFC #2711](https://github.com/mittwald/flow/issues/2711) for the full model
+and [ADR 0004](docs/adr/0004-forward-merge-main-into-next.md) for the
+forward-merge mechanics. (The `next` line and its publishing go live with the
+1.0.0 cut; until then every merge into `main` releases as it does today.)
 
 ## Getting help
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Contributing
+
+The contributor guide lives in **[CONTRIBUTE.md](CONTRIBUTE.md)**.
+
+This file is a thin pointer so GitHub surfaces the guidelines automatically (the
+"Contributing guidelines" link on new issues and pull requests) — all content is
+maintained in [CONTRIBUTE.md](CONTRIBUTE.md).


### PR DESCRIPTION
Adds contributor documentation for the 1.0.0 release model (RFC #2711, tracking #2738): how to choose a base branch, and a PR template that nudges the right Conventional-Commit title.

## What this adds
- **`CONTRIBUTE.md`** — new **"Choosing the base branch"** section documenting the routing model: `fix:`/`docs:`/`chore:`/… → `main`; `feat:` → `next`; breaking (`feat!:`/`BREAKING CHANGE`) → the major line. Includes a "The routing is enforced" subsection describing exactly what `.github/workflows/commit-guard.yml` does (lints the **PR title** because the repo squash-merges; self-gating/dormant until `next` exists; `next`/major-line/`sync/*` exemptions). Cross-links RFC #2711, ADR 0004, ADR 0005.
- **`.github/PULL_REQUEST_TEMPLATE.md`** (new) — concise: What & why, a base-branch/routing reminder with the Conventional-Commit-title nudge, and a short checklist (title matches base, lint/test, generated code committed, both locales, docs/snapshots).
- **`CONTRIBUTING.md`** (new) — thin pointer to `CONTRIBUTE.md` so GitHub auto-surfaces the "Contributing guidelines" link (and reconciles RFC #2711's wording).

## Accurate to today's enforced reality
Both the guide and the PR template carry an explicit caveat that **before the 1.0.0 cut** the `next`/major lines don't exist yet, so everything targets `main` and the routing guard stays dormant.

## Validation
`prettier --check` on all three files (green). `.github/PULL_REQUEST_TEMPLATE.md` is not in `.prettierignore`, so it's correctly subject to the format gate.

Part of #2738.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
