### PR TITLE
docs(sprach-guide): clarify du casing, number exceptions, AI term

### DIFF
--- a/apps/docs/src/content/02-foundations/03-content-guidelines/01-sprach-guide/index.mdx
+++ b/apps/docs/src/content/02-foundations/03-content-guidelines/01-sprach-guide/index.mdx
@@ -50,14 +50,17 @@ wir auf passive Satzkonstruktionen.
 
 ## Sie, Du oder Ihr
 
-Respekt braucht kein „Sie“. Wir reden User genauso an, wie Kolleg\*innen: mit
-einem freundlichen „Du“. Unsere User reden wir persönlich an, also im Singular.
+Respekt braucht kein „Sie”. Wir reden User genauso an, wie Kolleg\*innen: mit
+einem freundlichen „Du”. Unsere User reden wir persönlich an, also im Singular.
 In Mailings und Tickets werden Du, Dein, Deiner, usw. immer großgeschrieben.
 
 <DoAndDont>
   <Do>Du weißt, mittwald hat das beste Hosting für Agenturen.</Do>
   <Dont>Ihr wisst, mittwald hat das beste Hosting für Agenturen.</Dont>
 </DoAndDont>
+
+Im mStudio schreiben wir du, dein, deiner usw. dagegen klein. mStudio-Texte
+haben eher Anleitungscharakter, wofür sich die Kleinschreibung besser eignet.
 
 ## Bindestrich: Wörter koppeln
 
@@ -134,6 +137,18 @@ gefettet.
 Um die Lesbarkeit zu steigern, schreiben wir alle Zahlen als Ziffern, auch von 0
 bis 12.
 
+Im UX-Writing gibt es davon eine Ausnahme: Ist die Zahl für den User nicht
+besonders relevant und gibt keine konkrete Information wieder, kann sie
+ausgeschrieben werden.
+
+<DoAndDont>
+  <Do>Nur noch ein Schritt bis zum Abschluss.</Do>
+  <Dont>Nur noch 1 Schritt bis zum Abschluss.</Dont>
+</DoAndDont>
+
+Ist die Zahl dagegen eine wichtige Information, bleibt sie eine Ziffer, z. B.
+„Nach 7 Tagen wird dein Server gelöscht."
+
 ## Konsistente Begriffe für Entfernen, Löschen und Kündigen
 
 Wir wählen Begriffe, die sich logisch an der jeweiligen Aktion orientieren:
@@ -154,6 +169,7 @@ Verwirrung durch uneinheitliche Umrechnungen, wie sie bei dezimalen Angaben
 
 # Glossar
 
+- **AI:** Wir verwenden AI statt KI oder anderer Bezeichnungen.
 - **Anlegen:** Hinzufügen von Objekten ohne Vertragsposition, die von Grund auf
   von den Usern erstellt werden müssen.
 - **Artikel:** Alle kostenpflichtigen Produkte, z. B. Domains, die hinzugebucht


### PR DESCRIPTION
## Summary
- mStudio product texts use lowercase du/dein/deiner (instructional tone), distinct from the Marketing-authored Mailings/Tickets rule which stays uppercase.
- Documents the UX-writing exception for spelling out numbers that aren't factually relevant, with a Do/Dont example.
- Adds AI to the glossary as the preferred term over KI.

Source: internal review of gitlab.mittwald.it work item 3714.

## Test plan
- [x] `pnpm format` — no diff beyond the intended change
- [x] `pnpm lint` — passes (pre-existing warnings only, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)