### PR TITLE
docs(button,link): move link-vs-button guidance above comparison box

### DIFF
--- a/apps/docs/src/content/04-components/actions/button/guidelines.mdx
+++ b/apps/docs/src/content/04-components/actions/button/guidelines.mdx
@@ -26,9 +26,11 @@ Verwende einen Button, um ...
 
 ## Button vs. Link
 
-Buttons und [Links](/04-components/navigation/link/overview) werden häufig
-verwechselt. Um die beiden besser unterscheiden zu können, hier ein paar
-hilfreiche Anhaltspunkte.
+Verwende für Navigation bevorzugt Links und für Aktionen Buttons. Eine Ausnahme
+können hervorgehobene
+[Call-to-Actions](/04-components/navigation/link/overview#kombiniere-mit-button)
+sein, bei denen ein Button-ähnliches Erscheinungsbild für eine Navigation
+sinnvoll ist.
 
 <DoAndDont>
   <Plain heading="Verwende Buttons, um z. B. ...">

--- a/apps/docs/src/content/04-components/navigation/link/guidelines.mdx
+++ b/apps/docs/src/content/04-components/navigation/link/guidelines.mdx
@@ -17,11 +17,6 @@ Achte bei Verwendung eines Links darauf, dass ...
 - Links entweder einzeln stehen oder in einen Textblock integriert werden
   (Inline Link). Andernfalls ist es für den User schwieriger, den Link zu
   erkennen. Beispielsweise sollte ein Link nicht in der Überschrift stehen.
-- Verwende für Navigation bevorzugt Links und für Aktionen Buttons. Eine
-  Ausnahme können hervorgehobene
-  [Call-to-Actions](/04-components/navigation/link/overview#kombiniere-mit-button)
-  sein, bei denen ein Button-ähnliches Erscheinungsbild für eine Navigation
-  sinnvoll ist.
 
 ## Verwendung
 
@@ -34,9 +29,11 @@ Verwende einen Link, um ...
 
 ## Link vs. Button
 
-Links und [Buttons](/04-components/actions/button/overview) werden häufig
-verwechselt. Um die beiden besser unterscheiden zu können, hier ein paar
-hilfreiche Anhaltspunkte.
+Verwende für Navigation bevorzugt Links und für Aktionen Buttons. Eine Ausnahme
+können hervorgehobene
+[Call-to-Actions](/04-components/navigation/link/overview#kombiniere-mit-button)
+sein, bei denen ein Button-ähnliches Erscheinungsbild für eine Navigation
+sinnvoll ist.
 
 <DoAndDont>
   <Info heading="Verwende Links, um z. B. ...">


### PR DESCRIPTION
## What

Refines the link-vs-button guidance on the Button and Link guideline pages.

- **Link page:** Removed the "prefer links for navigation, buttons for actions" bullet from the Best Practices list and moved it to the intro above the **Link vs. Button** comparison box (replacing the previous generic intro sentence).
- **Button page:** Added the same sentence above the **Button vs. Link** comparison box, replacing the previous generic intro. It did not exist in the Button Best Practices before, so nothing was removed there.

Both pages now share the same intro sentence above their comparison box, including the link to the highlighted call-to-action guidance (`#kombiniere-mit-button`).

## Why

Keeps the navigation-vs-action guidance visible right where users compare the two components, and makes the two pages consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)