### PR TITLE
revert(PasswordCreationField): move PasswordCreationField to integrations

### DIFF
--- a/apps/docs/src/content/03-patterns/01-patterns/anlegeprozess/examples/install-app.tsx
+++ b/apps/docs/src/content/03-patterns/01-patterns/anlegeprozess/examples/install-app.tsx
@@ -15,8 +15,8 @@ import {
   Section,
   Select,
   TextField,
+  PasswordCreationField,
 } from "@mittwald/flow-react-components";
-import { PasswordCreationField } from "@mittwald/flow-react-components/password-tools";
 
 <ModalTrigger>
   <Button color="accent">Beispiel öffnen</Button>

--- a/apps/docs/src/content/04-components/form-controls/password-creation-field/examples/buttons.tsx
+++ b/apps/docs/src/content/04-components/form-controls/password-creation-field/examples/buttons.tsx
@@ -2,8 +2,8 @@ import {
   Button,
   Label,
   IconSshKey,
+  PasswordCreationField,
 } from "@mittwald/flow-react-components";
-import { PasswordCreationField } from "@mittwald/flow-react-components/password-tools";
 import { useState } from "react";
 export default () => {
   const [password, setPassword] = useState("");

--- a/apps/docs/src/content/04-components/form-controls/password-creation-field/examples/copyButton.tsx
+++ b/apps/docs/src/content/04-components/form-controls/password-creation-field/examples/copyButton.tsx
@@ -1,8 +1,8 @@
 import {
   CopyButton,
   Label,
+  PasswordCreationField,
 } from "@mittwald/flow-react-components";
-import { PasswordCreationField } from "@mittwald/flow-react-components/password-tools";
 
 export default () => {
   return (

--- a/apps/docs/src/content/04-components/form-controls/password-creation-field/examples/default.tsx
+++ b/apps/docs/src/content/04-components/form-controls/password-creation-field/examples/default.tsx
@@ -1,5 +1,7 @@
-import { Label } from "@mittwald/flow-react-components";
-import { PasswordCreationField } from "@mittwald/flow-react-components/password-tools";
+import {
+  Label,
+  PasswordCreationField,
+} from "@mittwald/flow-react-components";
 import { useState } from "react";
 
 export default () => {

--- a/apps/docs/src/content/04-components/form-controls/password-creation-field/examples/disabled.tsx
+++ b/apps/docs/src/content/04-components/form-controls/password-creation-field/examples/disabled.tsx
@@ -1,5 +1,7 @@
-import { Label } from "@mittwald/flow-react-components";
-import { PasswordCreationField } from "@mittwald/flow-react-components/password-tools";
+import {
+  Label,
+  PasswordCreationField,
+} from "@mittwald/flow-react-components";
 
 <PasswordCreationField isDisabled>
   <Label>Password</Label>

--- a/apps/docs/src/content/04-components/form-controls/password-creation-field/examples/form.tsx
+++ b/apps/docs/src/content/04-components/form-controls/password-creation-field/examples/form.tsx
@@ -8,13 +8,13 @@ import { sleep } from "@/content/04-components/actions/action/examples/lib";
 import {
   Label,
   Section,
+  PasswordCreationField,
 } from "@mittwald/flow-react-components";
 import {
-  PasswordCreationField,
-  generatePasswordCreationFieldValidation,
+  usePasswordCreationFieldValidation,
   Policy,
   RuleType,
-} from "@mittwald/flow-react-components/password-tools";
+} from "@mittwald/flow-react-components/mittwald-password-tools-js";
 
 export default () => {
   const customPolicy = Policy.fromDeclaration({
@@ -34,6 +34,8 @@ export default () => {
     },
   });
   const Field = typedField(form);
+  const validatePassword =
+    usePasswordCreationFieldValidation(customPolicy);
 
   return (
     <Section>
@@ -42,10 +44,7 @@ export default () => {
           name="password"
           rules={{
             required: true,
-            validate:
-              generatePasswordCreationFieldValidation(
-                customPolicy,
-              ),
+            validate: validatePassword,
           }}
         >
           <PasswordCreationField

--- a/apps/docs/src/content/04-components/form-controls/password-creation-field/examples/rules.tsx
+++ b/apps/docs/src/content/04-components/form-controls/password-creation-field/examples/rules.tsx
@@ -1,10 +1,12 @@
-import { Label } from "@mittwald/flow-react-components";
-import { PasswordCreationField } from "@mittwald/flow-react-components/password-tools";
+import {
+  PasswordCreationField,
+  Label,
+} from "@mittwald/flow-react-components";
 
 import {
   Policy,
   RuleType,
-} from "@mittwald/flow-react-components/password-tools";
+} from "@mittwald/flow-react-components/mittwald-password-tools-js";
 import { useState } from "react";
 
 export default () => {

--- a/apps/remote-dom-demo/src/app/remote/react-hook-form/page.tsx
+++ b/apps/remote-dom-demo/src/app/remote/react-hook-form/page.tsx
@@ -31,7 +31,7 @@ import {
   Policy,
   generatePasswordCreationFieldValidation,
   RuleType,
-} from "@mittwald/flow-react-components/password-tools";
+} from "@mittwald/flow-react-components/mittwald-password-tools-js";
 import { useForm } from "react-hook-form";
 
 const customPolicy = Policy.fromDeclaration({

--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -158,7 +158,7 @@ Remote generation details:
 Never break a shipped API — keep the old path working and warn at runtime with
 `useWarnDeprecation` (from `DeprecationWarningProvider`). This covers every kind
 of deprecated entry point: a prop, a whole component, a hook, or an integration
-export (`nextjs`, `password-tools`).
+export (`nextjs`, `mittwald-password-tools-js`).
 
 ```tsx
 const warnDeprecation = useWarnDeprecation();

--- a/packages/components/MIGRATION.md
+++ b/packages/components/MIGRATION.md
@@ -1,31 +1,5 @@
 # Migrations
 
-## From version `0.2.0-alpha.908` to `>=0.2.0-alpha.909`
-
-### PasswordCreationField moved to dedicated export entry
-
-`PasswordCreationField` is no longer exported from
-`@mittwald/flow-react-components`.
-
-Use `@mittwald/flow-react-components/password-tools` instead:
-
-```diff
-- import { PasswordCreationField } from "@mittwald/flow-react-components";
-+ import { PasswordCreationField } from "@mittwald/flow-react-components/password-tools";
-```
-
-### Use Codemod
-
-```shell
-npx jscodeshift \
-  -t https://raw.githubusercontent.com/mittwald/flow/refs/heads/main/packages/codemods/src/transforms/flowAlphaPasswordCreationField.ts \
-  --parser tsx \
-  src
-```
-
-Replace `src` with your sources folder. If you do not use TypeScript in your
-project, use `--parser jsx`.
-
 ## From version `0.2.0-alpha.779` to `>=0.2.0-alpha.780`
 
 ### CartesianChart

--- a/packages/components/dev/remote-components-generator/lib/componentModulePathOf.ts
+++ b/packages/components/dev/remote-components-generator/lib/componentModulePathOf.ts
@@ -1,15 +1,6 @@
 import type { ComponentDoc } from "react-docgen-typescript";
 
-const componentExportPathMap: Record<string, string> = {
-  PasswordCreationField: "/password-tools",
-};
-
 export const componentModulePathOf = (c: ComponentDoc) => {
-  const mappedPath = componentExportPathMap[c.displayName];
-  if (mappedPath) {
-    return mappedPath;
-  }
-
   const [, integrationsPath, integrationComponent] =
     /.*src\/integrations\/(.*?)\/components\/(.*?)\/.*/.exec(c.filePath) ?? [];
 

--- a/packages/components/dev/status-registry/exportEntries.test.ts
+++ b/packages/components/dev/status-registry/exportEntries.test.ts
@@ -7,7 +7,7 @@ test.each([
   [".", `${PKG}`],
   ["./nextjs", `${PKG}/nextjs`],
   ["./flr-universal", `${PKG}/flr-universal`],
-  ["./password-tools", `${PKG}/password-tools`],
+  ["./mittwald-password-tools-js", `${PKG}/mittwald-password-tools-js`],
 ] as const)("specifierOf(%s) === %s", (key, expected) => {
   expect(specifierOf(key, PKG)).toBe(expected);
 });
@@ -18,6 +18,6 @@ test("STATUS_EXPORT_ENTRIES covers the five component-bearing entries only", () 
     "./flr-universal",
     "./nextjs",
     "./react-hook-form",
-    "./password-tools",
+    "./mittwald-password-tools-js",
   ]);
 });

--- a/packages/components/dev/status-registry/exportEntries.ts
+++ b/packages/components/dev/status-registry/exportEntries.ts
@@ -34,7 +34,7 @@ export const STATUS_EXPORT_ENTRIES: StatusExportEntry[] = [
     sourceRoot: "src/integrations/react-hook-form",
   },
   {
-    key: "./password-tools",
+    key: "./mittwald-password-tools-js",
     indexFile: "src/integrations/@mittwald/password-tools-js/index.ts",
     sourceRoot: "src/integrations/@mittwald/password-tools-js",
   },

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -26,9 +26,9 @@
       "types": "./dist/types/integrations/react-hook-form/index.d.ts",
       "import": "./dist/js/react-hook-form.mjs"
     },
-    "./password-tools": {
+    "./mittwald-password-tools-js": {
       "types": "./dist/types/integrations/@mittwald/password-tools-js/index.d.ts",
-      "import": "./dist/js/password-tools.mjs"
+      "import": "./dist/js/@mittwald/password-tools-js.mjs"
     },
     "./all.css": "./dist/css/all.css",
     "./all-layered.css": "./dist/css/all-layered.css",

--- a/packages/components/src/components/public.ts
+++ b/packages/components/src/components/public.ts
@@ -80,6 +80,7 @@ export * from "@/components/NumberField";
 export * from "@/components/Option";
 export * from "@/components/Overlay";
 export * from "@/components/OverlayTrigger";
+export * from "@/components/PasswordCreationField";
 export * from "@/components/Popover";
 export * from "@/components/ProgressBar";
 export * from "@/components/RadioGroup";

--- a/packages/components/src/integrations/@mittwald/password-tools-js/index.ts
+++ b/packages/components/src/integrations/@mittwald/password-tools-js/index.ts
@@ -12,6 +12,5 @@ export {
 export type * from "@mittwald/password-tools-js/generator";
 export { Generator } from "@mittwald/password-tools-js/generator";
 
-export * from "@/components/PasswordCreationField";
 export * from "./defaultPasswordCreationPolicy";
 export * from "./usePasswordCreationFieldValidation";

--- a/packages/components/src/integrations/@mittwald/password-tools-js/passwordCreationFieldExport.test-types.ts
+++ b/packages/components/src/integrations/@mittwald/password-tools-js/passwordCreationFieldExport.test-types.ts
@@ -1,5 +1,2 @@
 /* eslint-disable unused-imports/no-unused-imports -- these imports only exist to type-assert what the entrypoints (re-)export. */
-import type { PasswordCreationFieldProps as ignoredPasswordCreationFieldPropsFromIntegration } from "@/integrations/@mittwald/password-tools-js";
-
-// @ts-expect-error PasswordCreationFieldProps is not exported from the default entry.
-import type { PasswordCreationFieldProps as ignoredPasswordCreationFieldPropsFromDefault } from "@/index/default";
+import type { PasswordCreationFieldProps as ignoredPasswordCreationFieldPropsFromIntegration } from "@/components/PasswordCreationField";

--- a/packages/components/src/status/component-status.json
+++ b/packages/components/src/status/component-status.json
@@ -315,6 +315,10 @@
     "level": "stable",
     "isNew": false
   },
+  "@mittwald/flow-react-components#PasswordCreationField": {
+    "level": "stable",
+    "isNew": false
+  },
   "@mittwald/flow-react-components#Popover": {
     "level": "stable",
     "isNew": false
@@ -502,10 +506,6 @@
     "deprecationNotice": "Use RouterProvider instead"
   },
   "@mittwald/flow-react-components/nextjs#RouterProvider": {
-    "level": "stable",
-    "isNew": false
-  },
-  "@mittwald/flow-react-components/password-tools#PasswordCreationField": {
     "level": "stable",
     "isNew": false
   },

--- a/packages/components/src/status/componentStatus.ts
+++ b/packages/components/src/status/componentStatus.ts
@@ -15,7 +15,7 @@ export type FlowExportEntry =
   | "flr-universal"
   | "nextjs"
   | "react-hook-form"
-  | "password-tools";
+  | "mittwald-password-tools-js";
 
 const PACKAGE_NAME = "@mittwald/flow-react-components";
 

--- a/packages/components/vite.build.config.ts
+++ b/packages/components/vite.build.config.ts
@@ -24,7 +24,7 @@ export default mergeConfig(
           "flr-universal": "./src/index/flr-universal.ts",
           nextjs: "./src/integrations/nextjs/index.ts",
           "react-hook-form": "./src/integrations/react-hook-form/index.ts",
-          "password-tools":
+          "@mittwald/password-tools-js":
             "./src/integrations/@mittwald/password-tools-js/index.ts",
           globals: "./src/styles/index.ts",
         },

--- a/packages/remote-core/src/serialization/serializers/passwordPolicy.ts
+++ b/packages/remote-core/src/serialization/serializers/passwordPolicy.ts
@@ -2,7 +2,7 @@ import { Serializer } from "@/serialization/Serializer";
 import {
   Policy,
   type PolicyDeclaration,
-} from "@mittwald/flow-react-components/password-tools";
+} from "@mittwald/flow-react-components/mittwald-password-tools-js";
 
 export const passwordPolicySerializer = new Serializer<
   Policy,

--- a/packages/remote-elements/src/auto-generated/RemotePasswordCreationFieldElement.ts
+++ b/packages/remote-elements/src/auto-generated/RemotePasswordCreationFieldElement.ts
@@ -1,8 +1,8 @@
 /* prettier-ignore */
 /* This file is auto-generated with the remote-components-generator */
 import { FlowRemoteElement } from "@/lib/FlowRemoteElement";
-import type { PasswordCreationFieldProps as RemotePasswordCreationFieldElementProps } from "@mittwald/flow-react-components/password-tools";
-export type { PasswordCreationFieldProps as RemotePasswordCreationFieldElementProps } from "@mittwald/flow-react-components/password-tools";
+import type { PasswordCreationFieldProps as RemotePasswordCreationFieldElementProps } from "@mittwald/flow-react-components";
+export type { PasswordCreationFieldProps as RemotePasswordCreationFieldElementProps } from "@mittwald/flow-react-components";
 
 export class RemotePasswordCreationFieldElement extends FlowRemoteElement<RemotePasswordCreationFieldElementProps> {
   static override get remoteAttributes() {

--- a/packages/remote-react-components/src/tests/lib/environments.tsx
+++ b/packages/remote-react-components/src/tests/lib/environments.tsx
@@ -5,7 +5,7 @@ import { RemoteRenderer } from "@mittwald/flow-remote-react-renderer";
 import type { Locator, ScreenshotMatcherOptions } from "vitest/browser";
 import * as RemoteComponents from "@/index";
 import * as Components from "@mittwald/flow-react-components";
-import * as PasswordToolsComponents from "@mittwald/flow-react-components/password-tools";
+import * as PasswordToolsComponents from "@mittwald/flow-react-components/mittwald-password-tools-js";
 import { NotificationProvider } from "@mittwald/flow-react-components";
 import { useMemo, type FC, type PropsWithChildren } from "react";
 import { RootContainer, rootContainerLocator } from "@/tests/lib/RootContainer";

--- a/packages/remote-react-renderer/src/auto-generated/index.ts
+++ b/packages/remote-react-renderer/src/auto-generated/index.ts
@@ -92,7 +92,7 @@ import { Notification as Notification } from "@mittwald/flow-react-components";
 import { NumberField as NumberField } from "@mittwald/flow-react-components";
 import { Option as Option } from "@mittwald/flow-react-components";
 import { OverlayContent as OverlayContent } from "@mittwald/flow-react-components";
-import { PasswordCreationField as PasswordCreationField } from "@mittwald/flow-react-components/password-tools";
+import { PasswordCreationField as PasswordCreationField } from "@mittwald/flow-react-components";
 import { PopoverContent as PopoverContent } from "@mittwald/flow-react-components";
 import { ProgressBar as ProgressBar } from "@mittwald/flow-react-components";
 import { Radio as Radio } from "@mittwald/flow-react-components";


### PR DESCRIPTION
To stay in contract not to introduce major breaks for 1.0 this partial reverts [#2646](https://github.com/mittwald/flow/pull/2646)