### PR TITLE
feat(Tooltip): show tooltips after 400ms

### DIFF
--- a/apps/docs/src/content/04-components/overlays/tooltip/examples/delay.tsx
+++ b/apps/docs/src/content/04-components/overlays/tooltip/examples/delay.tsx
@@ -1,0 +1,19 @@
+import {
+  Button,
+  IconEdit,
+  Tooltip,
+  TooltipTrigger,
+} from "@mittwald/flow-react-components";
+
+<>
+  <TooltipTrigger>
+    <Button aria-label="Bearbeiten" variant="plain">
+      <IconEdit />
+    </Button>
+    <Tooltip>Bearbeiten</Tooltip>
+  </TooltipTrigger>
+  <TooltipTrigger delay="long">
+    <Button variant="plain">Bearbeiten</Button>
+    <Tooltip>Name und Beschreibung ändern</Tooltip>
+  </TooltipTrigger>
+</>;

--- a/apps/docs/src/content/04-components/overlays/tooltip/guidelines.mdx
+++ b/apps/docs/src/content/04-components/overlays/tooltip/guidelines.mdx
@@ -20,6 +20,12 @@ Achte bei der Verwendung eines Tooltips darauf, dass ...
   enthalten sein.
 - sie nicht für Elemente mit vorhandener sichtbarer Beschriftung eingesetzt
   werden.
+- die Standard-Verzögerung von 400 ms beibehalten wird. Sie ist auf Aktionen
+  ausgelegt, die nicht selbsterklärend sind – z. B. Buttons, die nur aus einem
+  Icon bestehen.
+- vor dem Hinzufügen geprüft wird, ob der Tooltip überhaupt nötig ist. Ist die
+  Aktion durch ihren Kontext oder ihre Beschriftung bereits klar, lässt du ihn
+  besser weg.
 
 ## Verwendung
 

--- a/apps/docs/src/content/04-components/overlays/tooltip/guidelines.mdx
+++ b/apps/docs/src/content/04-components/overlays/tooltip/guidelines.mdx
@@ -18,11 +18,8 @@ Achte bei der Verwendung eines Tooltips darauf, dass ...
   [Buttons](/04-components/actions/button/overview),
   [Links](/04-components/navigation/link/overview) oder interaktiven Inhalte
   enthalten sein.
-- sie nicht für Elemente mit vorhandener sichtbarer Beschriftung eingesetzt
-  werden.
-- die Standard-Verzögerung von 400 ms beibehalten wird. Sie ist auf Aktionen
-  ausgelegt, die nicht selbsterklärend sind – z. B. Buttons, die nur aus einem
-  Icon bestehen.
+- er die sichtbare Beschriftung eines Elements nicht wiederholt, sondern
+  ergänzt.
 - vor dem Hinzufügen geprüft wird, ob der Tooltip überhaupt nötig ist. Ist die
   Aktion durch ihren Kontext oder ihre Beschriftung bereits klar, lässt du ihn
   besser weg.

--- a/apps/docs/src/content/04-components/overlays/tooltip/overview.mdx
+++ b/apps/docs/src/content/04-components/overlays/tooltip/overview.mdx
@@ -4,3 +4,20 @@ Verwende `<TooltipTrigger />` und `<Tooltip />` in Kombination mit der
 gewünschten Component, um beim Hovern der Component einen Tooltip anzuzeigen.
 
 <LiveCodeEditor />
+
+---
+
+# Delay
+
+Tooltips erscheinen verzögert, damit sie beim Hovern über die Oberfläche nicht
+aufblitzen. Über die `delay` Property des Triggers wählst du zwischen zwei
+Verzögerungen.
+
+<LiveCodeEditor example="delay" editorCollapsed row />
+
+**Default (400 ms):** Verwende ihn, wenn das Element ohne den Tooltip nicht
+verständlich ist – z. B. ein Button, der nur aus einem Icon besteht.
+
+**Long (1500 ms):** Verwende ihn für ergänzende Informationen an Elementen, die
+bereits beschriftet sind. Die längere Verzögerung verhindert, dass der Tooltip
+ungewollt ablenkt.

--- a/packages/components/src/components/Tooltip/components/TooltipTrigger/TooltipTrigger.tsx
+++ b/packages/components/src/components/Tooltip/components/TooltipTrigger/TooltipTrigger.tsx
@@ -1,23 +1,33 @@
 import * as Aria from "react-aria-components";
 import type { FC, PropsWithChildren } from "react";
 
