### PR TITLE
docs(homepage): let the developer experience example compose itself

### DIFF
--- a/apps/docs/src/app/_components/HomeCodeExample/HomeCodeExample.tsx
+++ b/apps/docs/src/app/_components/HomeCodeExample/HomeCodeExample.tsx
@@ -1,0 +1,109 @@
+"use client";
+import type { FC } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import {
+  LiveEditor,
+  LivePreview,
+  LiveProvider,
+} from "@mfalkenberg/react-live-ssr";
+import styles from "@/lib/liveCode/components/LiveCodeEditor/LiveCodeEditor.module.css";
+import { flowTheme } from "@/lib/liveCode/components/LiveCodeEditor/lib/flowTheme";
+import extractDefaultExport from "@/lib/liveCode/components/LiveCodeEditor/lib/extractDefaultExport";
+import { extractEditorScope } from "@/lib/liveCode/components/LiveCodeEditor/lib/extractEditorScope";
+import { codeSteps } from "./codeSteps";
+import { useTypedCode } from "./useTypedCode";
+
+const finalCode = codeSteps.at(-1) ?? "";
+const scope = extractEditorScope(finalCode);
+
+const useIsomorphicLayoutEffect =
+  typeof window === "undefined" ? useEffect : useLayoutEffect;
+
+/**
+ * The live example of the "Fokus auf Developer Experience" tile: it composes
+ * itself step by step, so the nesting and the automatic spacing the tile talks
+ * about happen in front of the reader. Stays a fully editable live example
+ * afterwards.
+ */
+const HomeCodeExample: FC = () => {
+  const editorRef = useRef<HTMLDivElement>(null);
+  const [reservedHeight, setReservedHeight] = useState<number>();
+  const [isVisible, setIsVisible] = useState(false);
+
+  // The example starts out complete: its final height is measured up front and
+  // held while the animation runs, so growing code never pushes the page
+  // around. The animation itself waits for the tile to be on screen — the tile
+  // sits below the fold and watching it compose itself is the whole point.
+  useIsomorphicLayoutEffect(() => {
+    const element = editorRef.current;
+
+    if (element === null) {
+      return;
+    }
+
+    setReservedHeight(element.getBoundingClientRect().height);
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting) {
+          setIsVisible(true);
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.3 },
+    );
+
+    observer.observe(element);
+
+    return () => observer.disconnect();
+  }, []);
+
+  const { code, isTyping, skip } = useTypedCode(
+    codeSteps,
+    isVisible && reservedHeight !== undefined,
+  );
+
+  const lastPreview = useRef("");
+
+  const transformCode = useCallback((code: string) => {
+    try {
+      lastPreview.current = extractDefaultExport(code);
+    } catch {
+      // Half-typed (and half-edited) code keeps the last preview instead of
+      // replacing it with a parser error.
+    }
+    return lastPreview.current;
+  }, []);
+
+  return (
+    <LiveProvider transformCode={transformCode} code={code} scope={scope}>
+      <div
+        className={styles.liveCodeEditor}
+        ref={editorRef}
+        style={isTyping ? { minBlockSize: reservedHeight } : undefined}
+      >
+        <LivePreview className={styles.preview} />
+
+        <div
+          className={styles.editorContainer}
+          onFocusCapture={skip}
+          onPointerDown={skip}
+        >
+          <LiveEditor
+            tabMode="focus"
+            theme={flowTheme}
+            className={styles.editor}
+          />
+        </div>
+      </div>
+    </LiveProvider>
+  );
+};
+
+export default HomeCodeExample;

--- a/apps/docs/src/app/_components/HomeCodeExample/HomeCodeExample.tsx
+++ b/apps/docs/src/app/_components/HomeCodeExample/HomeCodeExample.tsx
@@ -25,6 +25,34 @@ const scope = extractEditorScope(finalCode);
 const useIsomorphicLayoutEffect =
   typeof window === "undefined" ? useEffect : useLayoutEffect;
 
