### PR TITLE
docs(AGENTS): add writing-style rule for issues, ADRs, comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,6 +218,42 @@ A new or substantially changed component comes with:
 - **Only remote-capable components in a `PropsContext`** (see the PropsContext
   section of [packages/components/AGENTS.md](packages/components/AGENTS.md)).
 
+## Writing style (issues, ADRs, PR/commit bodies, code comments)
+
+Applies to prose we author — issues, ADRs, PR and commit bodies, code comments.
+Not to user-facing UI text (that lives in `locales/*` and follows product voice).
+
+Write **dense and simple**. Cut words, never content. Every fact stays —
+constraints, edge cases, reasons, trade-offs, links. Brevity filters words, not
+substance. Litmus test: if a sentence can be deleted without losing information,
+delete it.
+
+**Be dense:**
+
+- **Lead with the point.** First sentence = the decision, problem, or ask. Don't
+  restate the title or open with "In this issue we will…".
+- **No filler.** Drop "it's worth noting", "basically", "in order to", hedging
+  stacks ("might possibly perhaps").
+- **No summary that just repeats the body.** Either the TL;DR replaces the
+  detail or the detail replaces it — not both.
+- **Cut marketing adjectives.** "robust", "seamless", "comprehensive",
+  "powerful" carry no information. Delete them, or replace with the concrete fact.
+- **Structure only when it earns its keep.** Three lines don't need three
+  headings.
+
+**Be simple:**
+
+- **Short sentences, one idea each.** Break a clause chain into two or three
+  sentences.
+- **Simplify the glue, keep domain terms exact.** "in order to" → "to", but a
+  symbol name, a token, or a version number stays precise.
+- **Active voice, concrete subject.** "Flip the default and you change X" over
+  "flipping the default results in a change to X".
+- **Unpack lists.** Three options crammed into one sentence → three bullets.
+
+When brevity and clarity conflict, **clarity wins** — a few more words to split a
+dense sentence is a good trade.
+
 ## Common failures
 
 Symptom → cause → fix for the footguns that cost the most time here. None of

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,7 +221,8 @@ A new or substantially changed component comes with:
 ## Writing style (issues, ADRs, PR/commit bodies, code comments)
 
 Applies to prose we author — issues, ADRs, PR and commit bodies, code comments.
-Not to user-facing UI text (that lives in `locales/*` and follows product voice).
+Not to user-facing UI text (that lives in `locales/*` and follows product
+voice).
 
 Write **dense and simple**. Cut words, never content. Every fact stays —
 constraints, edge cases, reasons, trade-offs, links. Brevity filters words, not
@@ -237,7 +238,8 @@ delete it.
 - **No summary that just repeats the body.** Either the TL;DR replaces the
   detail or the detail replaces it — not both.
 - **Cut marketing adjectives.** "robust", "seamless", "comprehensive",
-  "powerful" carry no information. Delete them, or replace with the concrete fact.
+  "powerful" carry no information. Delete them, or replace with the concrete
+  fact.
 - **Structure only when it earns its keep.** Three lines don't need three
   headings.
 
@@ -251,8 +253,8 @@ delete it.
   "flipping the default results in a change to X".
 - **Unpack lists.** Three options crammed into one sentence → three bullets.
 
-When brevity and clarity conflict, **clarity wins** — a few more words to split a
-dense sentence is a good trade.
+When brevity and clarity conflict, **clarity wins** — a few more words to split
+a dense sentence is a good trade.
 
 ## Common failures
 


### PR DESCRIPTION
## What

Adds a **Writing style** section to the root `AGENTS.md`, governing the prose we author — issues, ADRs, PR/commit bodies, code comments. Explicitly *not* user-facing UI text (that stays in `locales/*` under product voice).

The rule sets two independent dials:

- **Be dense** — lead with the point, no filler, no summary that just repeats the body, no marketing adjectives, structure only when it earns its keep.
- **Be simple** — short sentences (one idea each), active voice, simplify the connective glue but keep domain terms exact.

Tie-breaker when they conflict: **clarity wins.**

## Why

AI-drafted issues and comments have been reading long and bloated. The complaint was verbosity, not missing information — so the rule targets the bloat (filler, restated summaries, hedging, marketing adjectives) while keeping every fact. Density and clarity go up; content stays.

## How it was validated

Before writing the rule, it was tested by rewriting real repo issues and a deliberately bloated AI-style issue, measuring word count and checking no fact was lost:

| Input | Type | Dense only | Dense + simple |
| --- | --- | --- | --- |
| Raw AI-style issue | prose-heavy, bloated | −80% | ~−75% |
| #2774 (export-surface RFC) | dense, table-heavy | −15% | −3% |
| #2790 (flag defaults) | dense, code-refs | −11% | −5% |

Pattern: the rule bites hard on genuine bloat and barely touches already-disciplined issues — i.e. it filters padding, not substance. Issue #2774's body was also updated in place to the dense+simple style as a live example.

## Reviewer notes

- English, consistent with the rest of `AGENTS.md` and the docs convention.
- Placed between **Hard rules** and **Common failures** as a cross-cutting authoring guideline.
- No code or generated artifacts touched — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)