+export type TooltipDelay = "default" | "long";
+
+const delays: Record<TooltipDelay, number> = {
+  default: 400,
+  long: 1500,
+};
+
 export interface TooltipTriggerProps extends PropsWithChildren<
-  Omit<Aria.TooltipTriggerComponentProps, "children">
+  Omit<Aria.TooltipTriggerComponentProps, "children" | "delay">
 > {
   /**
-   * The delay in milliseconds before the tooltip is shown on hover.
+   * How long the tooltip waits before it is shown on hover. Use `"default"`
+   * (400ms) for elements that cannot be understood without the tooltip – icon
+   * only buttons, for example. Use `"long"` (1500ms) for supplementary
+   * information on elements that are already labeled.
    *
-   * @default 400
+   * @default "default"
    */
-  delay?: number;
+  delay?: TooltipDelay;
 }
 
 /** @flr-generate all */
 export const TooltipTrigger: FC<TooltipTriggerProps> = (props) => {
-  const { children, delay = 400, ...rest } = props;
+  const { children, delay = "default", ...rest } = props;
 
   return (
-    <Aria.TooltipTrigger {...rest} delay={delay}>
+    <Aria.TooltipTrigger {...rest} delay={delays[delay]}>
       {children}
     </Aria.TooltipTrigger>
   );

--- a/packages/components/src/components/Tooltip/components/TooltipTrigger/TooltipTrigger.tsx
+++ b/packages/components/src/components/Tooltip/components/TooltipTrigger/TooltipTrigger.tsx
@@ -1,15 +1,26 @@
 import * as Aria from "react-aria-components";
 import type { FC, PropsWithChildren } from "react";
 
-export type TooltipTriggerProps = PropsWithChildren<
+export interface TooltipTriggerProps extends PropsWithChildren<
   Omit<Aria.TooltipTriggerComponentProps, "children">
->;
+> {
+  /**
+   * The delay in milliseconds before the tooltip is shown on hover.
+   *
+   * @default 400
+   */
+  delay?: number;
+}
 
 /** @flr-generate all */
 export const TooltipTrigger: FC<TooltipTriggerProps> = (props) => {
-  const { children, ...rest } = props;
+  const { children, delay = 400, ...rest } = props;
 
-  return <Aria.TooltipTrigger {...rest}>{children}</Aria.TooltipTrigger>;
+  return (
+    <Aria.TooltipTrigger {...rest} delay={delay}>
+      {children}
+    </Aria.TooltipTrigger>
+  );
 };
 
 export default TooltipTrigger;

--- a/packages/remote-react-components/src/tests/visual/Tooltip.browser.test.tsx
+++ b/packages/remote-react-components/src/tests/visual/Tooltip.browser.test.tsx
@@ -20,7 +20,7 @@ test.each(testEnvironments)(
     const button = page.getByLocator("button");
 
     await button.hover();
-    await sleep(1600);
+    await sleep(800);
 
     await testScreenshot("Tooltip - visible");
   },


### PR DESCRIPTION
## What & why

Closes #2803 — the tooltip delay felt unusually long. React Aria defaults to
1500ms; Flow already advises against tooltips on self-explanatory elements, so
the tooltips that remain carry information the user is waiting for.

Instead of just lowering the number, `delay` is now a named variant. Free-form
millisecond values invite one-off timings, and two cases cover what we actually
have:

- `"default"` (400ms) — elements that cannot be understood without the tooltip,
  e.g. icon only buttons
- `"long"` (1500ms) — supplementary information on elements that are already
  labeled

`closeDelay` stays a plain React Aria passthrough.

**Type-level break:** `delay={800}` no longer typechecks. It never was a
hand-written prop — it came in through the React Aria props spread — and
nothing breaks at runtime: an unknown value resolves to `undefined`, so Aria
falls back to its own default. The tooltip still works, it is just slow again.

### Docs

- New `# Delay` section in the tooltip overview with a live example, in the
  style of the Button variants page.
- Fixed a best practice that contradicted `"long"`: it forbade tooltips on
  labeled elements outright, while the "Verwendung" section right below asks
  for exactly that. The intended rule is that a tooltip must not *repeat* the
  visible label.

## Testing

`test:compile`, `test:unit` and `pnpm lint` are clean; the generators produce
no diff. Visual tests could not run locally (Playwright never connects to a
browser session in my environment) — added the `run-visual-tests` label, since
`Tooltip.browser.test.tsx` lost its 1500ms-era fixed wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)