### PR TITLE
docs(components): add missing prop descriptions

### DIFF
--- a/packages/components/src/components/Action/types.ts
+++ b/packages/components/src/components/Action/types.ts
@@ -11,15 +11,47 @@ import type {
 export type ActionFn = (...args: unknown[]) => unknown;
 
 export interface ActionProps extends PropsWithChildren, FlowComponentProps {
+  /**
+   * The function executed when the action is triggered. Returning a promise
+   * puts the action into its pending and feedback states automatically.
+   */
   onAction?: ActionFn;
+  /**
+   * An existing action model to use instead of creating a new one. Lets several
+   * components share one action state.
+   */
   actionModel?: ActionModel;
+  /** The overlay to close when the action is triggered. */
   closeOverlay?: FlowComponentName | OverlayController | CloseOverlayOptions;
+  /** The overlay to open when the action is triggered. */
   openOverlay?: FlowComponentName | OverlayController;
+  /** The overlay to open or close when the action is triggered. */
   toggleOverlay?: FlowComponentName | OverlayController;
+  /** Whether the surrounding modal is closed when the action is triggered. */
   closeModal?: boolean | CloseModalOptions;
+  /** Whether the surrounding modal is opened when the action is triggered. */
   openModal?: boolean;
+  /**
+   * Whether the surrounding modal is opened or closed when the action is
+   * triggered.
+   */
   toggleModal?: boolean;
+  /**
+   * Stops the execution here: parent actions are not executed.
+   *
+   * @default false
+   */
   break?: boolean;
+  /**
+   * The number of parent actions skipped when the action is triggered. `true`
+   * skips one.
+   *
+   * @default false
+   */
   skip?: number | boolean;
+  /**
+   * Whether success feedback is shown after the action succeeded. Asynchronous
+   * actions show feedback by default; set `false` to suppress it.
+   */
   showFeedback?: boolean;
 }

--- a/packages/components/src/components/CartesianChart/CartesianChart.tsx
+++ b/packages/components/src/components/CartesianChart/CartesianChart.tsx
@@ -38,8 +38,10 @@ export interface CartesianChartProps<TData = ChartDataValue>
       "className" | "syncId" | "syncMethod"
     >,
     PropsWithChildren {
+  /** The data points rendered by the chart. */
   data?: TData[];
 
+  /** The height of the chart. */
   height?: string;
 
   /** View that is provided when data is empty/undefined */

--- a/packages/components/src/components/Chat/Chat.tsx
+++ b/packages/components/src/components/Chat/Chat.tsx
@@ -11,7 +11,7 @@ import { flowComponent } from "@/lib/componentFactory/flowComponent";
 import { UiComponentTunnelExit } from "@/components/UiComponentTunnel/UiComponentTunnelExit";
 
 export interface ChatProps extends PropsWithChildren, PropsWithClassName {
-  // Height of the chat component
+  /** The height of the chat. */
   height?: CSSProperties["height"];
 }
 

--- a/packages/components/src/components/Checkbox/Checkbox.tsx
+++ b/packages/components/src/components/Checkbox/Checkbox.tsx
@@ -19,6 +19,7 @@ export interface CheckboxProps
       Omit<Aria.CheckboxProps, "children" | "ref" | "inputRef">
     >,
     FlowComponentProps<HTMLInputElement> {
+  /** The class name of the underlying input element. */
   inputClassName?: string;
 }
 

--- a/packages/components/src/components/CodeBlock/CodeBlock.tsx
+++ b/packages/components/src/components/CodeBlock/CodeBlock.tsx
@@ -14,6 +14,7 @@ export interface CodeBlockProps
     Partial<
       Pick<CodeEditorProps, "language" | "showLineNumbers" | "copyable">
     > {
+  /** The code displayed in the block. */
   code?: string;
   /**
    * Controls truncation of long code blocks. `false` disables it, `true`

--- a/packages/components/src/components/CodeEditor/CodeEditor.tsx
+++ b/packages/components/src/components/CodeEditor/CodeEditor.tsx
@@ -26,13 +26,41 @@ export interface CodeEditorProps
     Omit<ReactCodeMirrorProps, "theme" | "lang" | "basicSetup" | "readOnly">,
     CodeEditorSetup,
     FlowComponentProps {
+  /** The initial code of an uncontrolled editor. */
   defaultValue?: string;
+  /**
+   * Whether the code can be read but not edited.
+   *
+   * @default false
+   */
   isReadOnly?: boolean;
+  /**
+   * Whether the editor is displayed as invalid.
+   *
+   * @default false
+   */
   isInvalid?: boolean;
+  /** The elements class name. */
   className?: string;
+  /** The language the code is highlighted as. */
   language?: CodeEditorLanguage;
+  /**
+   * Whether a button to copy the code to the clipboard is shown.
+   *
+   * @default true
+   */
   copyable?: boolean;
+  /**
+   * Whether the field must be filled in. Only marks the editor as required for
+   * assistive technology — the editor does not validate itself.
+   *
+   * @default false
+   */
   isRequired?: boolean;
+  /**
+   * @internal Set by `<Field />` on every form field. The editor has no
+   * react-aria validation to forward it to and drops it.
+   */
   validationBehavior?: unknown;
 }
 

--- a/packages/components/src/components/CodeEditor/hooks/useCodeEditorExtensions.tsx
+++ b/packages/components/src/components/CodeEditor/hooks/useCodeEditorExtensions.tsx
@@ -9,10 +9,35 @@ import { gutterSpacer } from "@/components/CodeEditor/extensions/gutterSpacer";
 
 /** @internal */
 export interface CodeEditorSetup {
+  /**
+   * Whether the line the cursor is on is highlighted.
+   *
+   * @default true
+   */
   showActiveLineMarker?: boolean;
+  /**
+   * Whether the gutter offers controls to fold and unfold code blocks.
+   *
+   * @default true
+   */
   showCodeFolding?: boolean;
+  /**
+   * Whether indentation levels are visualized with guide lines.
+   *
+   * @default true
+   */
   showCodeIndentationMakers?: boolean;
+  /**
+   * Whether line numbers are shown in the gutter.
+   *
+   * @default true
+   */
   showLineNumbers?: boolean;
+  /**
+   * Whether linter results are shown in the gutter.
+   *
+   * @default true
+   */
   showLinterMarkers?: boolean;
 }
 

--- a/packages/components/src/components/ComboBox/ComboBox.tsx
+++ b/packages/components/src/components/ComboBox/ComboBox.tsx
@@ -24,6 +24,7 @@ export interface ComboBoxProps
     Pick<OptionsProps, "renderEmptyState">,
     PropsWithChildren,
     FlowComponentProps<HTMLInputElement> {
+  /** Called with the key of the selected option whenever the selection changes. */
   onChange?: (value: string) => void;
 }
 

--- a/packages/components/src/components/DateRangePicker/DateRangePicker.tsx
+++ b/packages/components/src/components/DateRangePicker/DateRangePicker.tsx
@@ -20,6 +20,12 @@ export interface DateRangePickerProps<T extends Aria.DateValue = Aria.DateValue>
   extends
     PropsWithChildren<Omit<Aria.DateRangePickerProps<T>, "children" | "ref">>,
     FlowComponentProps<HTMLSpanElement> {
+  /**
+   * Whether the calendar offers presets to pick a range with one click. Pass an
+   * array to replace the built-in presets with your own.
+   *
+   * @default false
+   */
   withDatePickerPresets?: boolean | DateRangePresets;
 }
 

--- a/packages/components/src/components/DonutChart/DonutChart.tsx
+++ b/packages/components/src/components/DonutChart/DonutChart.tsx
@@ -20,6 +20,7 @@ export interface DonutChartProps
   extends
     Omit<Aria.ProgressBarProps, "children" | "valueLabel">,
     PropsWithChildren {
+  /** The status the donut chart is colored by. */
   status?: Exclude<Status, "unavailable">;
   /** The size variant of the donut chart. @default "m" */
   size?: "m" | "l";

--- a/packages/components/src/components/FileDropZone/FileDropZone.tsx
+++ b/packages/components/src/components/FileDropZone/FileDropZone.tsx
@@ -21,6 +21,7 @@ export interface FileDropZoneProps
     PropsWithChildren,
     Pick<Aria.InputProps, "accept" | "multiple" | "name">,
     Pick<Aria.DropZoneProps, "isDisabled"> {
+  /** Called with the dropped or selected files whenever the selection changes. */
   onChange?: FileInputOnChangeHandler;
   /** Whether the component is read only. */
   isReadOnly?: boolean;

--- a/packages/components/src/components/Label/Label.tsx
+++ b/packages/components/src/components/Label/Label.tsx
@@ -18,7 +18,7 @@ export interface LabelProps
   optional?: boolean;
   /** Whether the label should be displayed as disabled. */
   isDisabled?: boolean;
-  /* @internal */
+  /** @internal */
   unstyled?: boolean;
 }
 

--- a/packages/components/src/components/Link/Link.tsx
+++ b/packages/components/src/components/Link/Link.tsx
@@ -34,7 +34,9 @@ export interface LinkProps
   linkComponent?: ComponentType<Omit<ComponentProps<"a">, "ref">>;
   /** The color of the link. @default "default" */
   color?: "default" | AlphaColor;
+  /** Marks the link as the currently active one, e.g. in a navigation. */
   "aria-current"?: string;
+  /** The name of the slot the link is placed in. */
   slot?: string;
   /** The whiteSpace css value of the element. */
   whiteSpace?: CSSProperties["whiteSpace"];

--- a/packages/components/src/components/List/List.tsx
+++ b/packages/components/src/components/List/List.tsx
@@ -57,8 +57,15 @@ export interface ListProps<T, TMeta = unknown>
    * @default false
    */
   infiniteScroll?: boolean;
+  /**
+   * Hides the pagination controls below the list.
+   *
+   * @default false
+   */
   hidePagination?: boolean;
+  /** The view rendered when a search or filter returns no results. */
   emptySearchResultView?: ReactNode;
+  /** The view rendered when the list contains no items. */
   emptyView?: ReactNode;
 }
 

--- a/packages/components/src/components/List/model/types.ts
+++ b/packages/components/src/components/List/model/types.ts
@@ -25,8 +25,14 @@ export type PropertyValueRenderMethod<TMatcherValue> = (
 export type OnListChanged<T, TMeta = unknown> = (list: List<T, TMeta>) => void;
 
 export interface ListSupportedComponentProps extends MultipleSelection {
+  /** The ID of the element labelling the list. */
   "aria-labelledby"?: string;
+  /** An accessible label for the list. */
   "aria-label"?: string;
+  /**
+   * Whether selecting an item replaces the current selection (`"replace"`) or
+   * adds to it (`"toggle"`).
+   */
   selectionBehavior?: SelectionBehavior;
 }
 
@@ -53,6 +59,11 @@ export interface ListShape<
   T,
   TMeta = unknown,
 > extends ListSupportedComponentProps {
+  /**
+   * The key the lists settings (view mode, search, filters, sorting) are
+   * persisted under. Requires a `<SettingsProvider />` — without a key nothing
+   * is persisted.
+   */
   settingStorageKey?: string;
 
   loader?: IncrementalLoaderShape<T>;
@@ -63,16 +74,40 @@ export interface ListShape<
   batchesController?: BatchesControllerShape;
   table?: TableShape<T>;
 
+  /** Called with the items data when the user activates a list item. */
   onAction?: ItemActionFn<T>;
+  /**
+   * Makes list items expandable. The expanded content is placed in `<Content
+   * slot="bottom" />`.
+   *
+   * @default false
+   */
   accordion?: boolean;
   infiniteScroll?: boolean;
+  /**
+   * The number of skeleton placeholder items rendered while data is loading.
+   * Defaults to the lists batch size.
+   */
   loadingItemsCount?: number;
+  /**
+   * Derives a stable ID from an items data. Used to deduplicate items across
+   * loaded batches and as the row ID in the table view.
+   */
   getItemId?: GetItemId<T>;
+  /** Called with the list model whenever its state changes. */
   onChange?: OnListChanged<T, TMeta>;
+  /**
+   * The view mode the list starts in. A persisted view mode takes precedence.
+   *
+   * @default "list"
+   */
   defaultViewMode?: ListViewMode;
+  /** Defaults for how the lists settings are persisted. */
   settingsStorageDefaults?: ListSettingsStorageDefaults;
 
+  /** The view rendered when a search or filter returns no results. */
   emptySearchResultView?: ReactNode;
+  /** The view rendered when the list contains no items. */
   emptyView?: ReactNode;
 }
 

--- a/packages/components/src/components/Markdown/Markdown.tsx
+++ b/packages/components/src/components/Markdown/Markdown.tsx
@@ -26,6 +26,7 @@ export interface MarkdownProps
   components?: Components;
   /** @internal */
   style?: CSSProperties;
+  /** A ref to the elements root. */
   ref?: Ref<HTMLDivElement>;
 }
 

--- a/packages/components/src/components/Message/Message.tsx
+++ b/packages/components/src/components/Message/Message.tsx
@@ -28,6 +28,7 @@ export interface MessageProps
     PropsWithElementType<"article" | "li"> {
   /** Determines the color and orientation of the message. @default "responder" */
   type?: "responder" | "sender";
+  /** A custom background color of the message as a CSS color value. */
   color?: string;
 }
 

--- a/packages/components/src/components/Overlay/Overlay.tsx
+++ b/packages/components/src/components/Overlay/Overlay.tsx
@@ -25,10 +25,19 @@ export interface OverlayProps
   isDismissable?: boolean;
   /** Whether the overlay is a modal or a light box. */
   overlayType?: "Modal" | "LightBox";
+  /** Whether the overlay is open. Use it to control the overlay state. */
   isOpen?: boolean;
+  /**
+   * Whether the overlay is open initially. Use it for an uncontrolled overlay.
+   *
+   * @default false
+   */
   isDefaultOpen?: boolean;
+  /** Called when the overlay is opened. */
   onOpen?: OverlayOpenHandler;
+  /** Called when the overlay is closed. */
   onClose?: OverlayCloseHandler;
+  /** Called with the new open state whenever the overlay is opened or closed. */
   onOpenChange?: OverlayOpenStateHandler;
   /** Whether closing the overlay must be confirmed. */
   confirmOnClose?: boolean;

--- a/packages/components/src/components/PasswordCreationField/PasswordCreationField.tsx
+++ b/packages/components/src/components/PasswordCreationField/PasswordCreationField.tsx
@@ -50,10 +50,19 @@ export interface PasswordCreationFieldProps
         Partial<Pick<Aria.FieldErrorRenderProps, "validationErrors">>
     >,
     FlowComponentProps<HTMLInputElement> {
+  /** The password of a controlled field. */
   value?: string;
+  /** Called with the password and its validity whenever the password changes. */
   onValidationResult?: (result: { password: string; isValid: boolean }) => void;
+  /** The initial password of an uncontrolled field. */
   defaultValue?: string;
+  /** The placeholder shown while the field is empty. */
   placeholder?: string;
+  /**
+   * The policy the password is validated against.
+   *
+   * @default defaultPasswordCreationPolicy
+   */
   validationPolicy?: PolicyGenericDeclaration;
 }
 

--- a/packages/components/src/components/ProgressBar/ProgressBar.tsx
+++ b/packages/components/src/components/ProgressBar/ProgressBar.tsx
@@ -18,6 +18,7 @@ export interface ProgressBarProps
   extends
     PropsWithChildren<Omit<Aria.ProgressBarProps, "children">>,
     FlowComponentProps {
+  /** The status the progress bar is colored by. */
   status?: Exclude<Status, "unavailable">;
   /** Whether the max value should be displayed. */
   showMaxValue?: boolean;

--- a/packages/components/src/components/Table/Table.tsx
+++ b/packages/components/src/components/Table/Table.tsx
@@ -20,6 +20,7 @@ export type TableProps = Omit<
    * horizontally instead of shrinking its columns.
    */
   minWidth?: number | string;
+  /** The elements class name. */
   className?: string;
 };
 

--- a/packages/components/src/components/Tabs/Tabs.tsx
+++ b/packages/components/src/components/Tabs/Tabs.tsx
@@ -15,7 +15,10 @@ export interface TabsProps
     Omit<Aria.TabsProps, "children">,
     PropsWithChildren,
     FlowComponentProps {
-  /* custom fallback view for not found tabs */
+  /**
+   * The view rendered when the selected tab does not exist. Defaults to a
+   * built-in IllustratedMessage.
+   */
   tabNotFoundView?: ReactNode;
 }
 

--- a/packages/components/src/components/Text/Text.tsx
+++ b/packages/components/src/components/Text/Text.tsx
@@ -22,19 +22,25 @@ export interface TextProps
     Omit<Aria.TextProps, "children" | "elementType">,
     PropsWithElementType<"span" | "div" | "p">,
     FlowComponentProps {
-  /* Whether the elements width should match the width it would have with mold text. */
+  /**
+   * Whether the elements width should match the width it would have with bold
+   * text.
+   */
   emulateBoldWidth?: boolean;
-  /* The color of the text. @default "default" */
+  /** The color of the text. @default "default" */
   color?: "default" | AlphaColor;
-  /* The alignment of the text. @default "start" */
+  /** The alignment of the text. @default "start" */
   align?: "start" | "end" | "center";
-  /* The text-wrap property of the text. @default undefined */
+  /** The text-wrap property of the text. */
   wrap?: "wrap" | "balance" | "pretty";
-  /* The white-space property of the text. @default undefined */
+  /** The white-space property of the text. */
   whiteSpace?: React.CSSProperties["whiteSpace"];
-  /* The word-break property of the text. @default undefined */
+  /** The word-break property of the text. */
   wordBreak?: React.CSSProperties["wordBreak"];
-  /* Disables standard and contextual ligatures for predictable, literal text rendering */
+  /**
+   * Disables standard and contextual ligatures for predictable, literal text
+   * rendering.
+   */
   noLigatures?: boolean;
 }
 

--- a/packages/components/src/components/Truncate/Truncate.tsx
+++ b/packages/components/src/components/Truncate/Truncate.tsx
@@ -12,7 +12,11 @@ export interface TruncateProps
     PropsWithChildren,
     PropsWithClassName,
     Omit<ReactTruncateProps, "text" | "width"> {
-  /** The native tooltip shown on hover, e.g. to reveal the truncated text. */
+  /**
+   * The `title` attribute of the elements root, which browsers show as a native
+   * tooltip on hover. It is not derived from the children — pass the full text
+   * to make it readable while truncated.
+   */
   title?: string;
 }
 

--- a/packages/components/src/components/Truncate/Truncate.tsx
+++ b/packages/components/src/components/Truncate/Truncate.tsx
@@ -12,6 +12,7 @@ export interface TruncateProps
     PropsWithChildren,
     PropsWithClassName,
     Omit<ReactTruncateProps, "text" | "width"> {
+  /** The native tooltip shown on hover, e.g. to reveal the truncated text. */
   title?: string;
 }
 

--- a/packages/components/src/integrations/react-hook-form/components/Form/Form.tsx
+++ b/packages/components/src/integrations/react-hook-form/components/Form/Form.tsx
@@ -33,6 +33,12 @@ export type FormOnSubmitHandler<F extends FieldValues> = SubmitHandler<F>;
 export type AfterFormSubmitCallback = (...unknownArgs: unknown[]) => unknown;
 
 export interface FormAutoResetOptions {
+  /**
+   * Whether the form is reset to its default values after the surrounding modal
+   * has closed.
+   *
+   * @default true
+   */
   onAfterModalClose?: boolean;
 }
 
@@ -49,10 +55,30 @@ export interface FormProps<F extends FieldValues>
     Omit<ComponentProps<"form">, "onSubmit">,
     PropsWithChildren,
     WithFormSubmitControllerProps {
+  /** The react-hook-form instance returned by `useForm()`. */
   form: UseFormReturn<F>;
+  /**
+   * Called with the validated form values when the form is submitted. Returning
+   * a promise keeps the submit button pending until it settles.
+   */
   onSubmit: FormOnSubmitHandler<F>;
+  /**
+   * The component rendered as the form element. Use it to render the form with
+   * a routers form component. Defaults to a plain `<form />`.
+   */
   formComponent?: FC<Omit<FormComponentType, "ref">>;
+  /**
+   * Whether all fields of the form can be read but not edited.
+   *
+   * @default false
+   */
   isReadOnly?: boolean;
+  /**
+   * When the form is reset to its default values. `true` resets it after the
+   * surrounding modal has closed, `false` never resets it.
+   *
+   * @default true
+   */
   autoReset?: FormAutoResetOptions | boolean;
 }
 

--- a/packages/components/src/integrations/react-hook-form/components/Form/hooks/useFormSubmitController.ts
+++ b/packages/components/src/integrations/react-hook-form/components/Form/hooks/useFormSubmitController.ts
@@ -3,10 +3,7 @@ import { useRef } from "react";
 export type FormSubmitController = ReturnType<typeof useFormSubmitController>;
 
 export interface WithFormSubmitControllerProps {
-  /**
-   * A controller to submit the form from outside of it — for example from a
-   * button in a modals footer.
-   */
+  /** A controller to submit the form from outside of it. */
   submitController?: FormSubmitController;
 }
 

--- a/packages/components/src/integrations/react-hook-form/components/Form/hooks/useFormSubmitController.ts
+++ b/packages/components/src/integrations/react-hook-form/components/Form/hooks/useFormSubmitController.ts
@@ -3,6 +3,10 @@ import { useRef } from "react";
 export type FormSubmitController = ReturnType<typeof useFormSubmitController>;
 
 export interface WithFormSubmitControllerProps {
+  /**
+   * A controller to submit the form from outside of it — for example from a
+   * button in a modals footer.
+   */
   submitController?: FormSubmitController;
 }
 

--- a/packages/components/src/lib/componentFactory/flowComponent.tsx
+++ b/packages/components/src/lib/componentFactory/flowComponent.tsx
@@ -29,6 +29,12 @@ type RefType<T> = T extends RefAttributes<infer R> ? R : undefined;
 
 export interface FlowComponentProps<R = HTMLDivElement>
   extends PropsWithTunnel, RefAttributes<R> {
+  /**
+   * A React element the component is wrapped with. The element is cloned and
+   * receives the component as its only child — useful to render the component
+   * inside a link, a tooltip trigger or any other wrapper without changing the
+   * surrounding markup.
+   */
   wrapWith?: ReactElement;
 }
 

--- a/packages/components/src/lib/types/props.ts
+++ b/packages/components/src/lib/types/props.ts
@@ -32,12 +32,18 @@ export interface PropsWithClassName {
 export type PropsWithElementType<
   T extends keyof HTMLElementTagNameMap = never,
 > = HTMLAttributes<HTMLElement> & {
+  /** The HTML element or React component rendered as the elements root. */
   elementType?: T | ExoticComponent;
 };
 
 export type ContainerBreakpointSize = "xs" | "s" | "m" | "l" | "xl";
 
 export interface PropsWithContainerBreakpointSize {
+  /**
+   * The breakpoint at which the element switches to its compact layout.
+   * Evaluated as a container query against the surrounding container, not
+   * against the viewport.
+   */
   containerBreakpointSize?: ContainerBreakpointSize;
 }
 


### PR DESCRIPTION
Closes #2846

84 props across 25 documented components had an empty description in the generated `doc-properties.json`, and thus in the properties table on flow.mittwald.de. All of them now carry a JSDoc description at their declaration site — including the shared ones (List's props in `model/types.ts`, CodeEditor's `show*` props in `useCodeEditorExtensions.tsx`, Action's in `Action/types.ts`, Modal's overlay props in `Overlay.tsx`).

Beyond plain missing comments, two causes were less obvious:

- Some props *were* commented, but with `/* … */` instead of `/** … */`, so react-docgen never saw them: all of `Text`, plus `Tabs.tabNotFoundView` and `Chat.height`. Fixed a typo in `Text.emulateBoldWidth` on the way ("mold text" → "bold text").
- `Label.unstyled` was marked `/* @internal */` — the broken comment kept it visible in the docs with an empty description instead of hiding it.

### Two rows disappear from the properties table

Both intentional, both visible on flow.mittwald.de:

- `Label.unstyled` — now actually hidden, as the original `@internal` marker intended.
- `CodeEditor.validationBehavior` — `<Field />` sets it on every form field via a shared props object; the editor is CodeMirror, has no react-aria validation to forward it to, and drops it. It is internal plumbing, so it is `@internal` with a note on *why* it exists rather than a public "does nothing" description.

Neither is a breaking change — the props still exist, only their docs rows go away.

### Notes

- Where a default is not a literal (e.g. `List.loadingItemsCount` defaulting to the batch size), it is stated in the description rather than in `@default`: react-docgen extracts `@default` into the table's *Default* column, where prose reads badly. Every literal default uses `@default`, matching the existing convention.
- JSDoc only, no behavior change. `pnpm build` produces no generated-code diff — this JSDoc does not flow into `view.ts` or `src/auto-generated/**`.

### Verification

- Regenerated `doc-properties.json` and asserted all 84 props resolve to a non-empty description under the docs site's own lookup (`loadProperties` uses `.find()`, so first match wins — relevant because `Table` and `Link` each have two entries).
- `pnpm lint`, `pnpm nx test:compile components` and `pnpm affected:test` pass.
- No visual tests needed — nothing rendered changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
