### PR TITLE
fix(ci): stop orphaning preview apps for fast-merged PRs

### DIFF
--- a/.github/workflows/build-previews.yml
+++ b/.github/workflows/build-previews.yml
@@ -9,8 +9,11 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+# Shared with cleanup-previews.yml: closing a PR queues the cleanup in this same
+# group and cancels any still-running build+deploy for that PR, so the deploy
+# can no longer create preview resources after the cleanup has already run.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: preview-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cleanup-previews.yml
+++ b/.github/workflows/cleanup-previews.yml
@@ -4,9 +4,26 @@ on:
   pull_request:
     types:
       - closed
+  # Manual escape hatch to clean up an orphaned preview — e.g. one left behind by
+  # a PR that was merged before its deploy finished (see the concurrency note).
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number whose orphaned preview should be cleaned up"
+        required: true
+        type: string
 
 permissions:
   contents: read
+
+# Shared with build-previews.yml: queuing this cleanup cancels a still-running
+# build+deploy for the same PR, closing the race where a deploy finishes after
+# the cleanup and orphans the preview resources.
+concurrency:
+  group:
+    preview-${{ github.event.pull_request.number ||
+    github.event.inputs.pr_number }}
+  cancel-in-progress: true
 
 jobs:
   cleanup:
@@ -31,7 +48,9 @@ jobs:
 
       - name: Cleanup preview environment
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER:
+            ${{ github.event.pull_request.number || github.event.inputs.pr_number
+            }}
           MITTWALD_PROJECT_ID: ${{ secrets.MITTWALD_PROJECT_ID }}
           MITTWALD_API_TOKEN: ${{ secrets.MITTWALD_API_TOKEN }}
         run: |

--- a/dev/deploy-review.ts
+++ b/dev/deploy-review.ts
@@ -109,6 +109,53 @@ class ReviewDeployer {
     return `${imageType.toUpperCase()}/PR-${this.prNumber}`;
   }
 
+  // Guard against a race with the cleanup workflow: the build+deploy takes
+  // several minutes, but `cleanup-previews.yml` fires the moment a PR closes.
+  // A PR merged before its deploy finishes gets cleaned up first (finds
+  // nothing), then this deploy would create preview resources the cleanup can
+  // never reach again — orphaning them forever. So bail out if the PR is no
+  // longer open. Fail open: only skip when we can positively confirm it's
+  // closed, otherwise keep deploying.
+  async isPullRequestClosed(): Promise<boolean> {
+    const token = process.env.GITHUB_TOKEN;
+    const repo = process.env.GITHUB_REPOSITORY;
+    if (!token || !repo) {
+      console.warn(
+        "⚠️  GITHUB_TOKEN or GITHUB_REPOSITORY not set — skipping the PR-state guard; proceeding with deployment.",
+      );
+      return false;
+    }
+
+    const [owner, repoName] = repo.split("/");
+    try {
+      const response = await fetch(
+        `https://api.github.com/repos/${owner}/${repoName}/pulls/${this.prNumber}`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: "application/vnd.github.v3+json",
+          },
+        },
+      );
+
+      if (!response.ok) {
+        console.warn(
+          `⚠️  Could not fetch PR #${this.prNumber} state (${response.status} ${response.statusText}); proceeding with deployment.`,
+        );
+        return false;
+      }
+
+      const pr = (await response.json()) as { state: string };
+      return pr.state !== "open";
+    } catch (error) {
+      console.warn(
+        `⚠️  Failed to check PR #${this.prNumber} state; proceeding with deployment.`,
+        error,
+      );
+      return false;
+    }
+  }
+
   async getServices(): Promise<MittwaldService[]> {
     console.log("📋 Fetching existing services...");
 
@@ -368,6 +415,13 @@ ${this.images.map((img) => `- ${img.imageType}: \`${img.name}\``).join("\n")}
   async deploy(): Promise<void> {
     try {
       console.log("🚀 Starting preview deployment process...\n");
+
+      if (await this.isPullRequestClosed()) {
+        console.log(
+          `⏭️  PR #${this.prNumber} is already closed/merged — skipping preview deployment to avoid orphaned resources the cleanup can no longer reach.`,
+        );
+        return;
+      }
 
       console.log(`📦 Parsed images (${this.images.length}):`);
       this.images.forEach((img) => {


### PR DESCRIPTION
## Problem

Review previews (docs + Storybook) are not cleaned up when a PR is closed — but only for **fast-merged PRs**. Confirmed orphaned right now: `pr-2757`, `pr-2752`, `pr-2750` (docs + storybook service + ingress each).

### Root cause: a race between the two preview workflows

- `build-previews.yml` starts on PR open/push. The Docker build takes **~10 min**, and the mittwald services/ingresses are created only at the very end, in the `deploy` job.
- `cleanup-previews.yml` fires **immediately** on the `closed` event.

If a PR is **merged before its deploy finishes**, the cleanup runs first, finds nothing (`ℹ️ No services found to delete`), and *then* the deploy creates the preview resources. Since the PR never gets another `closed` event, those resources are orphaned forever.

Evidence:

| PR | merged | cleanup ran | deploy finished |
|----|--------|-------------|-----------------|
| #2757 | 11:58:18 | 11:58:51 → nothing found | **11:59:35** |
| #2752 | 08:56:47 | 08:57:28 → nothing found | **09:01:56** |
| #2750 | 06:53:18 | 06:53:56 → nothing found | **06:56:41** |

Long-lived PRs finish their deploy before the merge, so cleanup finds & deletes correctly — which is why this only bites fast merges.

## Fix

- **Deploy guard** (`dev/deploy-review.ts`): before creating any resources, check whether the PR is still open via the GitHub API. If it's already `closed`/`merged`, skip the deploy. Fail-open — only skips on a positive "closed" confirmation, otherwise deploys as before. This is the timing-independent safety net.
- **Shared concurrency group**: `build-previews.yml` and `cleanup-previews.yml` now share `preview-<pr-number>` with `cancel-in-progress`. Closing a PR queues the cleanup in that group and cancels the still-running build+deploy — saving ~10 min of compute and shrinking the race window to nothing.
- **Manual cleanup** (`cleanup-previews.yml`): a `workflow_dispatch` input `pr_number` to remove already-orphaned previews.

## Cleaning up the existing orphans

After merge, run:

```bash
gh workflow run cleanup-previews.yml -f pr_number=2757
gh workflow run cleanup-previews.yml -f pr_number=2752
gh workflow run cleanup-previews.yml -f pr_number=2750
```

## Notes

- Prettier ✓. New TS logic type-checks clean (the `process` complaints in a standalone `tsc` run are just missing `@types/node`; the script runs via `tsx`).
- Out of scope, unverified: `cleanup-review.ts` "deletes" services via a stack `PATCH` with `{}` (ingresses use a real `DELETE`). Logs report success and cleanup works for slow-merged PRs, but whether `{}` truly deletes vs. no-ops couldn't be verified without an API token. Happy to look into it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)