### PR TITLE
docs: require migration note for deliberate TypeScript breaking changes

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -608,6 +608,12 @@ chore(docs): migrate site URL and redirect pages
 `feat` and `fix` are user-facing and drive releases; use `chore`/`docs`/`ci` for
 everything that isn't. Write messages for the changelog reader.
 
+TypeScript type-level changes aren't under the semver guarantee, so a type break
+never forces a Major on its own. But a **deliberate** (even small) TS breaking
+change still ships a **migration note in the commit body and in the release
+notes** telling consumers how to adapt — see
+[ADR 0005](docs/adr/0005-semver-contract.md) for the rationale.
+
 The commit **type** also decides **where your PR lands** — see
 [Choosing the base branch](#choosing-the-base-branch).
 

--- a/apps/docs/src/content/01-get-started/versioning/index.mdx
+++ b/apps/docs/src/content/01-get-started/versioning/index.mdx
@@ -123,7 +123,10 @@ Andernfalls kann bereits ein Patch dein Styling brechen.
 Flows TypeScript-Typen folgen nicht Semantic Versioning. Ein `tsc`-Fehler kann
 daher theoretisch schon in einem Patch auftreten. Wenn ein solcher Bruch für
 dein Projekt teuer wäre, pinne exakte Versionen (statt `^`-Ranges), sodass ein
-Update bewusst und kontrolliert erfolgt.
+Update bewusst und kontrolliert erfolgt. Zu einem bewusst herbeigeführten
+Type-Breaking-Change gehört eine Migrationsnotiz in den Release Notes – so
+bekommst du einen konkreten Upgrade-Pfad, auch wenn die Änderung in einem Minor
+oder Patch erscheint.
 
 ---
 

--- a/docs/adr/0005-semver-contract.md
+++ b/docs/adr/0005-semver-contract.md
@@ -80,8 +80,10 @@ React is a genuine runtime peer in every package.
 
 - **All type-level (TypeScript) changes.** The type surface is best-effort, not
   semver-protected. Even removing/renaming an exported type or narrowing a
-  prop's accepted type is not, on its own, breaking. (Notable type changes are
-  still called out in the changelog.)
+  prop's accepted type is not, on its own, breaking. A type break does not force
+  a Major on its own — but a **deliberate** (even small) type-breaking change
+  ships a **migration note in the commit body and in the release notes**: not
+  merely a mention that something changed, but how consumers adapt.
 - **Visual appearance.**
 - **Internal DOM structure.**
 - **CSS class names.**


### PR DESCRIPTION
Encodes one policy refinement to the semver contract (ADR 0005 §4): **TypeScript type-level changes stay outside the semver guarantee, but a deliberate (even small) TS breaking change must still ship a migration note — in the commit body *and* in the release notes.**

A type break does not force a Major on its own (types are best-effort). But "called out in the changelog" isn't enough for a deliberate break: consumers who depend on types need a concrete upgrade path, not just a note that something changed.

## Changes
- **`docs/adr/0005-semver-contract.md` §4** — strengthens the type-level bullet: a deliberate type break ships a migration note in the commit body + release notes (how to adapt, not just that it changed). Core point preserved (types best-effort, not a Major on their own).
- **`apps/docs/.../01-get-started/versioning/index.mdx`** (consumer page, German) — one sentence in "Behandle TypeScript-Typen als best-effort": deliberate TS breaks come with a migration note in the release notes, so consumers get an upgrade path even in a Minor/Patch.
- **`CONTRIBUTE.md`** ("Commit conventions") — contributor rule + link to ADR 0005 for the rationale.

## Notes
- Composes with the 1.0.0 no-breaking rule (runtime/public-API breaks deferred to 2.0.0); this is specifically about the *type* surface, which stays free-to-change but documented.
- `prettier --check` green on all three files.

Part of #2738 (public contract, ADR 0005 follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
