### PR TITLE
ci: install the Playwright browsers pinned by the workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint . && stylelint '**/*.{css,scss}' && pnpm format:check",
     "test": "nx run-many --targets=test:unit,test:compile",
     "test:browser": "nx run-many --targets=test:browser,test:e2e,test:visual",
-    "test:browser:prepare": "pnpx playwright install --with-deps firefox webkit",
+    "test:browser:prepare": "pnpm exec playwright install --with-deps firefox webkit",
     "test:visual": "nx run-many --targets=test:visual",
     "watch": "nx watch --projects=\"$@\" --includeDependentProjects -- run nx build:deps \"$@\""
   },


### PR DESCRIPTION
## What & why

**All browser tests in CI are currently broken** — the last green `test` run was
on 2026-07-31, everything since fails before a single test executes:

```
Error: browserType.launch: Executable doesn't exist at
/home/runner/.cache/ms-playwright/webkit-2311/pw_run.sh
```

Cause: `test:browser:prepare` installed the browsers through **`pnpx`**, which
resolves the *latest* Playwright from the registry instead of the version pinned
in the lockfile (`playwright@^1.61.1`). A Playwright release landed after
2026-07-31, so the prepare step now deletes the builds the workspace needs and
downloads its own (from the `update-screenshots` job log):

```
Removing unused browser at .../firefox-1532
Removing unused browser at .../webkit-2311
Firefox 153.0 (playwright firefox v1538) downloaded to .../firefox-1538
WebKit 26.5 (playwright webkit v2336) downloaded to .../webkit-2336
```

Vitest launches the browsers of the **pinned** Playwright (`firefox-1532` /
`webkit-2311`), which are now gone. It also survives across runs, because the
broken browser cache gets stored under the unchanged
`playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}` key.

Running the install through `pnpm exec` uses the workspace's Playwright — it is a
direct dev dependency — so it installs exactly the builds Vitest launches:

```
$ pnpm exec playwright install firefox webkit --dry-run
  Install location:    …/ms-playwright/firefox-1532
  Install location:    …/ms-playwright/ffmpeg-1011
  Install location:    …/ms-playwright/webkit-2311
```

Affects `test.yml` (browser tests), `update-screenshots.yml`,
`test-visual-label.yml` and `test-visual-scheduled.yml` — they all call this
script.

## Notes

- Caches written by the broken runs still contain the wrong builds. With this
  fix the prepare step repairs the cache on the next run, so no manual cache
  purge is needed.
- Found while working on #2766, whose `update-screenshots` run hit this. That PR
  carries the same one-line change so its baselines can be generated before this
  lands; it disappears from its diff once this is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
