### PR TITLE
docs: the pnpm lint git hook is pre-push, not pre-commit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,7 +125,7 @@ pnpm nx test:browser components --browser.name=webkit
 pnpm affected:test:browser --parallel=1 --browser.name=webkit   # what CI runs
 pnpm nx test:visual:update remote-react-components              # update visual snapshots
 
-pnpm lint                                  # eslint + stylelint + format:check (pre-commit hook runs this)
+pnpm lint                                  # eslint + stylelint + format:check (pre-push hook runs this)
 pnpm format                                # prettier --write
 pnpm format:check                          # prettier --check (part of pnpm lint)
 ```
@@ -168,9 +168,10 @@ and commit the results.
   own task outputs) — `dependsOn` alone only orders execution, it does not fold
   the dependency's hash into the dependent.
 - **Git hooks** (simple-git-hooks): `post-checkout` and `post-merge` run
-  `pnpm install` — expect installs after switching branches. `pre-commit` runs
+  `pnpm install` — expect installs after switching branches. `pre-push` runs
   `pnpm lint` — which includes `format:check`, so a stray unformatted
-  `.md`/`.json`/`.yml` blocks the commit; `pnpm format` fixes it.
+  `.md`/`.json`/`.yml` blocks the push, after the commit already exists;
+  `pnpm format` fixes it.
 - **New dependencies:** pnpm enforces a `minimumReleaseAge` of one week (exempt:
   `@mittwald/*`) — brand-new versions won't resolve.
 - **Breaking changes for consumers** ship with a `MIGRATION.md` entry and,

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -79,10 +79,12 @@ your time when developing components.
 [simple-git-hooks](https://github.com/toplenboren/simple-git-hooks). Once
 installed:
 
-- **pre-commit** runs `pnpm lint` (ESLint + Stylelint + Prettier check) on your
-  changes.
+- **pre-push** runs `pnpm lint` (ESLint + Stylelint + Prettier check) on your
+  changes. Lint failures surface at push time, so the commit already exists by
+  then — run `pnpm format` and amend or add a follow-up commit.
 - **post-checkout** / **post-merge** run `pnpm install` so your dependencies
-  stay in sync after switching branches or pulling.
+  stay in sync after switching branches or pulling. That same `pnpm install`
+  also registers the forward-merge merge drivers ([above](#getting-started)).
 
 ### Resolving a blocked forward-merge
 
@@ -593,7 +595,7 @@ pnpm affected:test:browser --parallel=1 --browser.name=webkit   # browser/e2e/vi
 
 ## Code style
 
-Formatting and linting are enforced; the pre-commit hook runs `pnpm lint` for
+Formatting and linting are enforced; the pre-push hook runs `pnpm lint` for
 you.
 
 ```shell


### PR DESCRIPTION
Closes #2872.

`simple-git-hooks` has run `pnpm lint` on **pre-push** since #2827 (`de72c8037`), but the docs still called it a pre-commit hook in four places:

```
$ node -p "JSON.stringify(require('./package.json')['simple-git-hooks'])"
{"post-checkout":"pnpm install","post-merge":"pnpm install","pre-push":"pnpm lint"}
```

Working through the checklist:

- **Renamed the hook** in all four spots — `AGENTS.md:128`, `AGENTS.md:171`, `CONTRIBUTE.md:82`, `CONTRIBUTE.md:596`.
- **Adjusted the consequence, not just the name.** Both prose spots now say lint blocks the *push*, and `CONTRIBUTE.md` notes the practical difference: the commit already exists by the time lint fires, so `pnpm format` is followed by an amend or a follow-up commit. `pnpm format` remains the fix.
- **Cross-linked the merge drivers** from the Git hooks section back to Getting started, rather than restating the fact 20 lines later.

```
$ git grep -n "pre-commit" -- AGENTS.md CONTRIBUTE.md
(no output, exits 1)
```

Docs only — no code touched.
