### PR TITLE
fix(docs): keep heading examples full width in live previews

### DIFF
--- a/apps/docs/src/lib/liveCode/components/LiveCodeEditor/LiveCodeEditor.module.css
+++ b/apps/docs/src/lib/liveCode/components/LiveCodeEditor/LiveCodeEditor.module.css
@@ -6,7 +6,8 @@
   justify-content: center;
   gap: var(--size-rem--m);
 
-  > :global(.flow--truncate) {
+  > :global(.flow--truncate),
+  > :global(.flow--heading) {
     align-self: normal;
   }
 


### PR DESCRIPTION
## What & why

The `Truncate` + `Heading` example on the Truncate page rendered as one long
unclipped line spilling out of the preview card on both sides.

The live-code preview centers examples in a column flex container
(`align-items: center`), which sizes a `Heading` to its min-content width. With
Truncate's `white-space: nowrap` that is the full untruncated text, so nothing
ever overflowed the element and `text-overflow: ellipsis` could not apply.
`.flow--truncate` and `.flow--text` already opted out of the centering;
`.flow--heading` now does too.

Heading examples are therefore flush left over the full preview width, matching
the Text examples. Affected besides Truncate: the heading examples on the
Heading and Color pages. Inline content (ContextualHelp trigger, AlertBadge)
stays next to the text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)