### PR TITLE
fix(DocsSearch): restore visible focus ring on search results

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,16 @@ apps/docs/out
 node_modules
 dist
 
+# Nested git worktrees for background agent sessions (Claude Code). Each is a
+# full checkout of a different branch — formatting them here just reformats
+# someone else's in-progress work and bloats format:check with unrelated diffs.
+.claude/worktrees
+
+# Per-machine Claude Code settings (permissions etc.), can exist in any
+# directory Claude Code was scoped to — always personal/local, never meant to
+# be formatted or committed.
+**/settings.local.json
+
 # Cross-version HTML-output references are exact snapshots compared byte-for-byte
 # by toMatchFileSnapshot; reformatting them would break the comparison.
 packages/remote-react-components/e2e/cross-version/__html__

--- a/apps/docs/src/app/_components/layout/DocsSearch/DocsSearch.module.scss
+++ b/apps/docs/src/app/_components/layout/DocsSearch/DocsSearch.module.scss
@@ -34,6 +34,12 @@
   color: inherit;
   cursor: pointer;
   scroll-margin-block: var(--size-px--s);
+  outline: var(--focus--outline-color) none var(--focus--outline-width);
+  outline-offset: calc(var(--focus--outline-offset) * -1);
+}
+
+.result:focus-visible {
+  outline-style: solid;
 }
 
 .result:hover,


### PR DESCRIPTION
Keyboard focus was hidden behind the search overlay while navigating results with arrow keys.

<!--
  Thanks for contributing to Flow! Full guide:
  https://github.com/mittwald/flow/blob/main/CONTRIBUTE.md
-->

## What & why

<!-- What does this change do, and why? Link related issues (e.g. Closes #123). -->

## Base branch & title

This repo **squash-merges**, so your **PR title becomes the release commit** —
it must be a valid [Conventional Commit](https://www.conventionalcommits.org/)
(e.g. `fix(Button): correct focus ring`). A CI guard lints the title _and_ that
it matches the base branch. Pick the base by change type
([details](https://github.com/mittwald/flow/blob/main/CONTRIBUTE.md#choosing-the-base-branch)):

- `fix:` / `docs:` / `chore:` / `refactor:` / … → base **`main`**
- `feat:` (new feature) → base **`next`**
- Breaking change (`feat!:` / `BREAKING CHANGE:`) → base **the major line**

> Before the 1.0.0 cut the `next` / major lines don't exist yet, so everything
> targets `main` and the routing guard stays dormant.

## Checklist

- [ ] PR title is a Conventional Commit and matches the base branch above
- [ ] `pnpm lint` is clean and `pnpm affected:test` passes (browser tests if
      behavior changed)
- [ ] **Generated code is committed** (`git diff` is empty after the relevant
      `build:*` targets)
- [ ] User-facing strings added to **both** `de-DE` and `en-US` locale files
- [ ] Docs updated if a public API changed; intentional visual changes get
      updated snapshots / the `update-screenshots` label