+interface ReservedHeights {
+  preview: number;
+  editor: number;
+}
+
+/**
+ * Heights of the finished example. Preview and code block each hold their own,
+ * so nothing inside the tile moves while the code is typed — a single height on
+ * the wrapper would keep the page still, but the preview would still drift as
+ * the code block grows underneath it.
+ *
+ * Neither element takes a ref (both come from react-live), hence the lookup by
+ * class name.
+ */
+const measure = (wrapper: HTMLElement): ReservedHeights | undefined => {
+  const preview = wrapper.querySelector(`.${styles.preview}`);
+  const editor = wrapper.querySelector(`.${styles.editor}`);
+
+  if (preview === null || editor === null) {
+    return undefined;
+  }
+
+  return {
+    preview: preview.getBoundingClientRect().height,
+    editor: editor.getBoundingClientRect().height,
+  };
+};
+
 /**
  * The live example of the "Fokus auf Developer Experience" tile: it composes
  * itself step by step, so the nesting and the automatic spacing the tile talks
@@ -32,22 +60,21 @@ const useIsomorphicLayoutEffect =
  * afterwards.
  */
 const HomeCodeExample: FC = () => {
-  const editorRef = useRef<HTMLDivElement>(null);
-  const [reservedHeight, setReservedHeight] = useState<number>();
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const [reserved, setReserved] = useState<ReservedHeights>();
   const [isVisible, setIsVisible] = useState(false);
 
-  // The example starts out complete: its final height is measured up front and
-  // held while the animation runs, so growing code never pushes the page
-  // around. The animation itself waits for the tile to be on screen — the tile
-  // sits below the fold and watching it compose itself is the whole point.
+  // The example starts out complete, which is what makes it measurable. The
+  // animation itself waits for the tile to be on screen — the tile sits below
+  // the fold and watching it compose itself is the whole point.
   useIsomorphicLayoutEffect(() => {
-    const element = editorRef.current;
+    const wrapper = wrapperRef.current;
 
-    if (element === null) {
+    if (wrapper === null) {
       return;
     }
 
-    setReservedHeight(element.getBoundingClientRect().height);
+    setReserved(measure(wrapper));
 
     const observer = new IntersectionObserver(
       ([entry]) => {
@@ -59,14 +86,14 @@ const HomeCodeExample: FC = () => {
       { threshold: 0.3 },
     );
 
-    observer.observe(element);
+    observer.observe(wrapper);
 
     return () => observer.disconnect();
   }, []);
 
   const { code, isTyping, skip } = useTypedCode(
     codeSteps,
-    isVisible && reservedHeight !== undefined,
+    isVisible && reserved !== undefined,
   );
 
   const lastPreview = useRef("");
@@ -83,12 +110,17 @@ const HomeCodeExample: FC = () => {
 
   return (
     <LiveProvider transformCode={transformCode} code={code} scope={scope}>
-      <div
-        className={styles.liveCodeEditor}
-        ref={editorRef}
-        style={isTyping ? { minBlockSize: reservedHeight } : undefined}
-      >
-        <LivePreview className={styles.preview} />
+      <div className={styles.liveCodeEditor} ref={wrapperRef}>
+        <LivePreview
+          className={styles.preview}
+          style={
+            isTyping
+              ? // Top aligned, or the composition would drift upwards inside
+                // the reserved space as it grows.
+                { minBlockSize: reserved?.preview, justifyContent: "start" }
+              : undefined
+          }
+        />
 
         <div
           className={styles.editorContainer}
@@ -99,6 +131,7 @@ const HomeCodeExample: FC = () => {
             tabMode="focus"
             theme={flowTheme}
             className={styles.editor}
+            style={isTyping ? { minBlockSize: reserved?.editor } : undefined}
           />
         </div>
       </div>

--- a/apps/docs/src/app/_components/HomeCodeExample/HomeCodeExample.tsx
+++ b/apps/docs/src/app/_components/HomeCodeExample/HomeCodeExample.tsx
@@ -30,13 +30,9 @@ interface ReservedHeights {
 }
 
 /**
- * Heights of the finished example. Preview and code block each hold their own,
- * so nothing inside the tile moves while the code is typed — a single height on
- * the wrapper would keep the page still, but the preview would still drift as
- * the code block grows underneath it.
- *
- * Neither element takes a ref (both come from react-live), hence the lookup by
- * class name.
+ * Preview and code block are measured apart: a single height on the wrapper
+ * keeps the page still, but the preview keeps drifting as the code block grows
+ * underneath it. Neither takes a ref, hence the lookup by class name.
  */
 const measure = (wrapper: HTMLElement): ReservedHeights | undefined => {
   const preview = wrapper.querySelector(`.${styles.preview}`);
@@ -52,20 +48,13 @@ const measure = (wrapper: HTMLElement): ReservedHeights | undefined => {
   };
 };
 
-/**
- * The live example of the "Fokus auf Developer Experience" tile: it composes
- * itself step by step, so the nesting and the automatic spacing the tile talks
- * about happen in front of the reader. Stays a fully editable live example
- * afterwards.
- */
 const HomeCodeExample: FC = () => {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const [reserved, setReserved] = useState<ReservedHeights>();
   const [isVisible, setIsVisible] = useState(false);
 
-  // The example starts out complete, which is what makes it measurable. The
-  // animation itself waits for the tile to be on screen — the tile sits below
-  // the fold and watching it compose itself is the whole point.
+  // Measuring here works because useTypedCode starts out on the last step. The
+  // animation waits for the tile, which sits below the fold, to be on screen.
   useIsomorphicLayoutEffect(() => {
     const wrapper = wrapperRef.current;
 
@@ -101,8 +90,8 @@ const HomeCodeExample: FC = () => {
     try {
       lastPreview.current = extractDefaultExport(code);
     } catch {
-      // Half-typed (and half-edited) code keeps the last preview instead of
-      // replacing it with a parser error.
+      // Half-typed code does not parse, which is most frames of the
+      // animation. Holding the last preview beats flashing a parser error.
     }
     return lastPreview.current;
   }, []);
@@ -114,8 +103,8 @@ const HomeCodeExample: FC = () => {
           className={styles.preview}
           style={
             isTyping
-              ? // Top aligned, or the composition would drift upwards inside
-                // the reserved space as it grows.
+              ? // The shared stylesheet centres the preview, which would drift
+                // the composition upwards inside the reserved height.
                 { minBlockSize: reserved?.preview, justifyContent: "start" }
               : undefined
           }

--- a/apps/docs/src/app/_components/HomeCodeExample/HomeCodeExample.tsx
+++ b/apps/docs/src/app/_components/HomeCodeExample/HomeCodeExample.tsx
@@ -16,11 +16,10 @@ import styles from "@/lib/liveCode/components/LiveCodeEditor/LiveCodeEditor.modu
 import { flowTheme } from "@/lib/liveCode/components/LiveCodeEditor/lib/flowTheme";
 import extractDefaultExport from "@/lib/liveCode/components/LiveCodeEditor/lib/extractDefaultExport";
 import { extractEditorScope } from "@/lib/liveCode/components/LiveCodeEditor/lib/extractEditorScope";
-import { codeSteps } from "./codeSteps";
+import { codeSteps, scopeSource } from "./codeSteps";
 import { useTypedCode } from "./useTypedCode";
 
-const finalCode = codeSteps.at(-1) ?? "";
-const scope = extractEditorScope(finalCode);
+const scope = extractEditorScope(scopeSource);
 
 const useIsomorphicLayoutEffect =
   typeof window === "undefined" ? useEffect : useLayoutEffect;

--- a/apps/docs/src/app/_components/HomeCodeExample/codeSteps.ts
+++ b/apps/docs/src/app/_components/HomeCodeExample/codeSteps.ts
@@ -1,3 +1,20 @@
+const components = [
+  "Button",
+  "Header",
+  "Heading",
+  "InlineCode",
+  "Label",
+  "LabeledValue",
+  "Section",
+];
+
+/**
+ * The editor shows the composition alone — spelled out, the import of seven
+ * components takes more room than the example itself. The editor scope is still
+ * derived from a real import statement, just one the reader never sees.
+ */
+export const scopeSource = `import { ${components.join(", ")} } from "@mittwald/flow-react-components";`;
+
 const heading = `    <Heading>WordPress 6.5.3</Heading>`;
 
 const headerAction = `    <Button color="secondary" variant="soft">Öffnen</Button>`;
@@ -9,18 +26,8 @@ const labeledValue = [
   `  </LabeledValue>`,
 ].join("\n");
 
-interface Snippet {
-  components: string[];
-  header: string[];
-  section: string[];
-}
-
-const snippet = ({ components, header, section }: Snippet): string =>
+const snippet = (header: string[], section: string[]): string =>
   [
-    "import {",
-    ...components.map((component) => `  ${component},`),
-    `} from "@mittwald/flow-react-components";`,
-    "",
     "<Section>",
     "  <Header>",
     ...header,
@@ -29,42 +36,16 @@ const snippet = ({ components, header, section }: Snippet): string =>
     "</Section>",
   ].join("\n");
 
-const base = ["Header", "Heading", "Section"];
-const withValue = [
-  "Header",
-  "Heading",
-  "InlineCode",
-  "Label",
-  "LabeledValue",
-  "Section",
-];
-const withAction = ["Button", ...withValue];
-
 /**
  * The composition the "Fokus auf Developer Experience" tile builds up, one
  * nested layer per step — the app details of the Anlegeprozess pattern.
  *
- * Every step inserts at a single position: a contiguous run of imports (the
- * component names are picked so the additions stay adjacent in alphabetical
- * order) or a block inside `<Header>` or `<Section>`. That is what lets the
- * animation type the difference between two steps.
+ * Every step inserts a block at a single position, inside `<Header>` or
+ * `<Section>`. That is what lets the animation type the difference between two
+ * steps.
  */
 export const codeSteps = [
-  snippet({ components: base, header: [heading], section: [] }),
-  snippet({ components: withValue, header: [heading], section: [] }),
-  snippet({
-    components: withValue,
-    header: [heading],
-    section: [labeledValue],
-  }),
-  snippet({
-    components: withAction,
-    header: [heading],
-    section: [labeledValue],
-  }),
-  snippet({
-    components: withAction,
-    header: [heading, headerAction],
-    section: [labeledValue],
-  }),
+  snippet([heading], []),
+  snippet([heading], [labeledValue]),
+  snippet([heading, headerAction], [labeledValue]),
 ];

--- a/apps/docs/src/app/_components/HomeCodeExample/codeSteps.ts
+++ b/apps/docs/src/app/_components/HomeCodeExample/codeSteps.ts
@@ -9,9 +9,8 @@ const components = [
 ];
 
 /**
- * The editor shows the composition alone — spelled out, the import of seven
- * components takes more room than the example itself. The editor scope is still
- * derived from a real import statement, just one the reader never sees.
+ * Source of the editor scope. The steps leave the import out on purpose —
+ * spelled out it takes more room in the tile than the composition itself.
  */
 export const scopeSource = `import { ${components.join(", ")} } from "@mittwald/flow-react-components";`;
 
@@ -39,14 +38,9 @@ const snippet = (header: string[], section: string[]): string =>
   ].join("\n");
 
 /**
- * The composition the "Fokus auf Developer Experience" tile builds up, one
- * nested layer per step — a profile section in the shape of the detail page
- * pattern. It starts from the bare `<Section>`, so every component the reader
- * sees was typed in front of them.
- *
- * Every step inserts a block at a single position, inside `<Header>` or
- * `<Section>`. That is what lets the animation type the difference between two
- * steps.
+ * Every step must add one block at a single position — that is what lets the
+ * animation type the difference between two steps. A step that wraps an
+ * existing element or grows in two places appears at once instead.
  */
 export const codeSteps = [
   snippet([], []),

--- a/apps/docs/src/app/_components/HomeCodeExample/codeSteps.ts
+++ b/apps/docs/src/app/_components/HomeCodeExample/codeSteps.ts
@@ -1,11 +1,18 @@
-const heading = `  <Heading>Domain hinzufügen</Heading>`;
+const heading = `  <Heading>WordPress 6.5.3</Heading>`;
 
-const text = `  <Text>Verbinde deine Domain mit deinem Projekt.</Text>`;
+const labeledValue = [
+  `  <LabeledValue>`,
+  `    <Label>Installationsverzeichnis</Label>`,
+  `    <InlineCode>/wordpress-th6v8</InlineCode>`,
+  `  </LabeledValue>`,
+].join("\n");
 
 const actionGroup = [
   `  <ActionGroup>`,
-  `    <Button color="accent">Domain verbinden</Button>`,
-  `    <Button color="secondary" variant="soft">Abbrechen</Button>`,
+  `    <Button color="accent">App öffnen</Button>`,
+  `    <Button color="secondary" variant="soft">`,
+  `      Einstellungen`,
+  `    </Button>`,
   `  </ActionGroup>`,
 ].join("\n");
 
@@ -21,19 +28,22 @@ const snippet = (components: string[], children: string[]): string =>
   ].join("\n");
 
 const base = ["Heading", "Section"];
-const withText = [...base, "Text"];
-const withActions = ["ActionGroup", "Button", ...withText];
+const withValue = ["Heading", "InlineCode", "Label", "LabeledValue", "Section"];
+const withActions = ["ActionGroup", "Button", ...withValue];
 
 /**
  * The composition the "Fokus auf Developer Experience" tile builds up, one
- * nested layer per step. Every step inserts at a single position (either inside
- * the import braces or before the closing `</Section>`) so the animation can
- * type the difference between two steps.
+ * nested layer per step — the app details of the Anlegeprozess pattern.
+ *
+ * Every step inserts at a single position: a contiguous run of imports (the
+ * component names are picked so the additions stay adjacent in alphabetical
+ * order) or a block before the closing `</Section>`. That is what lets the
+ * animation type the difference between two steps.
  */
 export const codeSteps = [
   snippet(base, [heading]),
-  snippet(withText, [heading]),
-  snippet(withText, [heading, text]),
-  snippet(withActions, [heading, text]),
-  snippet(withActions, [heading, text, actionGroup]),
+  snippet(withValue, [heading]),
+  snippet(withValue, [heading, labeledValue]),
+  snippet(withActions, [heading, labeledValue]),
+  snippet(withActions, [heading, labeledValue, actionGroup]),
 ];

--- a/apps/docs/src/app/_components/HomeCodeExample/codeSteps.ts
+++ b/apps/docs/src/app/_components/HomeCodeExample/codeSteps.ts
@@ -1,4 +1,6 @@
-const heading = `  <Heading>WordPress 6.5.3</Heading>`;
+const heading = `    <Heading>WordPress 6.5.3</Heading>`;
+
+const headerAction = `    <Button color="secondary" variant="soft">Öffnen</Button>`;
 
 const labeledValue = [
   `  <LabeledValue>`,
@@ -7,29 +9,36 @@ const labeledValue = [
   `  </LabeledValue>`,
 ].join("\n");
 
-const actionGroup = [
-  `  <ActionGroup>`,
-  `    <Button color="accent">App öffnen</Button>`,
-  `    <Button color="secondary" variant="soft">`,
-  `      Einstellungen`,
-  `    </Button>`,
-  `  </ActionGroup>`,
-].join("\n");
+interface Snippet {
+  components: string[];
+  header: string[];
+  section: string[];
+}
 
-const snippet = (components: string[], children: string[]): string =>
+const snippet = ({ components, header, section }: Snippet): string =>
   [
     "import {",
     ...components.map((component) => `  ${component},`),
     `} from "@mittwald/flow-react-components";`,
     "",
     "<Section>",
-    ...children,
+    "  <Header>",
+    ...header,
+    "  </Header>",
+    ...section,
     "</Section>",
   ].join("\n");
 
-const base = ["Heading", "Section"];
-const withValue = ["Heading", "InlineCode", "Label", "LabeledValue", "Section"];
-const withActions = ["ActionGroup", "Button", ...withValue];
+const base = ["Header", "Heading", "Section"];
+const withValue = [
+  "Header",
+  "Heading",
+  "InlineCode",
+  "Label",
+  "LabeledValue",
+  "Section",
+];
+const withAction = ["Button", ...withValue];
 
 /**
  * The composition the "Fokus auf Developer Experience" tile builds up, one
@@ -37,13 +46,25 @@ const withActions = ["ActionGroup", "Button", ...withValue];
  *
  * Every step inserts at a single position: a contiguous run of imports (the
  * component names are picked so the additions stay adjacent in alphabetical
- * order) or a block before the closing `</Section>`. That is what lets the
+ * order) or a block inside `<Header>` or `<Section>`. That is what lets the
  * animation type the difference between two steps.
  */
 export const codeSteps = [
-  snippet(base, [heading]),
-  snippet(withValue, [heading]),
-  snippet(withValue, [heading, labeledValue]),
-  snippet(withActions, [heading, labeledValue]),
-  snippet(withActions, [heading, labeledValue, actionGroup]),
+  snippet({ components: base, header: [heading], section: [] }),
+  snippet({ components: withValue, header: [heading], section: [] }),
+  snippet({
+    components: withValue,
+    header: [heading],
+    section: [labeledValue],
+  }),
+  snippet({
+    components: withAction,
+    header: [heading],
+    section: [labeledValue],
+  }),
+  snippet({
+    components: withAction,
+    header: [heading, headerAction],
+    section: [labeledValue],
+  }),
 ];

--- a/apps/docs/src/app/_components/HomeCodeExample/codeSteps.ts
+++ b/apps/docs/src/app/_components/HomeCodeExample/codeSteps.ts
@@ -1,0 +1,39 @@
+const heading = `  <Heading>Domain hinzufügen</Heading>`;
+
+const text = `  <Text>Verbinde deine Domain mit deinem Projekt.</Text>`;
+
+const actionGroup = [
+  `  <ActionGroup>`,
+  `    <Button color="accent">Domain verbinden</Button>`,
+  `    <Button color="secondary" variant="soft">Abbrechen</Button>`,
+  `  </ActionGroup>`,
+].join("\n");
+
+const snippet = (components: string[], children: string[]): string =>
+  [
+    "import {",
+    ...components.map((component) => `  ${component},`),
+    `} from "@mittwald/flow-react-components";`,
+    "",
+    "<Section>",
+    ...children,
+    "</Section>",
+  ].join("\n");
+
+const base = ["Heading", "Section"];
+const withText = [...base, "Text"];
+const withActions = ["ActionGroup", "Button", ...withText];
+
+/**
+ * The composition the "Fokus auf Developer Experience" tile builds up, one
+ * nested layer per step. Every step inserts at a single position (either inside
+ * the import braces or before the closing `</Section>`) so the animation can
+ * type the difference between two steps.
+ */
+export const codeSteps = [
+  snippet(base, [heading]),
+  snippet(withText, [heading]),
+  snippet(withText, [heading, text]),
+  snippet(withActions, [heading, text]),
+  snippet(withActions, [heading, text, actionGroup]),
+];

--- a/apps/docs/src/app/_components/HomeCodeExample/codeSteps.ts
+++ b/apps/docs/src/app/_components/HomeCodeExample/codeSteps.ts
@@ -33,9 +33,7 @@ const labeledValue = [
 const snippet = (header: string[], section: string[]): string =>
   [
     "<Section>",
-    "  <Header>",
-    ...header,
-    "  </Header>",
+    ...(header.length > 0 ? ["  <Header>", ...header, "  </Header>"] : []),
     ...section,
     "</Section>",
   ].join("\n");
@@ -43,13 +41,15 @@ const snippet = (header: string[], section: string[]): string =>
 /**
  * The composition the "Fokus auf Developer Experience" tile builds up, one
  * nested layer per step — a profile section in the shape of the detail page
- * pattern.
+ * pattern. It starts from the bare `<Section>`, so every component the reader
+ * sees was typed in front of them.
  *
  * Every step inserts a block at a single position, inside `<Header>` or
  * `<Section>`. That is what lets the animation type the difference between two
  * steps.
  */
 export const codeSteps = [
+  snippet([], []),
   snippet([heading], []),
   snippet([heading], [labeledValue]),
   snippet([heading, headerAction], [labeledValue]),

--- a/apps/docs/src/app/_components/HomeCodeExample/codeSteps.ts
+++ b/apps/docs/src/app/_components/HomeCodeExample/codeSteps.ts
@@ -1,8 +1,8 @@
 const components = [
   "Button",
+  "Content",
   "Header",
   "Heading",
-  "InlineCode",
   "Label",
   "LabeledValue",
   "Section",
@@ -15,14 +15,18 @@ const components = [
  */
 export const scopeSource = `import { ${components.join(", ")} } from "@mittwald/flow-react-components";`;
 
-const heading = `    <Heading>WordPress 6.5.3</Heading>`;
+const heading = `    <Heading>Profil</Heading>`;
 
-const headerAction = `    <Button color="secondary" variant="soft">Öffnen</Button>`;
+const headerAction = [
+  `    <Button color="secondary" variant="soft">`,
+  `      Bearbeiten`,
+  `    </Button>`,
+].join("\n");
 
 const labeledValue = [
   `  <LabeledValue>`,
-  `    <Label>Installationsverzeichnis</Label>`,
-  `    <InlineCode>/wordpress-th6v8</InlineCode>`,
+  `    <Label>E-Mail-Adresse</Label>`,
+  `    <Content>max@mustermann.de</Content>`,
   `  </LabeledValue>`,
 ].join("\n");
 
@@ -38,7 +42,8 @@ const snippet = (header: string[], section: string[]): string =>
 
 /**
  * The composition the "Fokus auf Developer Experience" tile builds up, one
- * nested layer per step — the app details of the Anlegeprozess pattern.
+ * nested layer per step — a profile section in the shape of the detail page
+ * pattern.
  *
  * Every step inserts a block at a single position, inside `<Header>` or
  * `<Section>`. That is what lets the animation type the difference between two

--- a/apps/docs/src/app/_components/HomeCodeExample/index.ts
+++ b/apps/docs/src/app/_components/HomeCodeExample/index.ts
@@ -1,0 +1,3 @@
+import HomeCodeExample from "@/app/_components/HomeCodeExample/HomeCodeExample";
+
+export default HomeCodeExample;

--- a/apps/docs/src/app/_components/HomeCodeExample/useTypedCode.ts
+++ b/apps/docs/src/app/_components/HomeCodeExample/useTypedCode.ts
@@ -16,11 +16,8 @@ interface Frame {
 }
 
 interface TypedCode {
-  /** The code of the current animation frame. */
   code: string;
-  /** Whether the animation is still running. */
   isTyping: boolean;
-  /** Jumps to the last step and stops the animation. */
   skip: () => void;
 }
 
@@ -30,15 +27,13 @@ const useIsomorphicLayoutEffect =
 const prefersReducedMotion = (): boolean =>
   window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
-/** Whether an insertion adds whole lines: starts on a fresh line, ends on one. */
 const insertsWholeLines = (text: string): boolean =>
   text.startsWith("\n") && !text.endsWith("\n");
 
 /**
- * The same insertion can be described at several positions — inserting `b\na`
- * before an `a` equals inserting `a\nb` after it. Prefers the description that
- * adds whole lines, so the new block is typed on its own line instead of
- * growing out of the line that follows it.
+ * An insertion can be described at several positions — inserting `b\na` before
+ * an `a` equals inserting `a\nb` after it. Picking the whole-line description
+ * types a new block on its own line instead of growing it out of the next one.
  */
 const preferWholeLines = (from: string, insertion: Insertion): Insertion => {
   let shifted = insertion;
@@ -57,10 +52,6 @@ const preferWholeLines = (from: string, insertion: Insertion): Insertion => {
   return insertsWholeLines(shifted.text) ? shifted : insertion;
 };
 
-/**
- * Describes `to` as a single chunk of text inserted into `from` — or
- * `undefined` when `to` is not just `from` with something inserted.
- */
 const getInsertion = (from: string, to: string): Insertion | undefined => {
   if (to.length <= from.length) {
     return undefined;
@@ -128,11 +119,6 @@ const buildFrames = (steps: string[]): Frame[] => {
   return frames;
 };
 
-/**
- * Types the given code steps into the editor, one nested layer at a time.
- * Renders the last step right away when the animation is disabled, skipped or
- * when the user prefers reduced motion.
- */
 export const useTypedCode = (steps: string[], enabled: boolean): TypedCode => {
   const finalCode = steps.at(-1) ?? "";
 
@@ -159,8 +145,9 @@ export const useTypedCode = (steps: string[], enabled: boolean): TypedCode => {
       return;
     }
 
-    // Applied synchronously — a frame of the finished example would flash
-    // otherwise, because timers only run after the browser has painted.
+    // Synchronously, and from a layout effect: the state this replaces is the
+    // finished example, so anything that lands after the first paint — a plain
+    // effect, or leaving the first frame to the timer — flashes it.
     setCode(firstFrame.code);
 
     let timeout: ReturnType<typeof setTimeout>;

--- a/apps/docs/src/app/_components/HomeCodeExample/useTypedCode.ts
+++ b/apps/docs/src/app/_components/HomeCodeExample/useTypedCode.ts
@@ -1,0 +1,194 @@
+"use client";
+import { useCallback, useEffect, useLayoutEffect, useState } from "react";
+
+const charDelay = 14;
+const lineDelay = 60;
+const stepDelay = 500;
+
+interface Insertion {
+  at: number;
+  text: string;
+}
+
+interface Frame {
+  code: string;
+  delay: number;
+}
+
+interface TypedCode {
+  /** The code of the current animation frame. */
+  code: string;
+  /** Whether the animation is still running. */
+  isTyping: boolean;
+  /** Jumps to the last step and stops the animation. */
+  skip: () => void;
+}
+
+const useIsomorphicLayoutEffect =
+  typeof window === "undefined" ? useEffect : useLayoutEffect;
+
+const prefersReducedMotion = (): boolean =>
+  window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+/** Whether an insertion adds whole lines: starts on a fresh line, ends on one. */
+const insertsWholeLines = (text: string): boolean =>
+  text.startsWith("\n") && !text.endsWith("\n");
+
+/**
+ * The same insertion can be described at several positions — inserting `b\na`
+ * before an `a` equals inserting `a\nb` after it. Prefers the description that
+ * adds whole lines, so the new block is typed on its own line instead of
+ * growing out of the line that follows it.
+ */
+const preferWholeLines = (from: string, insertion: Insertion): Insertion => {
+  let shifted = insertion;
+
+  while (
+    !insertsWholeLines(shifted.text) &&
+    shifted.at > 0 &&
+    from[shifted.at - 1] === shifted.text.at(-1)
+  ) {
+    shifted = {
+      at: shifted.at - 1,
+      text: `${shifted.text.at(-1)}${shifted.text.slice(0, -1)}`,
+    };
+  }
+
+  return insertsWholeLines(shifted.text) ? shifted : insertion;
+};
+
+/**
+ * Describes `to` as a single chunk of text inserted into `from` — or
+ * `undefined` when `to` is not just `from` with something inserted.
+ */
+const getInsertion = (from: string, to: string): Insertion | undefined => {
+  if (to.length <= from.length) {
+    return undefined;
+  }
+
+  let at = 0;
+  while (at < from.length && from[at] === to[at]) {
+    at++;
+  }
+
+  let suffixLength = 0;
+  while (
+    suffixLength < from.length - at &&
+    from[from.length - 1 - suffixLength] === to[to.length - 1 - suffixLength]
+  ) {
+    suffixLength++;
+  }
+
+  if (at + suffixLength !== from.length) {
+    return undefined;
+  }
+
+  return preferWholeLines(from, {
+    at,
+    text: to.slice(at, to.length - suffixLength),
+  });
+};
+
+const buildFrames = (steps: string[]): Frame[] => {
+  const [firstStep, ...nextSteps] = steps;
+
+  if (firstStep === undefined) {
+    return [];
+  }
+
+  const frames: Frame[] = [{ code: firstStep, delay: 0 }];
+  let previousStep = firstStep;
+
+  for (const step of nextSteps) {
+    const insertion = getInsertion(previousStep, step);
+
+    if (insertion === undefined) {
+      frames.push({ code: step, delay: stepDelay });
+    } else {
+      const prefix = previousStep.slice(0, insertion.at);
+      const suffix = previousStep.slice(insertion.at);
+
+      for (let length = 1; length <= insertion.text.length; length++) {
+        const typed = insertion.text.slice(0, length);
+        frames.push({
+          code: `${prefix}${typed}${suffix}`,
+          delay:
+            length === 1
+              ? stepDelay
+              : typed.endsWith("\n")
+                ? lineDelay
+                : charDelay,
+        });
+      }
+    }
+
+    previousStep = step;
+  }
+
+  return frames;
+};
+
+/**
+ * Types the given code steps into the editor, one nested layer at a time.
+ * Renders the last step right away when the animation is disabled, skipped or
+ * when the user prefers reduced motion.
+ */
+export const useTypedCode = (steps: string[], enabled: boolean): TypedCode => {
+  const finalCode = steps.at(-1) ?? "";
+
+  const [code, setCode] = useState(finalCode);
+  const [isFinished, setIsFinished] = useState(false);
+
+  const skip = useCallback(() => setIsFinished(true), []);
+
+  useIsomorphicLayoutEffect(() => {
+    if (!enabled || isFinished) {
+      return;
+    }
+
+    if (prefersReducedMotion()) {
+      setIsFinished(true);
+      return;
+    }
+
+    const frames = buildFrames(steps);
+    const [firstFrame] = frames;
+
+    if (firstFrame === undefined) {
+      setIsFinished(true);
+      return;
+    }
+
+    // Applied synchronously — a frame of the finished example would flash
+    // otherwise, because timers only run after the browser has painted.
+    setCode(firstFrame.code);
+
+    let timeout: ReturnType<typeof setTimeout>;
+    let index = 1;
+
+    const scheduleNextFrame = () => {
+      const frame = frames[index];
+
+      if (frame === undefined) {
+        setIsFinished(true);
+        return;
+      }
+
+      timeout = setTimeout(() => {
+        setCode(frame.code);
+        index++;
+        scheduleNextFrame();
+      }, frame.delay);
+    };
+
+    scheduleNextFrame();
+
+    return () => clearTimeout(timeout);
+  }, [steps, enabled, isFinished]);
+
+  return {
+    code: isFinished ? finalCode : code,
+    isTyping: enabled && !isFinished,
+    skip,
+  };
+};

--- a/apps/docs/src/app/_components/HomeCodeExample/useTypedCode.ts
+++ b/apps/docs/src/app/_components/HomeCodeExample/useTypedCode.ts
@@ -1,7 +1,7 @@
 "use client";
 import { useCallback, useEffect, useLayoutEffect, useState } from "react";
 
-const charDelay = 11;
+const charDelay = 16;
 const lineDelay = 60;
 const stepDelay = 400;
 

--- a/apps/docs/src/app/_components/HomeCodeExample/useTypedCode.ts
+++ b/apps/docs/src/app/_components/HomeCodeExample/useTypedCode.ts
@@ -1,9 +1,9 @@
 "use client";
 import { useCallback, useEffect, useLayoutEffect, useState } from "react";
 
-const charDelay = 14;
+const charDelay = 11;
 const lineDelay = 60;
-const stepDelay = 500;
+const stepDelay = 400;
 
 interface Insertion {
   at: number;

--- a/apps/docs/src/app/page.tsx
+++ b/apps/docs/src/app/page.tsx
@@ -19,36 +19,10 @@ import { FlowLogo } from "@/app/_components/layout/Header/FlowLogo";
 import darkmodeBg from "../../public/assets/darkmode-bg.png";
 import developerTile from "../../public/assets/developer-tile.png";
 import extensionsTile from "../../public/assets/extensions-tile.webp";
-import clsx from "clsx";
-import codeStyles from "@/lib/liveCode/components/LiveCodeEditor/LiveCodeEditor.module.css";
-import {
-  LiveEditor,
-  LivePreview,
-  LiveProvider,
-} from "@mfalkenberg/react-live-ssr";
-import { flowTheme } from "@/lib/liveCode/components/LiveCodeEditor/lib/flowTheme";
-import extractDefaultExport from "@/lib/liveCode/components/LiveCodeEditor/lib/extractDefaultExport";
-import { extractEditorScope } from "@/lib/liveCode/components/LiveCodeEditor/lib/extractEditorScope";
+import HomeCodeExample from "@/app/_components/HomeCodeExample";
 import styles from "./page.module.scss";
 
 const Home: FC = () => {
-  const transformCode = (code: string) => {
-    try {
-      return extractDefaultExport(code);
-    } catch (error) {
-      return `<p><em>Example could not be parsed:</em> ${String(error)}</p>`;
-    }
-  };
-
-  const code =
-    'import { Button } from "@mittwald/flow-react-components";\n' +
-    "\n" +
-    '<Button color="primary"> \n' +
-    "  Button\n" +
-    "</Button>";
-
-  const scope = extractEditorScope(code);
-
   return (
     <Flex direction="column" className={styles.wrapper} align="center">
       <Flex
@@ -116,19 +90,7 @@ const Home: FC = () => {
               Zu den Components
             </Link>
           </Section>
-          <LiveProvider transformCode={transformCode} code={code} scope={scope}>
-            <div className={clsx(codeStyles.liveCodeEditor)}>
-              <LivePreview className={clsx(codeStyles.preview)} />
-
-              <div className={codeStyles.editorContainer}>
-                <LiveEditor
-                  tabMode="focus"
-                  theme={flowTheme}
-                  className={codeStyles.editor}
-                />
-              </div>
-            </div>
-          </LiveProvider>
+          <HomeCodeExample />
         </ColumnLayout>
       </LayoutCard>
 


### PR DESCRIPTION
Closes #2824

The "Fokus auf Developer Experience" tile claimed nested components, automatic spacing and design system conformance while showing a single plain `Button`. None of the three was visible.

The example is now a profile section that composes itself from the bare `<Section>` — Header with its heading, then the labeled value, then the action. Every added layer snaps into place with the right spacing, and the header pushes its action to the opposite end on its own. That also ties the tile to its "Zu den Components" link.

```tsx
<Section>
  <Header>
    <Heading>Profil</Heading>
    <Button color="secondary" variant="soft">
      Bearbeiten
    </Button>
  </Header>
  <LabeledValue>
    <Label>E-Mail-Adresse</Label>
    <Content>max@mustermann.de</Content>
  </LabeledValue>
</Section>
```

The editor shows the composition without its import — spelled out, seven component names take more room than the example itself. The editor scope comes from a real import statement in `codeSteps.ts`, just one the reader never sees.

## How it behaves

- **Starts when the tile scrolls into view** (IntersectionObserver, 30 %). The tile sits below the fold; otherwise the animation would be over before anyone sees it.
- **Nothing moves.** The finished example is rendered server side; preview and code block each measure their final height on mount and hold it while typing, and the preview is top aligned during the run.
- **`prefers-reduced-motion`**: the last step immediately, no animation.
- **Stays a live example.** Focusing or clicking the editor jumps to the end and stops the animation; editing works as before.
- **`transformCode` keeps the last parsable preview** instead of rendering a parser error while the code is half typed. This also applies to manual edits.

## Implementation

`page.tsx` no longer builds the `LiveProvider` inline — it renders `<HomeCodeExample />`, which keeps the animation's re-renders out of the page component.

- `codeSteps.ts` — the four steps plus the import statement the scope is derived from. Each step inserts one block at a single position, inside `<Header>` or `<Section>`. That is what makes typing the difference between two steps possible.
- `useTypedCode.ts` — describes step *n+1* as one insertion into step *n*, expands it into frames and drives them with a timer chain. Insertions are normalised to whole lines, so a new block is typed on its own line instead of growing out of the line below it.
- `HomeCodeExample.tsx` — editor, height reservation, visibility trigger.

## Verified

Driven with Playwright against `pnpm nx dev docs`, sampled every 400 ms across the whole run:

- Tile 430 px, preview 143 px, code block 285 px, first code line 161 px — every value constant, and the heading stays at its offset of 25 px from the moment it appears.
- No horizontal scrolling in the code block at 1280 px, 1100 px or 390 px.
- Off screen the finished example stays put; scrolling in restarts it at `<Section></Section>` and it completes.
- Reduced motion keeps the complete example, on load and on scroll.
- Clicking the editor mid-run jumps to the end; editing "Bearbeiten" afterwards updates the button in the preview.
- Dark theme and 390 px width (no horizontal page overflow).

`pnpm lint`, `prettier --check` and `tsc --noEmit` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
