### PR TITLE
docs: collapse component navigation groups by default

### DIFF
--- a/apps/docs/src/app/_components/layout/MainNavigation/MainNavigation.tsx
+++ b/apps/docs/src/app/_components/layout/MainNavigation/MainNavigation.tsx
@@ -28,6 +28,11 @@ import { ComponentGroupingView } from "@/app/_components/ComponentGroupingView/C
 import type { SortableEntry } from "@/app/_lib/compareEntries";
 import { compareEntries } from "@/app/_lib/compareEntries";
 import { isIntegrationGroup } from "@/app/_lib/integrationGroups";
+import {
+  GroupExpansionProvider,
+  useGroupExpansion,
+} from "@/app/_components/layout/MainNavigation/components/GroupExpansion";
+import { GroupExpansionButton } from "@/app/_components/layout/MainNavigation/components/GroupExpansionButton";
 
 const componentsPathSegment = "04-components";
 
@@ -110,9 +115,25 @@ const NavigationEntries: FC<{ entries: TreeEntry[] }> = (props) =>
 
 const NavigationSection: FC<NavigationSectionProps> = (props) => {
   const { tree, group } = props;
+  const groupExpansion = useGroupExpansion();
+  const currentPathname = usePathname();
+
+  const containsActivePage = collectMdxFiles(Object.entries(tree)).some(
+    (treeItem) => treeItem.pathname === currentPathname,
+  );
+
+  const defaultExpanded = groupExpansion
+    ? (groupExpansion.expandAll ?? containsActivePage)
+    : undefined;
 
   return (
-    <NavigationGroup collapsable>
+    // `defaultExpanded` only applies on mount, so the group is remounted
+    // whenever the default it should follow changes.
+    <NavigationGroup
+      key={`${groupExpansion?.nonce}-${defaultExpanded}`}
+      collapsable
+      defaultExpanded={defaultExpanded}
+    >
       <Label>
         <GroupText>{group}</GroupText>
       </Label>
@@ -131,10 +152,11 @@ const ComponentsNavigation: FC<{ tree: MdxDirectoryTree }> = (props) => {
   );
 
   return (
-    <>
+    <GroupExpansionProvider>
       <Section>
         <Header>
           <Heading>Components</Heading>
+          <GroupExpansionButton />
           <ComponentGroupingMenu />
         </Header>
         <ComponentGroupingView view="grouped">
@@ -158,7 +180,7 @@ const ComponentsNavigation: FC<{ tree: MdxDirectoryTree }> = (props) => {
           <NavigationEntries entries={integrationEntries} />
         </Navigation>
       </Section>
-    </>
+    </GroupExpansionProvider>
   );
 };
 

--- a/apps/docs/src/app/_components/layout/MainNavigation/MainNavigation.tsx
+++ b/apps/docs/src/app/_components/layout/MainNavigation/MainNavigation.tsx
@@ -122,9 +122,8 @@ const NavigationSection: FC<NavigationSectionProps> = (props) => {
     (treeItem) => treeItem.pathname === currentPathname,
   );
 
-  const defaultExpanded = groupExpansion
-    ? (groupExpansion.expandAll ?? containsActivePage)
-    : undefined;
+  const defaultExpanded =
+    groupExpansion?.getDefaultExpanded(containsActivePage);
 
   return (
     // `defaultExpanded` only applies on mount, so the group is remounted

--- a/apps/docs/src/app/_components/layout/MainNavigation/components/GroupExpansion.tsx
+++ b/apps/docs/src/app/_components/layout/MainNavigation/components/GroupExpansion.tsx
@@ -3,10 +3,7 @@ import type { FC, PropsWithChildren } from "react";
 import { createContext, useContext, useMemo, useState } from "react";
 
 interface GroupExpansionState {
-  /**
-   * `null` until the user toggles: groups then follow the active page instead
-   * of a global expanded state.
-   */
+  /** `null` until the user toggles — groups then follow the active page. */
   expandAll: boolean | null;
   /** Changes on every toggle, so groups re-apply the default they already had. */
   nonce: number;
@@ -20,10 +17,6 @@ const groupExpansionContext = createContext<GroupExpansion | undefined>(
   undefined,
 );
 
-/**
- * Manages the expanded/collapsed default of the navigation groups it wraps.
- * Groups outside a provider keep the `NavigationGroup` default (expanded).
- */
 export const GroupExpansionProvider: FC<PropsWithChildren> = (props) => {
   const [state, setState] = useState<GroupExpansionState>({
     expandAll: null,

--- a/apps/docs/src/app/_components/layout/MainNavigation/components/GroupExpansion.tsx
+++ b/apps/docs/src/app/_components/layout/MainNavigation/components/GroupExpansion.tsx
@@ -1,0 +1,52 @@
+"use client";
+import type { FC, PropsWithChildren } from "react";
+import { createContext, useContext, useMemo, useState } from "react";
+
+interface GroupExpansionState {
+  /**
+   * `null` until the user toggles: groups then follow the active page instead
+   * of a global expanded state.
+   */
+  expandAll: boolean | null;
+  /** Changes on every toggle, so groups re-apply the default they already had. */
+  nonce: number;
+}
+
+interface GroupExpansion extends GroupExpansionState {
+  toggle: () => void;
+}
+
+const groupExpansionContext = createContext<GroupExpansion | undefined>(
+  undefined,
+);
+
+/**
+ * Manages the expanded/collapsed default of the navigation groups it wraps.
+ * Groups outside a provider keep the `NavigationGroup` default (expanded).
+ */
+export const GroupExpansionProvider: FC<PropsWithChildren> = (props) => {
+  const [state, setState] = useState<GroupExpansionState>({
+    expandAll: null,
+    nonce: 0,
+  });
+
+  const value = useMemo(
+    () => ({
+      ...state,
+      toggle: () =>
+        setState((state) => ({
+          expandAll: !state.expandAll,
+          nonce: state.nonce + 1,
+        })),
+    }),
+    [state],
+  );
+
+  return (
+    <groupExpansionContext.Provider value={value}>
+      {props.children}
+    </groupExpansionContext.Provider>
+  );
+};
+
+export const useGroupExpansion = () => useContext(groupExpansionContext);

--- a/apps/docs/src/app/_components/layout/MainNavigation/components/GroupExpansion.tsx
+++ b/apps/docs/src/app/_components/layout/MainNavigation/components/GroupExpansion.tsx
@@ -1,16 +1,22 @@
 "use client";
 import type { FC, PropsWithChildren } from "react";
 import { createContext, useContext, useMemo, useState } from "react";
+import { usePathname } from "next/navigation";
 
 interface GroupExpansionState {
-  /** `null` until the user toggles — groups then follow the active page. */
+  /** `null` until the user toggles. */
   expandAll: boolean | null;
+  /** Pathname the toggle was pressed on. */
+  togglePathname: string | null;
   /** Changes on every toggle, so groups re-apply the default they already had. */
   nonce: number;
 }
 
-interface GroupExpansion extends GroupExpansionState {
+interface GroupExpansion {
+  nonce: number;
   toggle: () => void;
+  expandAll: boolean | null;
+  getDefaultExpanded: (containsActivePage: boolean) => boolean;
 }
 
 const groupExpansionContext = createContext<GroupExpansion | undefined>(
@@ -18,21 +24,33 @@ const groupExpansionContext = createContext<GroupExpansion | undefined>(
 );
 
 export const GroupExpansionProvider: FC<PropsWithChildren> = (props) => {
+  const currentPathname = usePathname();
   const [state, setState] = useState<GroupExpansionState>({
     expandAll: null,
+    togglePathname: null,
     nonce: 0,
   });
 
   const value = useMemo(
     () => ({
-      ...state,
+      nonce: state.nonce,
+      expandAll: state.expandAll,
+
       toggle: () =>
         setState((state) => ({
           expandAll: !state.expandAll,
+          togglePathname: currentPathname,
           nonce: state.nonce + 1,
         })),
+
+      // The group of the active page opens on navigation, even after "collapse
+      // all" — that toggle only applies on the page it was pressed on.
+      getDefaultExpanded: (containsActivePage: boolean) =>
+        containsActivePage && currentPathname !== state.togglePathname
+          ? true
+          : (state.expandAll ?? containsActivePage),
     }),
-    [state],
+    [state, currentPathname],
   );
 
   return (

--- a/apps/docs/src/app/_components/layout/MainNavigation/components/GroupExpansionButton.tsx
+++ b/apps/docs/src/app/_components/layout/MainNavigation/components/GroupExpansionButton.tsx
@@ -1,0 +1,34 @@
+"use client";
+import type { FC } from "react";
+import { Button, Icon } from "@mittwald/flow-react-components";
+import { IconChevronsDown, IconChevronsUp } from "@tabler/icons-react";
+import { useGroupExpansion } from "@/app/_components/layout/MainNavigation/components/GroupExpansion";
+import { useComponentGrouping } from "@/app/_lib/useComponentGrouping";
+
+export const GroupExpansionButton: FC = () => {
+  const groupExpansion = useGroupExpansion();
+  const { grouping } = useComponentGrouping();
+
+  // A Section header tunnels its buttons out of this component's DOM position,
+  // so the alphabetical view can't hide the button with CSS.
+  if (!groupExpansion || grouping !== "grouped") {
+    return null;
+  }
+
+  const allExpanded = groupExpansion.expandAll === true;
+
+  return (
+    <Button
+      variant="plain"
+      color="secondary"
+      aria-label={
+        allExpanded ? "Alle Gruppen einklappen" : "Alle Gruppen ausklappen"
+      }
+      onPress={groupExpansion.toggle}
+    >
+      <Icon>{allExpanded ? <IconChevronsUp /> : <IconChevronsDown />}</Icon>
+    </Button>
+  );
+};
+
+export default GroupExpansionButton;

--- a/apps/docs/src/app/_components/layout/MainNavigation/components/GroupExpansionButton.tsx
+++ b/apps/docs/src/app/_components/layout/MainNavigation/components/GroupExpansionButton.tsx
@@ -9,8 +9,8 @@ export const GroupExpansionButton: FC = () => {
   const groupExpansion = useGroupExpansion();
   const { grouping } = useComponentGrouping();
 
-  // A Section header tunnels its buttons out of this component's DOM position,
-  // so the alphabetical view can't hide the button with CSS.
+  // A Section header tunnels its buttons out of this DOM position, so the
+  // alphabetical view can't hide the button with CSS.
   if (!groupExpansion || grouping !== "grouped") {
     return null;
   }


### PR DESCRIPTION
Closes #2822

Stacked on #2852 (`NavigationGroup`'s new `defaultExpanded` prop) — please merge that one first, then this PR retargets to `main`.

Groups in the docs component navigation now start collapsed; only the group containing the active page is expanded. A toggle button in the section header expands or collapses all groups at once. Verified in desktop and mobile navigation.

`defaultExpanded` only applies on mount, so a group is remounted when the default it should follow changes (toggle pressed, or the active page moved into/out of the group).

Scope: the component navigation, as in the issue. Get Started, Foundations and Patterns keep the expanded default — their trees fit on one screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)