### PR TITLE
fix(Autocomplete): apply consumer className to root element

### DIFF
--- a/packages/components/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/components/Autocomplete/Autocomplete.tsx
@@ -23,6 +23,7 @@ import { useFieldComponent } from "@/lib/hooks/useFieldComponent";
 import { isFocused } from "@/lib/form/isFocused";
 import { emitElementValueChange } from "@/lib/react/emitElementValueChange";
 import { UiComponentTunnelExit } from "@/components/UiComponentTunnel/UiComponentTunnelExit";
+import clsx from "clsx";
 
 export interface AutocompleteProps
   extends
@@ -36,7 +37,7 @@ export interface AutocompleteProps
 
 /** @flr-generate all */
 export const Autocomplete = flowComponent("Autocomplete", (props) => {
-  const { children, ref, ...rest } = props;
+  const { children, className, ref, ...rest } = props;
 
   const inputRef = useObjectRef(ref);
 
@@ -91,6 +92,8 @@ export const Autocomplete = flowComponent("Autocomplete", (props) => {
     fieldProps,
   } = useFieldComponent(props, "Autocomplete");
 
+  const rootClassName = clsx(fieldProps.className, className);
+
   const propsContext: PropsContext = {
     SearchField: inputProps,
     TextField: inputProps,
@@ -107,7 +110,7 @@ export const Autocomplete = flowComponent("Autocomplete", (props) => {
   };
 
   return (
-    <div {...fieldProps}>
+    <div {...fieldProps} className={rootClassName}>
       <FieldErrorCaptureContext>
         <PropsContextProvider
           props={propsContext}


### PR DESCRIPTION
`AutocompleteProps` extends `PropsWithClassName`, but `className` never reached the DOM. The component destructured only `{ children, ref, ...rest }` and spread `rest` onto `<Aria.Autocomplete>` — which renders no element — so a consumer-provided `className` silently disappeared.

## Fix

Destructure `className` and compose it onto the root `<div>` alongside `fieldProps.className`, the same way `TextField` does:

```tsx
const rootClassName = clsx(fieldProps.className, className);
// …
<div {...fieldProps} className={rootClassName}>
```

Destructuring also stops `className` from reaching `<Aria.Autocomplete>` via `rest`, where it was a no-op anyway.

## Notes

- **No regeneration needed.** `className` was already part of `AutocompleteProps`, so it is already present in `RemoteAutocompleteElement.ts` and the other auto-generated artifacts. `pnpm nx build:remote-components components` produces no diff.
- **No visual-test change.** For the existing scenarios the rendered output is unchanged: previously `className` never reached the DOM, and the visual tests pass none. Existing snapshots stay valid.

## Checks

`pnpm nx test:compile components`, `pnpm nx test:browser components --browser.name=webkit` and `pnpm lint` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)