### PR TITLE
test(remote-react-components): gate screenshots on painted content

### DIFF
--- a/packages/remote-react-components/src/tests/lib/environments.tsx
+++ b/packages/remote-react-components/src/tests/lib/environments.tsx
@@ -105,6 +105,14 @@ const waitForPaintedContent = async (): Promise<void> => {
           isPainted,
         ),
       {
+        /*
+         * The wait itself costs nothing once content is there — polling stops on
+         * the first painted frame, ~25ms in. The budget only bounds the failure
+         * case, so keep it well above `expect.poll`'s 1s default: a heavy
+         * scenario on a loaded machine would otherwise fail here for being slow
+         * rather than for being blank.
+         */
+        timeout: 5000,
         message:
           "The root container never painted any content, so the screenshot would have captured a blank frame.",
       },

--- a/packages/remote-react-components/src/tests/lib/environments.tsx
+++ b/packages/remote-react-components/src/tests/lib/environments.tsx
@@ -64,10 +64,59 @@ const setNeutralPointerPosition = async () => {
   rootContainerLocator.element().focus();
 };
 
+/*
+ * An element counts as painted when it occupies space and is not hidden. Both
+ * environments mirror the remote tree through a 0x0, `visibility: hidden`
+ * wrapper whose children can still report a non-empty box, so the computed
+ * style is what separates real output from that mirror.
+ */
+const isPainted = (element: Element): boolean => {
+  const { width, height } = element.getBoundingClientRect();
+  if (width === 0 || height === 0) {
+    return false;
+  }
+  const { display, visibility } = getComputedStyle(element);
+  return display !== "none" && visibility !== "hidden";
+};
+
+/*
+ * `toMatchScreenshot` decides the page is ready by taking two screenshots back
+ * to back and comparing them — two identical frames count as "stable". A
+ * container that has not painted its content yet is trivially stable, because
+ * two blank frames are identical, so the matcher returns the blank frame. With
+ * `--update` that frame is written to disk as the new reference and nothing
+ * fails, which is how blank snapshots end up committed.
+ *
+ * The Remote environment enters that window on every render: `render()` resolves
+ * before <RemoteRenderer /> has materialised the host tree, because it
+ * lazy-imports RemoteRendererBrowser and mounts only after `useIsMounted()`
+ * flips. Measured at ~25ms — short enough that both screenshots regularly land
+ * inside it, and load-dependent enough to look random per scenario.
+ *
+ * So gate the screenshot on content actually being painted instead of trusting
+ * pixel stability. A scenario that never paints fails here with this message
+ * rather than silently producing an empty reference.
+ */
+const waitForPaintedContent = async (): Promise<void> => {
+  await expect
+    .poll(
+      () =>
+        Array.from(rootContainerLocator.element().querySelectorAll("*")).some(
+          isPainted,
+        ),
+      {
+        message:
+          "The root container never painted any content, so the screenshot would have captured a blank frame.",
+      },
+    )
+    .toBe(true);
+};
+
 const testScreenshot = async (
   description: string,
   options: ScreenshotMatcherOptions = {},
 ): Promise<void> => {
+  await waitForPaintedContent();
   await setNeutralPointerPosition();
   await expect(rootContainerLocator).toMatchScreenshot(description, options);
 };

--- a/packages/remote-react-components/vitest.config.ts
+++ b/packages/remote-react-components/vitest.config.ts
@@ -32,6 +32,15 @@ export default mergeConfig(
             name: "visual",
             include: ["src/tests/visual/**/*.browser.test.{ts,tsx}"],
             setupFiles: "./dev/vitest/setupBrowser.ts",
+            browser: {
+              ...vitestBrowserTestConfig.browser,
+              // Failure screenshots land in src/tests/visual/__screenshots__ —
+              // the tracked baseline directory — and are not gitignored, so a
+              // local failure leaves stray PNGs that `git add` picks up. They
+              // add nothing either: a mismatch already writes reference, actual
+              // and diff to the gitignored .vitest-attachments.
+              screenshotFailures: false,
+            },
           },
         },
         {


### PR DESCRIPTION
## Problem

Visual snapshots came out blank sporadically on local runs, and `test:visual:update` wrote those blank frames to disk as new references **without failing**.

## Cause

Two things combine.

**`toMatchScreenshot` treats "blank" as "ready".** Vitest decides the page is stable by taking two screenshots back to back and comparing them — identical frames count as stable ([`getStableScreenshot`](https://github.com/vitest-dev/vitest/blob/main/packages/browser/src/node/commands/screenshotMatcher.ts)). A container that has not painted its content yet is trivially stable, because two blank frames are identical, so the matcher returns the blank frame.

**`render()` resolves too early.** In the `Remote` environment the container is still empty after `render()`, because `RemoteRenderer` lazy-imports `RemoteRendererBrowser` and mounts only after `useIsMounted()` flips.

Measured: `paintedAtRender=0`, then after **24ms** `final=7`. The content does arrive — just late. When both screenshots land inside that window, the blank frame wins, and `--update` bakes it into the baseline silently. That window depends on machine load and module warmth, which is why it looked random and hit individual scenarios.

Reproduced deterministically in a fresh worktree: all four `Button (Remote)` screenshots came out blank, all four `actual` PNGs exactly 4851 bytes.

## Change

**Gate the screenshot on painted content** instead of trusting pixel stability. Central, because the repo has exactly one `toMatchScreenshot` call site. The `visibility` check is what separates real output from the hidden 0x0 mirror of the remote tree. A scenario that never paints now fails with an explicit message rather than producing an empty reference.

**Disable `screenshotFailures` for the `visual` project.** Those PNGs land in `src/tests/visual/__screenshots__` — the tracked baseline directory — and are not gitignored, so a local failure left stray files that `git add` picks up. They add nothing: a mismatch already writes reference, actual and diff to the gitignored `.vitest-attachments`. The cross-version harness already makes this same call for the same reason.

## Verification

| Check | Result |
|---|---|
| `Button` (previously 4x blank) | 8/8 green, against the **committed** baselines |
| Full visual suite, webkit | 348/350 green |
| Blank container + `--update` | fails with an explicit message, writes **no** baseline |
| Failure after the config change | no directory created in `__screenshots__` |
| Both browser instances intact | 2 instances, 16/16 green |
| Prettier, ESLint, `tsc --noEmit` | green |

That `Button` now matches the committed baselines is the key result: those baselines were correct all along, and the blank frames were the anomaly.

`Local` is unaffected — its content is already painted when `testScreenshot` runs, so the gate is a no-op there.

## Not caused by this change

Two tests fail on this macOS machine: `Initials` (1 pixel) and, under Firefox, `Modal offCanvas` (75 pixels). Both fail symmetrically in `Local` **and** `Remote`, and for `Local` the gate is provably a no-op. A control run with the fix stashed fails `Initials` identically. This is local antialiasing against non-darwin baselines; no baseline was changed in this PR.

## Note for reviewers

While testing I hit a related footgun worth knowing: **`--update` ignores a positional file filter** and runs the whole suite. It overwrote an unrelated `Initials` baseline with this machine's antialiasing (reverted here). For a targeted update, `-t <testname>` is the safer route.

CI gates on `-webkit-linux`; local runs only produce `-darwin`. Adding the verify-only `run-visual-tests` label to exercise this on the Linux baselines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
