### PR TITLE
docs(SkeletonText): add component documentation

### DIFF
--- a/apps/docs/src/app/04-components/_components/wireframe/registry.ts
+++ b/apps/docs/src/app/04-components/_components/wireframe/registry.ts
@@ -73,6 +73,7 @@ import { SectionWireframe } from "@/app/04-components/_components/wireframe/wire
 import { SegmentedControlWireframe } from "@/app/04-components/_components/wireframe/wireframes/SegmentedControl";
 import { SelectWireframe } from "@/app/04-components/_components/wireframe/wireframes/Select";
 import { SeparatorWireframe } from "@/app/04-components/_components/wireframe/wireframes/Separator";
+import { SkeletonTextWireframe } from "@/app/04-components/_components/wireframe/wireframes/SkeletonText";
 import { SkeletonWireframe } from "@/app/04-components/_components/wireframe/wireframes/Skeleton";
 import { SliderWireframe } from "@/app/04-components/_components/wireframe/wireframes/Slider";
 import { SubmitButtonWireframe } from "@/app/04-components/_components/wireframe/wireframes/SubmitButton";
@@ -162,6 +163,7 @@ const wireframes: Record<string, FC> = {
   "segmented-control": SegmentedControlWireframe,
   select: SelectWireframe,
   separator: SeparatorWireframe,
+  "skeleton-text": SkeletonTextWireframe,
   skeleton: SkeletonWireframe,
   slider: SliderWireframe,
   "submit-button": SubmitButtonWireframe,

--- a/apps/docs/src/app/04-components/_components/wireframe/wireframes/SkeletonText.tsx
+++ b/apps/docs/src/app/04-components/_components/wireframe/wireframes/SkeletonText.tsx
@@ -1,17 +1,19 @@
 "use client";
 import type { FC } from "react";
 import {
-  WBox,
   WFrame,
   WStack,
+  WText,
 } from "@/app/04-components/_components/wireframe/primitives";
 
-export const SkeletonWireframe: FC = () => (
+export const SkeletonTextWireframe: FC = () => (
   <WFrame justifyContent="center">
     <WStack width="72%">
-      <WBox tone="300" height={64} />
+      <WText tone="300" height={28} width="46%" />
+      <WText tone="300" />
+      <WText tone="300" width="74%" />
     </WStack>
   </WFrame>
 );
 
-export default SkeletonWireframe;
+export default SkeletonTextWireframe;

--- a/apps/docs/src/content/04-components/content/skeleton-text/develop.mdx
+++ b/apps/docs/src/content/04-components/content/skeleton-text/develop.mdx
@@ -1,0 +1,3 @@
+# Properties
+
+<PropertiesTables />

--- a/apps/docs/src/content/04-components/content/skeleton-text/examples/default.tsx
+++ b/apps/docs/src/content/04-components/content/skeleton-text/examples/default.tsx
@@ -1,0 +1,8 @@
+import {
+  SkeletonText,
+  Text,
+} from "@mittwald/flow-react-components";
+
+<Text>
+  <SkeletonText />
+</Text>;

--- a/apps/docs/src/content/04-components/content/skeleton-text/examples/heading.tsx
+++ b/apps/docs/src/content/04-components/content/skeleton-text/examples/heading.tsx
@@ -1,0 +1,8 @@
+import {
+  Heading,
+  SkeletonText,
+} from "@mittwald/flow-react-components";
+
+<Heading level={1}>
+  <SkeletonText width="8em" />
+</Heading>;

--- a/apps/docs/src/content/04-components/content/skeleton-text/examples/width.tsx
+++ b/apps/docs/src/content/04-components/content/skeleton-text/examples/width.tsx
@@ -1,0 +1,16 @@
+import {
+  SkeletonText,
+  Text,
+} from "@mittwald/flow-react-components";
+
+<>
+  <Text>
+    <SkeletonText />
+  </Text>
+  <Text>
+    <SkeletonText width="60%" />
+  </Text>
+  <Text>
+    <SkeletonText width="12em" />
+  </Text>
+</>;

--- a/apps/docs/src/content/04-components/content/skeleton-text/guidelines.mdx
+++ b/apps/docs/src/content/04-components/content/skeleton-text/guidelines.mdx
@@ -22,7 +22,13 @@ Achte bei der Verwendung eines SkeletonTexts darauf, dass ...
 ## Verwendung
 
 Verwende einen SkeletonText, um Textinhalte wie Überschriften, Fließtext oder
-Labels während des Ladens als Platzhalter darzustellen.
+Labels während des Ladens als Platzhalter darzustellen. Er ersetzt den späteren
+Text an genau der Stelle, an der dieser erscheint. Bilde damit die Struktur der
+Seite nach – also Überschrift, Absätze und Labels in ihrer tatsächlichen
+Reihenfolge und Position.
+
+Mehrere SkeletonTexts untereinander deuten einen Textblock an. Variiere dabei
+die Breite der letzten Zeile, damit der Block wie echter Fließtext wirkt.
 
 ## SkeletonText vs. Skeleton
 
@@ -43,14 +49,3 @@ dasselbe Erscheinungsbild, unterscheiden sich aber in ihrer Größe.
 
   </Plain>
 </DoAndDont>
-
----
-
-# Anwendung
-
-Ein SkeletonText ersetzt den späteren Text an genau der Stelle, an der dieser
-erscheint. Bilde damit die Struktur der Seite nach – also Überschrift, Absätze
-und Labels in ihrer tatsächlichen Reihenfolge und Position.
-
-Mehrere SkeletonTexts untereinander deuten einen Textblock an. Variiere dabei
-die Breite der letzten Zeile, damit der Block wie echter Fließtext wirkt.

--- a/apps/docs/src/content/04-components/content/skeleton-text/guidelines.mdx
+++ b/apps/docs/src/content/04-components/content/skeleton-text/guidelines.mdx
@@ -1,0 +1,56 @@
+# Grundlagen
+
+Der SkeletonText ist der Platzhalter für eine Textzeile, die noch geladen wird.
+Er passt sich der Typografie seines Umfelds an und deutet so an, welcher Text an
+dieser Stelle erscheint.
+
+## Best Practices
+
+Achte bei der Verwendung eines SkeletonTexts darauf, dass ...
+
+- er innerhalb der Component steht, die später den Text enthält (z. B.
+  [Text](/04-components/content/text/overview) oder
+  [Heading](/04-components/content/heading/overview)). So entspricht seine Höhe
+  der finalen Typografie und es entsteht kein Layout-Sprung.
+- seine Breite ungefähr der Länge des erwarteten Textes entspricht.
+- pro Textblock nur wenige Zeilen verwendet werden – zwei bis drei genügen, um
+  den Inhalt anzudeuten, ohne visuelle Unruhe zu erzeugen.
+- er ausschließlich für das initiale und kurzzeitige Laden eingesetzt wird. Für
+  andere Lade- oder Feedbackprozesse verwende beispielsweise stattdessen den
+  [LoadingSpinner](/04-components/status/loading-spinner/overview).
+
+## Verwendung
+
+Verwende einen SkeletonText, um Textinhalte wie Überschriften, Fließtext oder
+Labels während des Ladens als Platzhalter darzustellen.
+
+## SkeletonText vs. Skeleton
+
+SkeletonText und [Skeleton](/04-components/content/skeleton/overview) haben
+dasselbe Erscheinungsbild, unterscheiden sich aber in ihrer Größe.
+
+<DoAndDont>
+  <Plain heading="Verwende SkeletonText für ...">
+    - Textzeilen, deren Höhe sich aus der umgebenden Typografie ergibt.
+    - Überschriften, Fließtext und Labels.
+
+  </Plain>
+
+  <Plain heading="Verwende Skeleton für ...">
+    - Flächen, deren Größe du selbst festlegst.
+    - Bilder, [Avatare](/04-components/content/avatar/overview) und andere
+      grafische Elemente.
+
+  </Plain>
+</DoAndDont>
+
+---
+
+# Anwendung
+
+Ein SkeletonText ersetzt den späteren Text an genau der Stelle, an der dieser
+erscheint. Bilde damit die Struktur der Seite nach – also Überschrift, Absätze
+und Labels in ihrer tatsächlichen Reihenfolge und Position.
+
+Mehrere SkeletonTexts untereinander deuten einen Textblock an. Variiere dabei
+die Breite der letzten Zeile, damit der Block wie echter Fließtext wirkt.

--- a/apps/docs/src/content/04-components/content/skeleton-text/index.mdx
+++ b/apps/docs/src/content/04-components/content/skeleton-text/index.mdx
@@ -1,0 +1,8 @@
+---
+component: SkeletonText
+description:
+  Der SkeletonText zeigt eine vereinfachte Vorschau einer Textzeile, bis der
+  Content geladen ist.
+---
+
+<Wireframe />

--- a/apps/docs/src/content/04-components/content/skeleton-text/overview.mdx
+++ b/apps/docs/src/content/04-components/content/skeleton-text/overview.mdx
@@ -1,0 +1,25 @@
+# Playground
+
+Verwende `<SkeletonText />`, um eine noch ladende Textzeile darzustellen. Der
+SkeletonText übernimmt die Schriftgröße und Zeilenhöhe seines Umfelds –
+platziere ihn deshalb in der Component, die später den Text enthält.
+
+<LiveCodeEditor />
+
+---
+
+# Breite
+
+Ohne weitere Angabe füllt der SkeletonText die volle Breite des umgebenden
+Elements. Über das `width`-Property lässt sich die Breite anpassen, damit die
+Vorschau der erwarteten Textlänge entspricht.
+
+<LiveCodeEditor example="width" editorCollapsed />
+
+---
+
+# Kombiniere mit ...
+
+## Heading
+
+<LiveCodeEditor example="heading" editorCollapsed />

--- a/apps/docs/src/content/04-components/content/skeleton/guidelines.mdx
+++ b/apps/docs/src/content/04-components/content/skeleton/guidelines.mdx
@@ -29,9 +29,8 @@ Achte bei der Verwendung von Skeletons darauf, dass ...
 ## Verwendung
 
 Verwende Skeletons, um visuell ansprechende Ladezustände für Inhalte wie
-[Listes](/04-components/structure/list/overview),
-[Images](/04-components/content/image/overview) oder
-[Texte](/04-components/content/text/overview) darzustellen – sie bieten
+[Listes](/04-components/structure/list/overview) oder
+[Images](/04-components/content/image/overview) darzustellen – sie bieten
 Orientierung, indem sie die spätere Struktur und Position der Inhalte andeuten.
 
 ## Skeleton vs. SkeletonText

--- a/apps/docs/src/content/04-components/content/skeleton/guidelines.mdx
+++ b/apps/docs/src/content/04-components/content/skeleton/guidelines.mdx
@@ -11,7 +11,8 @@ Achte bei der Verwendung von Skeletons darauf, dass ...
 
 - sie das finale Layout der Benutzeroberfläche so gut wie möglich widerspiegeln,
   sodass User erkennen können, welche Inhalte zu erwarten sind. Verwende dafür
-  vereinfachte Formen wie z. B. Platzhalter für Textblöcke,
+  vereinfachte Formen wie z. B.
+  [SkeletonText](/04-components/content/skeleton-text/overview),
   [Avatare](/04-components/content/avatar/overview) oder
   [Images](/04-components/content/image/overview).
 - Detailgrad und Anzahl der Skeletons nicht zu hoch sind – sie sollten eher an
@@ -32,3 +33,23 @@ Verwende Skeletons, um visuell ansprechende Ladezustände für Inhalte wie
 [Images](/04-components/content/image/overview) oder
 [Texte](/04-components/content/text/overview) darzustellen – sie bieten
 Orientierung, indem sie die spätere Struktur und Position der Inhalte andeuten.
+
+## Skeleton vs. SkeletonText
+
+Skeleton und [SkeletonText](/04-components/content/skeleton-text/overview) haben
+dasselbe Erscheinungsbild, unterscheiden sich aber in ihrer Größe.
+
+<DoAndDont>
+  <Plain heading="Verwende Skeleton für ...">
+    - Flächen, deren Größe du selbst festlegst.
+    - Bilder, [Avatare](/04-components/content/avatar/overview) und andere
+      grafische Elemente.
+
+  </Plain>
+
+  <Plain heading="Verwende SkeletonText für ...">
+    - Textzeilen, deren Höhe sich aus der umgebenden Typografie ergibt.
+    - Überschriften, Fließtext und Labels.
+
+  </Plain>
+</DoAndDont>

--- a/apps/docs/src/content/04-components/structure/list/overview.mdx
+++ b/apps/docs/src/content/04-components/structure/list/overview.mdx
@@ -154,9 +154,9 @@ dem initialen Laden noch suspenden – etwa weil ihr Inhalt eigene Daten nachlä
 
 Gestalte die Loading View so, dass sie dem tatsächlichen Inhalt in Aufbau und
 Größe möglichst nahekommt, und verwende dafür
-[Skeleton](/04-components/content/skeleton/overview) und `SkeletonText`. So
-wirkt der Übergang von der Lade- zur Inhaltsansicht ruhig und ohne
-Layout-Sprung.
+[Skeleton](/04-components/content/skeleton/overview) und
+[SkeletonText](/04-components/content/skeleton-text/overview). So wirkt der
+Übergang von der Lade- zur Inhaltsansicht ruhig und ohne Layout-Sprung.
 
 <LiveCodeEditor example="loadingView" editorCollapsed stretch />
 


### PR DESCRIPTION
SkeletonText had no page in the Styleguide although it is exported publicly and already used in several docs examples (List loading view, Boundaries).

## What's in here

- New component page `04-components/content/skeleton-text` with `index`, `overview`, `develop`, `guidelines` and three examples (default, width, heading).
- Own wireframe plus registry entry — without it the component card falls back to the placeholder wireframe.
- `Skeleton vs. SkeletonText` comparison on both guideline pages.
- SkeletonText is now linked from the Skeleton and List pages, where it was only mentioned as inline code.
- Removed the two narrow bars from the Skeleton wireframe; they read as text and blurred the distinction to the new SkeletonText wireframe.

## Verification

Checked all three tabs on `pnpm nx dev docs`: they render without console errors, the properties table resolves, and every example shows a preview. Prettier and eslint are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)