### PR TITLE
fix(docs): align component order in navigation and lists

### DIFF
--- a/apps/docs/src/app/04-components/_components/ComponentsOverview.tsx
+++ b/apps/docs/src/app/04-components/_components/ComponentsOverview.tsx
@@ -5,6 +5,7 @@ import type { ComponentLink } from "@/app/04-components/_components/ComponentsLi
 import { ComponentsList } from "@/app/04-components/_components/ComponentsList";
 import { ComponentGroupingView } from "@/app/_components/ComponentGroupingView/ComponentGroupingView";
 import { extractTextFromPath } from "@/app/_lib/extractTextFromPath";
+import { compareGroupPaths } from "@/app/_lib/compareLabels";
 
 interface Props {
   components: ComponentLink[];
@@ -14,7 +15,7 @@ export const ComponentsOverview: FC<Props> = (props) => {
   const { components } = props;
 
   const groups = Object.entries(groupBy(components, (c) => c.group)).sort(
-    ([a], [b]) => a.localeCompare(b),
+    ([a], [b]) => compareGroupPaths(a, b),
   );
 
   return (

--- a/apps/docs/src/app/04-components/page.tsx
+++ b/apps/docs/src/app/04-components/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { MdxFileFactory } from "@/lib/mdx/MdxFileFactory";
 import styles from "@/app/layout.module.scss";
 import { ComponentsOverview } from "@/app/04-components/_components/ComponentsOverview";
+import { compareLabels } from "@/app/_lib/compareLabels";
 
 const contentFolder = "src/content/04-components";
 
@@ -23,7 +24,7 @@ export default async function Page() {
       description: mdxFile.mdxSource.frontmatter.description,
       href: `/04-components${mdxFile.pathname}/overview`,
     }))
-    .sort((a, b) => a.name.localeCompare(b.name));
+    .sort((a, b) => compareLabels(a.name, b.name));
 
   return (
     <LayoutCard className={styles.mainContent}>

--- a/apps/docs/src/app/_components/layout/MainNavigation/MainNavigation.tsx
+++ b/apps/docs/src/app/_components/layout/MainNavigation/MainNavigation.tsx
@@ -42,7 +42,6 @@ interface Props {
 interface NavigationSectionProps {
   tree: MdxDirectoryTree;
   group: string;
-  sortByLabel?: boolean;
 }
 
 type TreeEntry = [string, MdxDirectoryTree | MdxFile];
@@ -95,11 +94,25 @@ const entryLabel = ([group, treeItem]: TreeEntry): string =>
     ? treeItem.getNavTitle()
     : extractTextFromPath(group);
 
-const sortEntries = (entries: TreeEntry[], sortByLabel = false): TreeEntry[] =>
+/** A numeric path prefix ("01-design") is the author's intended order. */
+const pathPrefix = ([group]: TreeEntry): number | undefined => {
+  const prefix = /^(\d+)-/.exec(group)?.[1];
+  return prefix === undefined ? undefined : Number(prefix);
+};
+
+const comparePosition = (a: TreeEntry, b: TreeEntry): number => {
+  const prefixA = pathPrefix(a);
+  const prefixB = pathPrefix(b);
+
+  return prefixA !== undefined && prefixB !== undefined
+    ? prefixA - prefixB
+    : compareLabels(entryLabel(a), entryLabel(b));
+};
+
+const sortEntries = (entries: TreeEntry[]): TreeEntry[] =>
   [...entries].sort(
     (a, b) =>
-      deprecatedRank(a[1]) - deprecatedRank(b[1]) ||
-      (sortByLabel ? compareLabels(entryLabel(a), entryLabel(b)) : 0),
+      deprecatedRank(a[1]) - deprecatedRank(b[1]) || comparePosition(a, b),
   );
 
 const collectMdxFiles = (entries: TreeEntry[]): MdxFile[] =>
@@ -109,35 +122,24 @@ const collectMdxFiles = (entries: TreeEntry[]): MdxFile[] =>
       : collectMdxFiles(Object.entries(treeItem)),
   );
 
-const NavigationEntries: FC<{
-  entries: TreeEntry[];
-  sortByLabel?: boolean;
-}> = (props) =>
-  sortEntries(props.entries, props.sortByLabel).map(([group, treeItem]) =>
+const NavigationEntries: FC<{ entries: TreeEntry[] }> = (props) =>
+  sortEntries(props.entries).map(([group, treeItem]) =>
     treeItem instanceof MdxFile ? (
       <NavigationLink key={treeItem.pathname} treeItem={treeItem} />
     ) : (
-      <NavigationSection
-        key={group}
-        tree={treeItem}
-        group={group}
-        sortByLabel={props.sortByLabel}
-      />
+      <NavigationSection key={group} tree={treeItem} group={group} />
     ),
   );
 
 const NavigationSection: FC<NavigationSectionProps> = (props) => {
-  const { tree, group, sortByLabel } = props;
+  const { tree, group } = props;
 
   return (
     <NavigationGroup collapsable>
       <Label>
         <GroupText>{group}</GroupText>
       </Label>
-      <NavigationEntries
-        entries={Object.entries(tree)}
-        sortByLabel={sortByLabel}
-      />
+      <NavigationEntries entries={Object.entries(tree)} />
     </NavigationGroup>
   );
 };
@@ -160,7 +162,7 @@ const ComponentsNavigation: FC<{ tree: MdxDirectoryTree }> = (props) => {
         </Header>
         <ComponentGroupingView view="grouped">
           <Navigation aria-label="Components">
-            <NavigationEntries entries={componentEntries} sortByLabel />
+            <NavigationEntries entries={componentEntries} />
           </Navigation>
         </ComponentGroupingView>
         <ComponentGroupingView view="alphabetical">
@@ -176,7 +178,7 @@ const ComponentsNavigation: FC<{ tree: MdxDirectoryTree }> = (props) => {
       <Section>
         <Heading>Integrations</Heading>
         <Navigation aria-label="Integrations">
-          <NavigationEntries entries={integrationEntries} sortByLabel />
+          <NavigationEntries entries={integrationEntries} />
         </Navigation>
       </Section>
     </>

--- a/apps/docs/src/app/_components/layout/MainNavigation/MainNavigation.tsx
+++ b/apps/docs/src/app/_components/layout/MainNavigation/MainNavigation.tsx
@@ -28,6 +28,7 @@ import styles from "@/app/layout.module.scss";
 import { extractTextFromPath } from "@/app/_lib/extractTextFromPath";
 import { ComponentGroupingMenu } from "@/app/_components/layout/MainNavigation/components/ComponentGroupingMenu";
 import { ComponentGroupingView } from "@/app/_components/ComponentGroupingView/ComponentGroupingView";
+import { compareLabels } from "@/app/_lib/compareLabels";
 
 const componentsPathSegment = "04-components";
 
@@ -41,6 +42,7 @@ interface Props {
 interface NavigationSectionProps {
   tree: MdxDirectoryTree;
   group: string;
+  sortByLabel?: boolean;
 }
 
 type TreeEntry = [string, MdxDirectoryTree | MdxFile];
@@ -88,8 +90,17 @@ const deprecatedRank = (treeItem: MdxDirectoryTree | MdxFile): number => {
   return status?.level === "deprecated" ? 1 : 0;
 };
 
-const sortEntriesByStatus = (entries: TreeEntry[]): TreeEntry[] =>
-  [...entries].sort(([, a], [, b]) => deprecatedRank(a) - deprecatedRank(b));
+const entryLabel = ([group, treeItem]: TreeEntry): string =>
+  treeItem instanceof MdxFile
+    ? treeItem.getNavTitle()
+    : extractTextFromPath(group);
+
+const sortEntries = (entries: TreeEntry[], sortByLabel = false): TreeEntry[] =>
+  [...entries].sort(
+    (a, b) =>
+      deprecatedRank(a[1]) - deprecatedRank(b[1]) ||
+      (sortByLabel ? compareLabels(entryLabel(a), entryLabel(b)) : 0),
+  );
 
 const collectMdxFiles = (entries: TreeEntry[]): MdxFile[] =>
   entries.flatMap(([, treeItem]) =>
@@ -98,24 +109,35 @@ const collectMdxFiles = (entries: TreeEntry[]): MdxFile[] =>
       : collectMdxFiles(Object.entries(treeItem)),
   );
 
-const NavigationEntries: FC<{ entries: TreeEntry[] }> = (props) =>
-  sortEntriesByStatus(props.entries).map(([group, treeItem]) =>
+const NavigationEntries: FC<{
+  entries: TreeEntry[];
+  sortByLabel?: boolean;
+}> = (props) =>
+  sortEntries(props.entries, props.sortByLabel).map(([group, treeItem]) =>
     treeItem instanceof MdxFile ? (
       <NavigationLink key={treeItem.pathname} treeItem={treeItem} />
     ) : (
-      <NavigationSection key={group} tree={treeItem} group={group} />
+      <NavigationSection
+        key={group}
+        tree={treeItem}
+        group={group}
+        sortByLabel={props.sortByLabel}
+      />
     ),
   );
 
 const NavigationSection: FC<NavigationSectionProps> = (props) => {
-  const { tree, group } = props;
+  const { tree, group, sortByLabel } = props;
 
   return (
     <NavigationGroup collapsable>
       <Label>
         <GroupText>{group}</GroupText>
       </Label>
-      <NavigationEntries entries={Object.entries(tree)} />
+      <NavigationEntries
+        entries={Object.entries(tree)}
+        sortByLabel={sortByLabel}
+      />
     </NavigationGroup>
   );
 };
@@ -138,13 +160,13 @@ const ComponentsNavigation: FC<{ tree: MdxDirectoryTree }> = (props) => {
         </Header>
         <ComponentGroupingView view="grouped">
           <Navigation aria-label="Components">
-            <NavigationEntries entries={componentEntries} />
+            <NavigationEntries entries={componentEntries} sortByLabel />
           </Navigation>
         </ComponentGroupingView>
         <ComponentGroupingView view="alphabetical">
           <Navigation aria-label="Components">
             {collectMdxFiles(componentEntries)
-              .sort((a, b) => a.getNavTitle().localeCompare(b.getNavTitle()))
+              .sort((a, b) => compareLabels(a.getNavTitle(), b.getNavTitle()))
               .map((treeItem) => (
                 <NavigationLink key={treeItem.pathname} treeItem={treeItem} />
               ))}
@@ -154,7 +176,7 @@ const ComponentsNavigation: FC<{ tree: MdxDirectoryTree }> = (props) => {
       <Section>
         <Heading>Integrations</Heading>
         <Navigation aria-label="Integrations">
-          <NavigationEntries entries={integrationEntries} />
+          <NavigationEntries entries={integrationEntries} sortByLabel />
         </Navigation>
       </Section>
     </>

--- a/apps/docs/src/app/_lib/compareLabels.ts
+++ b/apps/docs/src/app/_lib/compareLabels.ts
@@ -1,0 +1,11 @@
+import { extractTextFromPath } from "@/app/_lib/extractTextFromPath";
+
+/**
+ * Navigation and lists must agree on order, so both sort by the rendered label.
+ * Path order is not the same: "action-group" sorts before "action".
+ */
+export const compareLabels = (a: string, b: string): number =>
+  a.localeCompare(b);
+
+export const compareGroupPaths = (a: string, b: string): number =>
+  compareLabels(extractTextFromPath(a), extractTextFromPath(b));


### PR DESCRIPTION
The component navigation took its order from the filesystem, where whole paths are compared and `-` sorts before `/`: `actions/action-group/` came before `actions/action/`. The overview lists sort by the rendered name, so navigation and list disagreed — same for AvatarStack/Avatar, MessageThread/Message and FormRootError/Form.

Both now sort by the rendered label through a shared comparator (`compareLabels`). Where a path segment carries a numeric prefix (`01-design`), that prefix keeps deciding the order, so Get Started, Foundations and Patterns stay as authored — their unprefixed pages already sort identically by label. "Deprecated last" stays the primary key in the navigation.

Verified in the docs dev server: navigation and list match group by group, and all four sections keep their intended order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)