### PR TITLE
fix(Section): collapse sections whose content renders nothing

### DIFF
--- a/packages/components/src/components/Section/Section.module.scss
+++ b/packages/components/src/components/Section/Section.module.scss
@@ -11,6 +11,16 @@
     row-gap: var(--section--spacing);
   }
 
+  /* Children that render nothing still leave the element behind — the guard in
+     Section.tsx only sees the child, not its output (a boundary returning null,
+     an empty fragment, a map over an empty array). Collapse it so it neither
+     draws its own separator nor claims section-to-section spacing, while
+     staying in the sibling chain so the next section keeps exactly one
+     separator. */
+  &:empty {
+    display: none;
+  }
+
   + .section {
     margin-block-start: var(--section--section-to-section-spacing);
   }

--- a/packages/components/src/components/Section/stories/EdgeCases.stories.tsx
+++ b/packages/components/src/components/Section/stories/EdgeCases.stories.tsx
@@ -8,6 +8,10 @@ import { action } from "storybook/actions";
 import { TextField } from "@/components/TextField";
 import { Label } from "@/components/Label";
 import { ActionGroup } from "@/components/ActionGroup";
+import { Text } from "@/components/Text";
+import { Link } from "@/components/Link";
+import { dummyText } from "@/lib/dev/dummyText";
+import type { FC } from "react";
 
 const meta: Meta<typeof Section> = {
   ...defaultStories,
@@ -16,6 +20,37 @@ const meta: Meta<typeof Section> = {
 export default meta;
 
 type Story = StoryObj<typeof Section>;
+
+/**
+ * Stands in for a boundary, permission gate or empty list — a child that is
+ * present but renders nothing.
+ */
+const RendersNothing: FC = () => null;
+
+/**
+ * The middle section renders no content and collapses, so the sections around
+ * it are separated by exactly one line.
+ */
+export const EmptyContentBetweenSections: Story = {
+  parameters: {
+    controls: { disable: true },
+  },
+  render: (props) => (
+    <>
+      <Section {...props}>
+        <Heading>Rebel Alliance Briefing</Heading>
+        <Text>{dummyText.medium}</Text>
+      </Section>
+      <Section {...props}>
+        <RendersNothing />
+      </Section>
+      <Section {...props}>
+        <Heading>Helpful Transmissions</Heading>
+        <Link href="#">Join the Alliance</Link>
+      </Section>
+    </>
+  ),
+};
 
 export const WithForm: Story = {
   parameters: {

--- a/packages/remote-react-components/src/tests/visual/Section.browser.test.tsx
+++ b/packages/remote-react-components/src/tests/visual/Section.browser.test.tsx
@@ -3,6 +3,12 @@ import { useState, type FC } from "react";
 import { test } from "vitest";
 import { page, userEvent } from "vitest/browser";
 
+/**
+ * Stands in for a boundary, permission gate or empty list — a child that is
+ * present but renders nothing.
+ */
+const RendersNothing: FC = () => null;
+
 test.each(testEnvironments)(
   "Section (%s)",
   async ({
@@ -66,6 +72,12 @@ test.each(testEnvironments)(
             </Text>
             <Heading level={3}>Sub-Heading</Heading>
             <Link>Link</Link>
+          </Section>
+          {/* Must collapse: a section that renders no content may neither draw
+              its own separator nor claim section-to-section spacing, so the
+              section below it keeps exactly one separator. */}
+          <Section>
+            <RendersNothing />
           </Section>
           <Section>
             <Header>


### PR DESCRIPTION
## What

A `Section` whose children render nothing left a DOM-empty `<section>` behind. Because the separator is a `border-block-start` on the *following* sibling, that invisible element both received a line from its predecessor **and** handed the next section another one — two separators with a band of blank space between them.

Empty sections now collapse with `display: none`. They stay in the sibling chain, so the following section keeps exactly one separator and the rendering becomes pixel-identical to the section not being there at all.

Closes #2768 — reported from mStudio, where the empty API-keys area on *Organisation → AI Hosting* showed the doubled line. The consumer-side workaround (`.flow--section:empty { display: none }`) can be removed once this ships.

## Why in CSS and not in `Section.tsx`

`Section` already guards `if (!children) return null`, but that only inspects the child *element*, never its output. A boundary returning `null`, an empty fragment, or `items.map()` over an empty array are all truthy children that produce no DOM — invisible to React from the outside. The `:empty` selector catches every one of them uniformly, and it is an established pattern here (Heading, Navigation, ColumnLayout, Table, RadioGroup, CheckboxGroup).

No `@flr-generate` prop changed, so there is nothing to regenerate, no MIGRATION entry and no codemod.

## Verification

- **Visual test** — [Section.browser.test.tsx](packages/remote-react-components/src/tests/visual/Section.browser.test.tsx) gains a section whose child renders nothing, between two filled ones. Runs in both `Local` and `Remote`; both reproduce the bug and both are fixed.
- **Red/green proved locally** (webkit): with the fix the test matches the *existing* baselines; with the fix reverted both environments fail at 17392 px / ratio 0.02, the diff showing the phantom separator plus the downward shift of the following section.
- **No baseline update needed** — that is the nice consequence of the fix: an empty section now renders identically to no section. Hence `run-visual-tests` (verify-only) rather than `update-screenshots`.
- **Full visual suite** (webkit, all 84 files): 24 failures on unmodified `main` and 24 with this change — the pre-existing stale `-darwin` baselines, unchanged by this PR. (Two `ActionGroup` snapshots have no `-darwin` baseline at all; a local run creates them. Not committed here.)
- `pnpm lint`, `pnpm nx test:unit components` (156 tests), `test:compile` for both packages, and no generated-code drift.

## Known limitation

An empty section in **first** position still gives its follower a top separator with nothing above it. Suppressing that requires the nearest preceding *visible* section — `~` instead of `+` — which would regress the Alert-before-Section layout that [Alert.module.scss](packages/components/src/components/Alert/Alert.module.scss) relies on (a Section after an Alert gets spacing but no line). Left out deliberately; worth its own issue if it shows up in practice.

## Review notes

- One story added (`EmptyContentBetweenSections` in Section edge cases) so the behaviour is inspectable in Storybook.
- The `docs/adr` and release-model files are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)