### PR TITLE
feat(bundle): declare sideEffect config to all packages for optimized tree-shaking

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -5,6 +5,10 @@
   "description": "A React implementation of Flow, mittwald’s design system",
   "homepage": "https://flow.mittwald.de",
   "repository": "https://github.com/mittwald/flow",
+  "sideEffects": [
+    "**/*.css",
+    "**/*.scss"
+  ],
   "exports": {
     ".": {
       "types": "./dist/types/index/default.d.ts",

--- a/packages/icons-pro/package.json
+++ b/packages/icons-pro/package.json
@@ -5,6 +5,7 @@
   "description": "Pro iconset for Flow, mittwald’s design system",
   "homepage": "https://flow.mittwald.de",
   "repository": "https://github.com/mittwald/flow",
+  "sideEffects": false,
   "exports": {
     ".": {
       "types": "./dist/types/components/index.d.ts",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -5,6 +5,7 @@
   "description": "Default iconset for Flow, mittwald’s design system",
   "homepage": "https://flow.mittwald.de",
   "repository": "https://github.com/mittwald/flow",
+  "sideEffects": false,
   "exports": {
     ".": {
       "types": "./dist/types/components/index.d.ts",

--- a/packages/remote-react-components/package.json
+++ b/packages/remote-react-components/package.json
@@ -5,6 +5,10 @@
   "description": "React components that can be used in a remote environment",
   "homepage": "https://flow.mittwald.de",
   "repository": "https://github.com/mittwald/flow",
+  "sideEffects": [
+    "**/*.css",
+    "**/*.scss"
+  ],
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",


### PR DESCRIPTION
Our published packages don't set `sideEffects` in `package.json`. Without it, bundlers can't prove the barrel (`export *`) modules are pure, so a consumer importing only a few components or icons results into whole package dependency gets dragged into the build output. 

https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free

This adds the `sideEffects` config to the package configs: 

- `icons`, `icons-pro` → `false` (pure re-export barrels, no CSS) 
- `components`, `remote-react-components` → `["**/*.css","**/*.scss"]` (guards the stylesheets) 