### PR TITLE
docs: render component property tables in three columns

### DIFF
--- a/apps/docs/src/lib/PropertiesTables/PropertiesTables.module.scss
+++ b/apps/docs/src/lib/PropertiesTables/PropertiesTables.module.scss
@@ -1,0 +1,35 @@
+.propertyName {
+  background-color: transparent;
+  padding-inline: 0;
+  font-weight: var(--font-weight--bold);
+  overflow-wrap: anywhere;
+}
+
+.propertyCell {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--size-px--xs);
+}
+
+.type {
+  overflow-wrap: anywhere;
+}
+
+.typeChips {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: var(--size-px--xs);
+}
+
+.typeCell {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--size-px--xs);
+}
+
+.defaultValue {
+  font-size: var(--label--font-size);
+  color: var(--label--color--default);
+}

--- a/apps/docs/src/lib/PropertiesTables/PropertiesTables.module.scss
+++ b/apps/docs/src/lib/PropertiesTables/PropertiesTables.module.scss
@@ -1,8 +1,3 @@
-.propertyName {
-  font-family: FiraCode, monospace;
-  overflow-wrap: anywhere;
-}
-
 .propertyCell {
   display: flex;
   flex-wrap: wrap;
@@ -14,12 +9,6 @@
   overflow-wrap: anywhere;
 }
 
-.typeChips {
-  display: inline-flex;
-  flex-wrap: wrap;
-  gap: var(--size-px--xs);
-}
-
 .typeCell {
   display: flex;
   flex-direction: column;
@@ -27,7 +16,8 @@
   gap: var(--size-px--xs);
 }
 
