### PR TITLE
fix(MarkdownEditor): enable flex-wrap for toolbar buttons

### DIFF
--- a/packages/components/src/components/MarkdownEditor/MarkdownEditor.module.scss
+++ b/packages/components/src/components/MarkdownEditor/MarkdownEditor.module.scss
@@ -30,6 +30,7 @@
 
   .toolbarButtons {
     display: flex;
+    flex-wrap: wrap;
     column-gap: var(--form-control--padding-y);
   }
 


### PR DESCRIPTION
fixes #2802 2802