### PR TITLE
docs(Switch): wrap Switch labels in Label

### DIFF
--- a/apps/docs/src/content/03-patterns/01-patterns/detail-page/examples/detail-page.tsx
+++ b/apps/docs/src/content/03-patterns/01-patterns/detail-page/examples/detail-page.tsx
@@ -199,7 +199,9 @@ export default () => {
         <Section>
           <Header>
             <Heading>Spamschutz</Heading>
-            <Switch defaultSelected>Aktivieren</Switch>
+            <Switch defaultSelected>
+              <Label>Aktivieren</Label>
+            </Switch>
           </Header>
           <Text>
             Der Spamfilter schützt dich vor ungewollten

--- a/apps/docs/src/content/04-components/content/label/examples/usage.tsx
+++ b/apps/docs/src/content/04-components/content/label/examples/usage.tsx
@@ -13,7 +13,9 @@ import {
 <Section>
   <Header>
     <Heading>Cronjob</Heading>
-    <Switch>Aktiviert</Switch>
+    <Switch>
+      <Label>Aktiviert</Label>
+    </Switch>
   </Header>
   <ColumnLayout l={[1, 1]}>
     <TextField>

--- a/apps/docs/src/content/04-components/form-controls/switch/examples/default.tsx
+++ b/apps/docs/src/content/04-components/form-controls/switch/examples/default.tsx
@@ -1,3 +1,8 @@
-import { Switch } from "@mittwald/flow-react-components";
+import {
+  Label,
+  Switch,
+} from "@mittwald/flow-react-components";
 
-<Switch defaultSelected>Autoresponder</Switch>;
+<Switch defaultSelected>
+  <Label>Autoresponder</Label>
+</Switch>;

--- a/apps/docs/src/content/04-components/form-controls/switch/examples/disabled.tsx
+++ b/apps/docs/src/content/04-components/form-controls/switch/examples/disabled.tsx
@@ -1,3 +1,8 @@
-import { Switch } from "@mittwald/flow-react-components";
+import {
+  Label,
+  Switch,
+} from "@mittwald/flow-react-components";
 
-<Switch isDisabled>Autoresponder</Switch>;
+<Switch isDisabled>
+  <Label>Autoresponder</Label>
+</Switch>;

--- a/apps/docs/src/content/04-components/form-controls/switch/examples/leading-label.tsx
+++ b/apps/docs/src/content/04-components/form-controls/switch/examples/leading-label.tsx
@@ -1,3 +1,8 @@
-import { Switch } from "@mittwald/flow-react-components";
+import {
+  Label,
+  Switch,
+} from "@mittwald/flow-react-components";
 
-<Switch labelPosition="leading">Autoresponder</Switch>;
+<Switch labelPosition="leading">
+  <Label>Autoresponder</Label>
+</Switch>;

--- a/apps/docs/src/content/04-components/overlays/modal/examples/noAction.tsx
+++ b/apps/docs/src/content/04-components/overlays/modal/examples/noAction.tsx
@@ -3,6 +3,7 @@ import {
   ActionGroup,
   Button,
   Heading,
+  Label,
   Section,
   Switch,
 } from "@mittwald/flow-react-components";
@@ -14,9 +15,11 @@ import {
   <div className="flow--modal--content">
     <Section>
       <Switch defaultSelected>
-        Container Frontend anzeigen
+        <Label>Container Frontend anzeigen</Label>
       </Switch>
-      <Switch>Extensions anzeigen</Switch>
+      <Switch>
+        <Label>Extensions anzeigen</Label>
+      </Switch>
     </Section>
   </div>
   <ActionGroup className="flow--modal--action-group">

--- a/apps/docs/src/content/04-components/overlays/modal/examples/size.tsx
+++ b/apps/docs/src/content/04-components/overlays/modal/examples/size.tsx
@@ -112,7 +112,9 @@ export default () => {
               </Text>
               <ColumnLayout s={[1]} gap="xl">
                 <ColumnLayout s={[1]} gap="s">
-                  <Switch>Erste Schritte</Switch>
+                  <Switch>
+                    <Label>Erste Schritte</Label>
+                  </Switch>
                   <Text>
                     Im Onboarding erklären wir dir alles
                     Wichtige im mStudio.
@@ -122,7 +124,7 @@ export default () => {
 
                 <ColumnLayout s={[1]} gap="s">
                   <Switch defaultSelected>
-                    mittwald Status
+                    <Label>mittwald Status</Label>
                   </Switch>
                   <Text>
                     Wir informieren dich über Wartung und
@@ -131,7 +133,9 @@ export default () => {
                 </ColumnLayout>
 
                 <ColumnLayout s={[1]} gap="s">
-                  <Switch>mittwald Produkt-Slider</Switch>
+                  <Switch>
+                    <Label>mittwald Produkt-Slider</Label>
+                  </Switch>
                   <Text>
                     Im Produkt-Slider erhälst du
                     Informationen und einen schnellen
@@ -141,7 +145,7 @@ export default () => {
 
                 <ColumnLayout s={[1]} gap="s">
                   <Switch defaultSelected>
-                    Neue Features
+                    <Label>Neue Features</Label>
                   </Switch>
                   <Text>
                     Wir entwickeln das mStudio stetig weiter
@@ -153,7 +157,7 @@ export default () => {
 
                 <ColumnLayout s={[1]} gap="s">
                   <Switch defaultSelected>
-                    Neue Blogbeiträge
+                    <Label>Neue Blogbeiträge</Label>
                   </Switch>
                   <Text>
                     Wir zeigen dir den neuesten mittwald
@@ -163,7 +167,9 @@ export default () => {
                 </ColumnLayout>
 
                 <ColumnLayout s={[1]} gap="s">
-                  <Switch>Lastschift Hinweis</Switch>
+                  <Switch>
+                    <Label>Lastschift Hinweis</Label>
+                  </Switch>
                   <Text>
                     Wir informieren über die neue
                     Möglichkeit, deine Rechnungen per

--- a/apps/docs/src/content/04-components/structure/section/examples/switch.tsx
+++ b/apps/docs/src/content/04-components/structure/section/examples/switch.tsx
@@ -1,6 +1,7 @@
 import {
   Header,
   Heading,
+  Label,
   Section,
   Switch,
   Text,
@@ -9,7 +10,9 @@ import {
 <Section>
   <Header>
     <Heading>Autoresponder</Heading>
-    <Switch>Aktivieren</Switch>
+    <Switch>
+      <Label>Aktivieren</Label>
+    </Switch>
   </Header>
   <Text>
     Lasse den Autoresponder für dich arbeiten. Er kann

--- a/packages/components/src/components/ActionGroup/stories/Default.stories.tsx
+++ b/packages/components/src/components/ActionGroup/stories/Default.stories.tsx
@@ -5,6 +5,7 @@ import { Action } from "@/components/Action";
 import { sleep } from "@/lib/promises/sleep";
 import { Switch } from "@/components/Switch";
 import { Link } from "@/components/Link";
+import { Label } from "@/components/Label";
 import { useForm } from "react-hook-form";
 import { Form, SubmitButton } from "@/integrations/react-hook-form";
 
@@ -104,7 +105,9 @@ export const WithSwitch: Story = {
   render: (props) => (
     <ActionGroup {...props}>
       <Button slot="secondary">Edit</Button>
-      <Switch slot="primary">Activate</Switch>
+      <Switch slot="primary">
+        <Label>Activate</Label>
+      </Switch>
     </ActionGroup>
   ),
 };

--- a/packages/components/src/components/Section/stories/Default.stories.tsx
+++ b/packages/components/src/components/Section/stories/Default.stories.tsx
@@ -23,6 +23,7 @@ import Content from "@/components/Content";
 import ActionGroup from "@/components/ActionGroup";
 import { Badge } from "@/components/Badge";
 import Alert from "@/components/Alert";
+import { Label } from "@/components/Label";
 
 const meta: Meta<typeof Section> = {
   title: "Structure/Section",
@@ -81,7 +82,9 @@ export const MultipleSections: Story = {
             Rebel Alliance Briefing <Badge>Subscribed</Badge>
           </Heading>
 
-          <Switch defaultSelected>Transmissions</Switch>
+          <Switch defaultSelected>
+            <Label>Transmissions</Label>
+          </Switch>
           <ContextualHelpTrigger>
             <Button />
             <ContextualHelp>

--- a/packages/components/src/components/Tabs/stories/Default.stories.tsx
+++ b/packages/components/src/components/Tabs/stories/Default.stories.tsx
@@ -53,7 +53,9 @@ const meta: Meta<typeof Tabs> = {
           <Section>
             <Header>
               <Heading>Spam protection</Heading>
-              <Switch>Spam protection</Switch>
+              <Switch>
+                <Label>Spam protection</Label>
+              </Switch>
             </Header>
             <Text>
               The spam filter protects you from unwanted transmissions. Nobody

--- a/packages/components/src/integrations/react-hook-form/components/Field/stories/Switch.stories.tsx
+++ b/packages/components/src/integrations/react-hook-form/components/Field/stories/Switch.stories.tsx
@@ -15,6 +15,7 @@ import { ActionGroup } from "@/components/ActionGroup";
 import { sleep } from "@/lib/promises/sleep";
 import { Switch } from "@/components/Switch";
 import { FieldError } from "@/components/FieldError";
+import { Label } from "@/components/Label";
 
 const submitAction = action("submit");
 
@@ -43,7 +44,9 @@ const meta: Meta<typeof Field> = {
       <Form form={form} onSubmit={handleSubmit}>
         <Section>
           <Field name="isEnabled">
-            <Switch>Engage hyperdrive</Switch>
+            <Switch>
+              <Label>Engage hyperdrive</Label>
+            </Switch>
           </Field>
 
           <ActionGroup>
@@ -75,10 +78,12 @@ export const WithFieldError: Story = {
       <Form form={form} onSubmit={async () => await sleep(2000)}>
         <Section>
           <Field name="field">
-            <Switch {...props}>Field1</Switch>
+            <Switch {...props}>
+              <Label>Field1</Label>
+            </Switch>
           </Field>
           <Switch>
-            Field2
+            <Label>Field2</Label>
             <FieldError>ErrorFromOuterFieldError!</FieldError>
           </Switch>
         </Section>
@@ -93,7 +98,9 @@ export const WithFocus: Story = {
     return (
       <Form form={form} onSubmit={async () => await sleep(2000)}>
         <Field name="field">
-          <Switch {...props}>Field</Switch>
+          <Switch {...props}>
+            <Label>Field</Label>
+          </Switch>
         </Field>
         <div style={{ marginBottom: "2200px" }} />
         <ActionGroup>


### PR DESCRIPTION
The Switch examples and several stories passed the label as raw text children. Switch renders those in a wrapper div that hardcodes `--label--color--default`, so a disabled Switch showed its label in the default color — visible in the "Disabled" example on the docs page.

Switch's own story and visual tests already use `<Label>`; the remaining call sites now follow: 8 docs examples and the ActionGroup, Section, Tabs and react-hook-form Field stories.

No component change — Flow does not actively prevent this kind of misuse elsewhere either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)