### PR TITLE
docs(sprach-guide): drop the "User" glossary entry

### DIFF
--- a/apps/docs/src/content/02-foundations/03-content-guidelines/01-sprach-guide/index.mdx
+++ b/apps/docs/src/content/02-foundations/03-content-guidelines/01-sprach-guide/index.mdx
@@ -29,10 +29,10 @@ generieren wir das beste Nutzungserlebnis.
 
 ## Konsistent
 
-Kunde oder User? Buchen oder installieren? Ist alles geregelt. Deshalb quäle
-dich nicht mit solchen Fragen, sondern verwende die allgemeinen Schreibweisen
-des Unternehmens. So generieren wir für unsere User immer und überall das
-gleiche Erlebnis.
+AI oder KI? Buchen oder installieren? Ist alles geregelt. Deshalb quäle dich
+nicht mit solchen Fragen, sondern verwende die allgemeinen Schreibweisen des
+Unternehmens. So generieren wir für unsere User immer und überall das gleiche
+Erlebnis.
 
 ---
 
@@ -184,8 +184,6 @@ Verwirrung durch uneinheitliche Umrechnungen, wie sie bei dezimalen Angaben
   müssen gekündigt werden (Ausnahme: Domains).
 - **Löschen:** Elemente, die nicht an einer vertraglichen Verbindlichkeit
   hängen, werden gelöscht (Ausnahme: Domains).
-- **User:** Wir reden im mStudio immer vom User oder der Organisation. Den
-  Begriff „Kunde“ verwenden wir nicht.
 - **Organisation:** In der Organisation werden alle wichtigen
   Zahlungsinformationen sowie Vertragspartnerdaten hinterlegt. Server und
   Einzelprojekte sind immer einer Organisation zugeordnet.


### PR DESCRIPTION
The glossary claimed mStudio always says "User". In practice we mostly say "Benutzer", and not consistently either — the rule described something the product does not do.

The "Konsistent" section used "Kunde oder User?" as its example of a settled question. Replaced with "AI oder KI?", which the glossary still settles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)