### PR TITLE
docs: correct lint git hook to pre-push

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,7 +125,7 @@ pnpm nx test:browser components --browser.name=webkit
 pnpm affected:test:browser --parallel=1 --browser.name=webkit   # what CI runs
 pnpm nx test:visual:update remote-react-components              # update visual snapshots
 
-pnpm lint                                  # eslint + stylelint + format:check (pre-commit hook runs this)
+pnpm lint                                  # eslint + stylelint + format:check (pre-push hook runs this)
 pnpm format                                # prettier --write
 pnpm format:check                          # prettier --check (part of pnpm lint)
 ```
@@ -168,9 +168,9 @@ and commit the results.
   own task outputs) — `dependsOn` alone only orders execution, it does not fold
   the dependency's hash into the dependent.
 - **Git hooks** (simple-git-hooks): `post-checkout` and `post-merge` run
-  `pnpm install` — expect installs after switching branches. `pre-commit` runs
+  `pnpm install` — expect installs after switching branches. `pre-push` runs
   `pnpm lint` — which includes `format:check`, so a stray unformatted
-  `.md`/`.json`/`.yml` blocks the commit; `pnpm format` fixes it.
+  `.md`/`.json`/`.yml` blocks the push, not the commit; `pnpm format` fixes it.
 - **New dependencies:** pnpm enforces a `minimumReleaseAge` of one week (exempt:
   `@mittwald/*`) — brand-new versions won't resolve.
 - **Breaking changes for consumers** ship with a `MIGRATION.md` entry and,

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -79,8 +79,9 @@ your time when developing components.
 [simple-git-hooks](https://github.com/toplenboren/simple-git-hooks). Once
 installed:
 
-- **pre-commit** runs `pnpm lint` (ESLint + Stylelint + Prettier check) on your
-  changes.
+- **pre-push** runs `pnpm lint` (ESLint + Stylelint + Prettier check) across the
+  repo. It blocks the push, not the commit — unformatted files surface once the
+  commits already exist; `pnpm format` fixes them.
 - **post-checkout** / **post-merge** run `pnpm install` so your dependencies
   stay in sync after switching branches or pulling.
 
@@ -593,8 +594,7 @@ pnpm affected:test:browser --parallel=1 --browser.name=webkit   # browser/e2e/vi
 
 ## Code style
 
-Formatting and linting are enforced; the pre-commit hook runs `pnpm lint` for
-you.
+Formatting and linting are enforced; the pre-push hook runs `pnpm lint` for you.
 
 ```shell
 pnpm lint           # check with ESLint + Stylelint + Prettier


### PR DESCRIPTION
`AGENTS.md` and `CONTRIBUTE.md` documented `pnpm lint` as a **pre-commit** hook. Since #2827 it runs on **pre-push**. Fixed in all four spots.

pre-push stays as it is — pre-commit was too noisy. This is a docs-only correction, no hook change.

Beyond the rename, the docs now state the changed consequence: lint blocks the **push**, not the commit, so a stray unformatted file surfaces once the commits already exist. `pnpm format` is still the fix.

Also drops the inaccurate "on your changes" in `CONTRIBUTE.md` — `pnpm lint` runs across the repo.

Closes #2872

🤖 Generated with [Claude Code](https://claude.com/claude-code)