-.defaultValue {
+.defaultValue,
+.defaultMarker {
   font-size: var(--label--font-size);
   color: var(--label--color--default);
 }

--- a/apps/docs/src/lib/PropertiesTables/PropertiesTables.module.scss
+++ b/apps/docs/src/lib/PropertiesTables/PropertiesTables.module.scss
@@ -1,7 +1,5 @@
 .propertyName {
-  background-color: transparent;
-  padding-inline: 0;
-  font-weight: var(--font-weight--bold);
+  font-family: FiraCode, monospace;
   overflow-wrap: anywhere;
 }
 

--- a/apps/docs/src/lib/PropertiesTables/components/PropertiesTable.tsx
+++ b/apps/docs/src/lib/PropertiesTables/components/PropertiesTable.tsx
@@ -14,20 +14,17 @@ interface PropertiesTableProps {
 
 export const PropertiesTable: FC<PropertiesTableProps> = ({ properties }) => {
   return (
-    <>
-      <Table aria-label="Properties">
-        <TableHeader>
-          <TableColumn>Property</TableColumn>
-          <TableColumn>Type</TableColumn>
-          <TableColumn>Default</TableColumn>
-          <TableColumn>Description</TableColumn>
-        </TableHeader>
-        <TableBody>
-          {properties.map((prop) => (
-            <PropertyRow property={prop} key={prop.name}></PropertyRow>
-          ))}
-        </TableBody>
-      </Table>
-    </>
+    <Table aria-label="Properties" layout="fixed" minWidth={640}>
+      <TableHeader>
+        <TableColumn width="22%">Property</TableColumn>
+        <TableColumn width="34%">Type</TableColumn>
+        <TableColumn width="44%">Description</TableColumn>
+      </TableHeader>
+      <TableBody>
+        {properties.map((prop) => (
+          <PropertyRow property={prop} key={prop.name}></PropertyRow>
+        ))}
+      </TableBody>
+    </Table>
   );
 };

--- a/apps/docs/src/lib/PropertiesTables/components/PropertyRow.tsx
+++ b/apps/docs/src/lib/PropertiesTables/components/PropertyRow.tsx
@@ -39,7 +39,7 @@ export const PropertyRow: FC<PropertyTableGroupProps> = ({ property }) => {
           <Text className={styles.type}>
             <TypeValue {...type} />
           </Text>
-          {property.default && !type.includesDefault && (
+          {property.default && !type.defaultMember && (
             <Text className={styles.defaultValue}>
               default: {property.default}
             </Text>

--- a/apps/docs/src/lib/PropertiesTables/components/PropertyRow.tsx
+++ b/apps/docs/src/lib/PropertiesTables/components/PropertyRow.tsx
@@ -1,10 +1,16 @@
 import type { FC } from "react";
 import type { Property } from "../types";
-import { TableCell, TableRow, Text } from "@mittwald/flow-react-components";
+import {
+  InlineCode,
+  TableCell,
+  TableRow,
+  Text,
+} from "@mittwald/flow-react-components";
 import { createCustomComponents } from "@/lib/mdx/components/MdxFileView/customComponents";
 import Markdown from "react-markdown";
 import { omit } from "remeda";
 import { Badge } from "@mittwald/flow-react-components";
+import { formatType } from "@/lib/PropertiesTables/lib/unionType";
 import { TypeValue } from "./TypeValue";
 import styles from "../PropertiesTables.module.scss";
 
@@ -18,25 +24,24 @@ export const PropertyRow: FC<PropertyTableGroupProps> = ({ property }) => {
     .replaceAll(/{@link (\S+)}/g, "[$1]($1)");
 
   const customComponents = createCustomComponents();
+  const type = formatType(property.type, property.default);
 
   return (
     <TableRow>
       <TableCell>
         <div className={styles.propertyCell}>
-          <Text className={styles.propertyName}>
-            <small>
-              <strong>{property.name}</strong>
-            </small>
-          </Text>
+          <InlineCode>{property.name}</InlineCode>
           {property.required && <Badge>Required</Badge>}
         </div>
       </TableCell>
       <TableCell>
         <div className={styles.typeCell}>
-          <TypeValue type={property.type} />
-          {property.default && (
+          <Text className={styles.type}>
+            <TypeValue {...type} />
+          </Text>
+          {property.default && !type.includesDefault && (
             <Text className={styles.defaultValue}>
-              Default: {property.default}
+              default: {property.default}
             </Text>
           )}
         </div>

--- a/apps/docs/src/lib/PropertiesTables/components/PropertyRow.tsx
+++ b/apps/docs/src/lib/PropertiesTables/components/PropertyRow.tsx
@@ -1,7 +1,6 @@
 import type { FC } from "react";
 import type { Property } from "../types";
 import { TableCell, TableRow, Text } from "@mittwald/flow-react-components";
-import { InlineCode } from "@mittwald/flow-react-components";
 import { createCustomComponents } from "@/lib/mdx/components/MdxFileView/customComponents";
 import Markdown from "react-markdown";
 import { omit } from "remeda";
@@ -24,9 +23,11 @@ export const PropertyRow: FC<PropertyTableGroupProps> = ({ property }) => {
     <TableRow>
       <TableCell>
         <div className={styles.propertyCell}>
-          <InlineCode className={styles.propertyName}>
-            {property.name}
-          </InlineCode>
+          <Text className={styles.propertyName}>
+            <small>
+              <strong>{property.name}</strong>
+            </small>
+          </Text>
           {property.required && <Badge>Required</Badge>}
         </div>
       </TableCell>

--- a/apps/docs/src/lib/PropertiesTables/components/PropertyRow.tsx
+++ b/apps/docs/src/lib/PropertiesTables/components/PropertyRow.tsx
@@ -1,11 +1,13 @@
 import type { FC } from "react";
 import type { Property } from "../types";
-import { TableCell, TableRow } from "@mittwald/flow-react-components";
+import { TableCell, TableRow, Text } from "@mittwald/flow-react-components";
 import { InlineCode } from "@mittwald/flow-react-components";
 import { createCustomComponents } from "@/lib/mdx/components/MdxFileView/customComponents";
 import Markdown from "react-markdown";
 import { omit } from "remeda";
 import { Badge } from "@mittwald/flow-react-components";
+import { TypeValue } from "./TypeValue";
+import styles from "../PropertiesTables.module.scss";
 
 export interface PropertyTableGroupProps {
   property: Property;
@@ -21,23 +23,37 @@ export const PropertyRow: FC<PropertyTableGroupProps> = ({ property }) => {
   return (
     <TableRow>
       <TableCell>
-        <InlineCode whiteSpace="nowrap">{property.name}</InlineCode>
-        {property.required && <Badge>Required</Badge>}
+        <div className={styles.propertyCell}>
+          <InlineCode className={styles.propertyName}>
+            {property.name}
+          </InlineCode>
+          {property.required && <Badge>Required</Badge>}
+        </div>
       </TableCell>
-      <TableCell>{property.type}</TableCell>
-      <TableCell>{property.default || "-"}</TableCell>
       <TableCell>
-        <Markdown
-          components={omit(customComponents, [
-            "Content",
-            "Heading",
-            "Alert",
-            "DoAndDont",
-            "ColumnLayout",
-          ])}
-        >
-          {formattedDescription}
-        </Markdown>
+        <div className={styles.typeCell}>
+          <TypeValue type={property.type} />
+          {property.default && (
+            <Text className={styles.defaultValue}>
+              Default: {property.default}
+            </Text>
+          )}
+        </div>
+      </TableCell>
+      <TableCell>
+        <Text elementType="div">
+          <Markdown
+            components={omit(customComponents, [
+              "Content",
+              "Heading",
+              "Alert",
+              "DoAndDont",
+              "ColumnLayout",
+            ])}
+          >
+            {formattedDescription}
+          </Markdown>
+        </Text>
       </TableCell>
     </TableRow>
   );

--- a/apps/docs/src/lib/PropertiesTables/components/StaticPropertiesTables.tsx
+++ b/apps/docs/src/lib/PropertiesTables/components/StaticPropertiesTables.tsx
@@ -25,7 +25,7 @@ const StaticRow: FC<{ property: Property }> = ({ property }) => {
           <span className={styles.type}>
             <TypeValue {...type} />
           </span>
-          {property.default && !type.includesDefault && (
+          {property.default && !type.defaultMember && (
             <span className={styles.defaultValue}>
               default: {property.default}
             </span>

--- a/apps/docs/src/lib/PropertiesTables/components/StaticPropertiesTables.tsx
+++ b/apps/docs/src/lib/PropertiesTables/components/StaticPropertiesTables.tsx
@@ -22,9 +22,11 @@ const StaticTable: FC<{ properties: Property[] }> = ({ properties }) => (
         <tr className="flow--table--row" key={property.name}>
           <td className="flow--table--cell">
             <div className={styles.propertyCell}>
-              <code className={`flow--inline-code ${styles.propertyName}`}>
-                {property.name}
-              </code>
+              <span className={styles.propertyName}>
+                <small>
+                  <strong>{property.name}</strong>
+                </small>
+              </span>
               {property.required ? " (required)" : ""}
             </div>
           </td>

--- a/apps/docs/src/lib/PropertiesTables/components/StaticPropertiesTables.tsx
+++ b/apps/docs/src/lib/PropertiesTables/components/StaticPropertiesTables.tsx
@@ -1,5 +1,7 @@
 import type { FC } from "react";
 import type { Properties, Property } from "@/lib/PropertiesTables/types";
+import { TypeValue } from "./TypeValue";
+import styles from "../PropertiesTables.module.scss";
 
 const formatDescription = (description: string | null | undefined): string =>
   (description ?? "")
@@ -12,7 +14,6 @@ const StaticTable: FC<{ properties: Property[] }> = ({ properties }) => (
       <tr className="flow--table--row">
         <th className="flow--table--column">Property</th>
         <th className="flow--table--column">Type</th>
-        <th className="flow--table--column">Default</th>
         <th className="flow--table--column">Description</th>
       </tr>
     </thead>
@@ -20,13 +21,23 @@ const StaticTable: FC<{ properties: Property[] }> = ({ properties }) => (
       {properties.map((property) => (
         <tr className="flow--table--row" key={property.name}>
           <td className="flow--table--cell">
-            <code>{property.name}</code>
-            {property.required ? " (required)" : ""}
+            <div className={styles.propertyCell}>
+              <code className={`flow--inline-code ${styles.propertyName}`}>
+                {property.name}
+              </code>
+              {property.required ? " (required)" : ""}
+            </div>
           </td>
           <td className="flow--table--cell">
-            <code>{property.type}</code>
+            <div className={styles.typeCell}>
+              <TypeValue type={property.type} />
+              {property.default && (
+                <span className={styles.defaultValue}>
+                  Default: {property.default}
+                </span>
+              )}
+            </div>
           </td>
-          <td className="flow--table--cell">{property.default || "-"}</td>
           <td className="flow--table--cell">
             {formatDescription(property.description)}
           </td>

--- a/apps/docs/src/lib/PropertiesTables/components/StaticPropertiesTables.tsx
+++ b/apps/docs/src/lib/PropertiesTables/components/StaticPropertiesTables.tsx
@@ -1,5 +1,6 @@
 import type { FC } from "react";
 import type { Properties, Property } from "@/lib/PropertiesTables/types";
+import { formatType } from "@/lib/PropertiesTables/lib/unionType";
 import { TypeValue } from "./TypeValue";
 import styles from "../PropertiesTables.module.scss";
 
@@ -7,6 +8,36 @@ const formatDescription = (description: string | null | undefined): string =>
   (description ?? "")
     .replaceAll(/{@link (\S+) (.+?)}/g, "$2")
     .replaceAll(/{@link (\S+)}/g, "$1");
+
+const StaticRow: FC<{ property: Property }> = ({ property }) => {
+  const type = formatType(property.type, property.default);
+
+  return (
+    <tr className="flow--table--row">
+      <td className="flow--table--cell">
+        <div className={styles.propertyCell}>
+          <code className="flow--inline-code">{property.name}</code>
+          {property.required ? " (required)" : ""}
+        </div>
+      </td>
+      <td className="flow--table--cell">
+        <div className={styles.typeCell}>
+          <span className={styles.type}>
+            <TypeValue {...type} />
+          </span>
+          {property.default && !type.includesDefault && (
+            <span className={styles.defaultValue}>
+              default: {property.default}
+            </span>
+          )}
+        </div>
+      </td>
+      <td className="flow--table--cell">
+        {formatDescription(property.description)}
+      </td>
+    </tr>
+  );
+};
 
 const StaticTable: FC<{ properties: Property[] }> = ({ properties }) => (
   <table aria-label="Properties" className="flow--table">
@@ -19,31 +50,7 @@ const StaticTable: FC<{ properties: Property[] }> = ({ properties }) => (
     </thead>
     <tbody className="flow--table--body">
       {properties.map((property) => (
-        <tr className="flow--table--row" key={property.name}>
-          <td className="flow--table--cell">
-            <div className={styles.propertyCell}>
-              <span className={styles.propertyName}>
-                <small>
-                  <strong>{property.name}</strong>
-                </small>
-              </span>
-              {property.required ? " (required)" : ""}
-            </div>
-          </td>
-          <td className="flow--table--cell">
-            <div className={styles.typeCell}>
-              <TypeValue type={property.type} />
-              {property.default && (
-                <span className={styles.defaultValue}>
-                  Default: {property.default}
-                </span>
-              )}
-            </div>
-          </td>
-          <td className="flow--table--cell">
-            {formatDescription(property.description)}
-          </td>
-        </tr>
+        <StaticRow property={property} key={property.name} />
       ))}
     </tbody>
   </table>

--- a/apps/docs/src/lib/PropertiesTables/components/TypeValue.tsx
+++ b/apps/docs/src/lib/PropertiesTables/components/TypeValue.tsx
@@ -2,13 +2,13 @@ import { Fragment, type FC } from "react";
 import type { FormattedType } from "@/lib/PropertiesTables/lib/unionType";
 import styles from "../PropertiesTables.module.scss";
 
-export const TypeValue: FC<FormattedType> = ({ members, includesDefault }) => (
+export const TypeValue: FC<FormattedType> = ({ members, defaultMember }) => (
   <>
     {members.map((member, index) => (
       <Fragment key={member}>
         {index > 0 && " | "}
         {member}
-        {index === 0 && includesDefault && (
+        {member === defaultMember && (
           <span className={styles.defaultMarker}> (default)</span>
         )}
       </Fragment>

--- a/apps/docs/src/lib/PropertiesTables/components/TypeValue.tsx
+++ b/apps/docs/src/lib/PropertiesTables/components/TypeValue.tsx
@@ -6,7 +6,7 @@ export const TypeValue: FC<FormattedType> = ({ members, includesDefault }) => (
   <>
     {members.map((member, index) => (
       <Fragment key={member}>
-        {index > 0 && ", "}
+        {index > 0 && " | "}
         {member}
         {index === 0 && includesDefault && (
           <span className={styles.defaultMarker}> (default)</span>

--- a/apps/docs/src/lib/PropertiesTables/components/TypeValue.tsx
+++ b/apps/docs/src/lib/PropertiesTables/components/TypeValue.tsx
@@ -1,24 +1,17 @@
-import type { FC } from "react";
-import { InlineCode } from "@mittwald/flow-react-components";
-import { splitUnion, unquote } from "@/lib/PropertiesTables/lib/unionType";
+import { Fragment, type FC } from "react";
+import type { FormattedType } from "@/lib/PropertiesTables/lib/unionType";
 import styles from "../PropertiesTables.module.scss";
 
-interface TypeValueProps {
-  type: string;
-}
-
-export const TypeValue: FC<TypeValueProps> = ({ type }) => {
-  const members = splitUnion(type);
-
-  if (members.length < 2) {
-    return <InlineCode className={styles.type}>{type}</InlineCode>;
-  }
-
-  return (
-    <span className={styles.typeChips}>
-      {members.map((member) => (
-        <InlineCode key={member}>{unquote(member)}</InlineCode>
-      ))}
-    </span>
-  );
-};
+export const TypeValue: FC<FormattedType> = ({ members, includesDefault }) => (
+  <>
+    {members.map((member, index) => (
+      <Fragment key={member}>
+        {index > 0 && ", "}
+        {member}
+        {index === 0 && includesDefault && (
+          <span className={styles.defaultMarker}> (default)</span>
+        )}
+      </Fragment>
+    ))}
+  </>
+);

--- a/apps/docs/src/lib/PropertiesTables/components/TypeValue.tsx
+++ b/apps/docs/src/lib/PropertiesTables/components/TypeValue.tsx
@@ -1,0 +1,24 @@
+import type { FC } from "react";
+import { InlineCode } from "@mittwald/flow-react-components";
+import { splitUnion, unquote } from "@/lib/PropertiesTables/lib/unionType";
+import styles from "../PropertiesTables.module.scss";
+
+interface TypeValueProps {
+  type: string;
+}
+
+export const TypeValue: FC<TypeValueProps> = ({ type }) => {
+  const members = splitUnion(type);
+
+  if (members.length < 2) {
+    return <InlineCode className={styles.type}>{type}</InlineCode>;
+  }
+
+  return (
+    <span className={styles.typeChips}>
+      {members.map((member) => (
+        <InlineCode key={member}>{unquote(member)}</InlineCode>
+      ))}
+    </span>
+  );
+};

--- a/apps/docs/src/lib/PropertiesTables/lib/loadProperties.ts
+++ b/apps/docs/src/lib/PropertiesTables/lib/loadProperties.ts
@@ -6,6 +6,14 @@ const eventRegex = /^on[A-Z]+.*/;
 const a11yRegex = /^aria-.+/;
 const optionalRegex = / \| (undefined|null)/g;
 
+/** An `@default: x` JSDoc tag keeps its colon in the generated metadata. */
+const normalizeDefaultValue = (value: unknown): string | null => {
+  if (typeof value !== "string") {
+    return null;
+  }
+  return value.replace(/^\s*:/, "").replace(/\s+/g, " ").trim() || null;
+};
+
 export default function loadProperties(name: string): Properties | null {
   const typeDocGenFile = (docGenFile ?? []) as unknown as ComponentDoc[];
   const componentDoc = typeDocGenFile.find(
@@ -28,7 +36,7 @@ export default function loadProperties(name: string): Properties | null {
       }
       return {
         name: prop.name,
-        default: prop.defaultValue ? prop.defaultValue.value : null,
+        default: normalizeDefaultValue(prop.defaultValue?.value),
         description: prop.description,
         required: prop.required,
         deprecated: prop.description.includes("@deprecated"),

--- a/apps/docs/src/lib/PropertiesTables/lib/unionType.ts
+++ b/apps/docs/src/lib/PropertiesTables/lib/unionType.ts
@@ -1,13 +1,20 @@
+import { partition } from "remeda";
+
 /** `Iterable<A | B> | null` yields two members, not three. */
-export const splitUnion = (type: string): string[] => {
+const splitUnion = (type: string): string[] => {
   const parts: string[] = [];
   let depth = 0;
   let current = "";
+  let previousChar = "";
 
   for (const char of type) {
+    // The ">" of an arrow function type closes nothing.
+    const isArrow = char === ">" && previousChar === "=";
+    previousChar = char;
+
     if ("<([{".includes(char)) {
       depth++;
-    } else if (">)]}".includes(char)) {
+    } else if (">)]}".includes(char) && !isArrow) {
       depth--;
     }
 
@@ -25,5 +32,30 @@ export const splitUnion = (type: string): string[] => {
 
 const stringLiteralPattern = /^["'](.*)["']$/;
 
-export const unquote = (member: string): string =>
+const unquote = (member: string): string =>
   member.replace(stringLiteralPattern, "$1");
+
+export interface FormattedType {
+  /** Union members in display order — the default value first. */
+  members: string[];
+  /** True when the first member is the default value. */
+  includesDefault: boolean;
+}
+
+export const formatType = (
+  type: string,
+  defaultValue?: string | null,
+): FormattedType => {
+  const members = splitUnion(type).map(unquote);
+  const trimmedDefault = defaultValue?.trim();
+  const normalizedDefault = trimmedDefault ? unquote(trimmedDefault) : null;
+  const [defaultMembers, otherMembers] = partition(
+    members,
+    (member) => member === normalizedDefault,
+  );
+
+  return {
+    members: [...defaultMembers, ...otherMembers],
+    includesDefault: defaultMembers.length > 0,
+  };
+};

--- a/apps/docs/src/lib/PropertiesTables/lib/unionType.ts
+++ b/apps/docs/src/lib/PropertiesTables/lib/unionType.ts
@@ -1,5 +1,3 @@
-import { partition } from "remeda";
-
 /** `Iterable<A | B> | null` yields two members, not three. */
 const splitUnion = (type: string): string[] => {
   const parts: string[] = [];
@@ -36,10 +34,9 @@ const unquote = (member: string): string =>
   member.replace(stringLiteralPattern, "$1");
 
 export interface FormattedType {
-  /** Union members in display order — the default value first. */
   members: string[];
-  /** True when the first member is the default value. */
-  includesDefault: boolean;
+  /** The member the default value refers to, if the type names one. */
+  defaultMember: string | null;
 }
 
 export const formatType = (
@@ -49,13 +46,10 @@ export const formatType = (
   const members = splitUnion(type).map(unquote);
   const trimmedDefault = defaultValue?.trim();
   const normalizedDefault = trimmedDefault ? unquote(trimmedDefault) : null;
-  const [defaultMembers, otherMembers] = partition(
-    members,
-    (member) => member === normalizedDefault,
-  );
 
   return {
-    members: [...defaultMembers, ...otherMembers],
-    includesDefault: defaultMembers.length > 0,
+    members,
+    defaultMember:
+      members.find((member) => member === normalizedDefault) ?? null,
   };
 };

--- a/apps/docs/src/lib/PropertiesTables/lib/unionType.ts
+++ b/apps/docs/src/lib/PropertiesTables/lib/unionType.ts
@@ -1,0 +1,29 @@
+/** `Iterable<A | B> | null` yields two members, not three. */
+export const splitUnion = (type: string): string[] => {
+  const parts: string[] = [];
+  let depth = 0;
+  let current = "";
+
+  for (const char of type) {
+    if ("<([{".includes(char)) {
+      depth++;
+    } else if (">)]}".includes(char)) {
+      depth--;
+    }
+
+    if (char === "|" && depth === 0) {
+      parts.push(current.trim());
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+  parts.push(current.trim());
+
+  return parts.filter(Boolean);
+};
+
+const stringLiteralPattern = /^["'](.*)["']$/;
+
+export const unquote = (member: string): string =>
+  member.replace(stringLiteralPattern, "$1");


### PR DESCRIPTION
The property tables squeezed the description into a narrow column and grew rows several lines tall; below ~900px content width the table cut the description off entirely.

- **3 columns instead of 4** — the `Default` column was `-` for most properties, its value now sits under the type. `layout="fixed"` with 22/34/44% and `minWidth={640}` so one long generic can't size the whole table.
- **Type column**: union members without their quotes, the member matching the default marked `(default)` in the muted label style. The `default:` line under the type only appears when nothing matches (`className`, `boolean`).
- **Property names wrap** instead of overflowing their column — `whiteSpace="nowrap"` plus a fixed layout let `excludeFromTabOrder` bleed into the Type column.
- The server-rendered fallback mirrors all of it, so mounting the react-aria table does not shift the page.
- Fixes a pre-existing display bug: defaults from an `@default: x` JSDoc tag kept their colon and rendered as `: true`.

Out of scope: `propertiesToMarkdown.ts` (`llms.txt`) keeps its four-column markdown — a machine-readable `Default` column is useful there.

Verified in-browser at 375/768/900/1280px against `Button`, `TextField`, `Select` and `Form`: nothing overflows, the table scrolls inside its own container on narrow viewports, and the static fallback matches the mounted table. No automated visual coverage exists for docs pages — worth a look at the rendered component pages during review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
