### PR TITLE
fix(docs): make anchor links scroll to their heading

### DIFF
--- a/apps/docs/src/app/_components/layout/AnchorNavigation/AnchorNavigation.tsx
+++ b/apps/docs/src/app/_components/layout/AnchorNavigation/AnchorNavigation.tsx
@@ -51,6 +51,23 @@ export const AnchorNavigation: FC<Props> = (props) => {
     };
   }, []);
 
+  // The MDX content renders on the client, so the browser's own jump to the
+  // hash happens while the headings don't exist yet. Repeat it once the content
+  // is there.
+  useEffect(() => {
+    if (!ready || initialScrollProcessed.current) {
+      return;
+    }
+
+    const slug = decodeURIComponent(window.location.hash.slice(1));
+    if (!slug) {
+      return;
+    }
+
+    initialScrollProcessed.current = true;
+    document.getElementById(slug)?.scrollIntoView();
+  }, [ready]);
+
   const [activeAnchor, setActiveAnchor] = React.useState<string | null>(null);
 
   useEffect(() => {
@@ -64,23 +81,8 @@ export const AnchorNavigation: FC<Props> = (props) => {
         if (firstVisible) {
           setActiveAnchor(firstVisible.target.id);
         } else {
-          const currentUrlSlug = window.location.hash.slice(1);
           const aboveViewport = anchors
-            .map((a) => {
-              const slugElement = document.getElementById(a.slug);
-
-              if (!initialScrollProcessed.current) {
-                initialScrollProcessed.current = true;
-                if (
-                  currentUrlSlug &&
-                  currentUrlSlug === encodeURIComponent(a.slug)
-                ) {
-                  slugElement?.scrollIntoView();
-                }
-              }
-
-              return slugElement;
-            })
+            .map((a) => document.getElementById(a.slug))
             .filter((el): el is HTMLElement => el !== null)
             .filter(
               (el) =>

--- a/apps/docs/src/app/global.scss
+++ b/apps/docs/src/app/global.scss
@@ -4,10 +4,6 @@
   }
 }
 
-html {
-  scroll-behavior: smooth;
-}
-
 body {
   margin: 0;
 }

--- a/apps/docs/src/content/02-foundations/03-content-guidelines/02-informationskonzept/index.mdx
+++ b/apps/docs/src/content/02-foundations/03-content-guidelines/02-informationskonzept/index.mdx
@@ -59,7 +59,7 @@ einen [Alert](/04-components/status/alert) ergänzt, etwa auf der
 [Detailseite](/03-patterns/01-patterns/detail-page), um zusätzliche
 Informationen bereitzustellen. Für Metadaten oder ergänzende Informationen ist
 hingegen die [Badge](/04-components/status/badge) besser geeignet (siehe
-[AlertBadge vs. Badge](/04-components/status/alert-badge#alertbadge-vs-badge)).
+[AlertBadge vs. Badge](/04-components/status/alert-badge#best-practices-alertbadge-vs-badge)).
 
 <LiveCodeEditor example="alertBadge" editorCollapsed row />
 

--- a/apps/docs/src/content/03-patterns/01-patterns/anlegeprozess/index.mdx
+++ b/apps/docs/src/content/03-patterns/01-patterns/anlegeprozess/index.mdx
@@ -34,7 +34,7 @@ Anlege- und Bearbeitungsprozesse werden im mStudio grundsätzlich in einem
 [Modal](/04-components/overlays/modal) ausgeführt. So kann der User jederzeit
 den passenden Prozess starten, ohne seinen Workflow zu unterbrechen. Das Modal
 gibt es in der klassischen Modal Darstellung und als
-[Off-Canvas](/04-components/overlays/modal#variants)-Variant:
+[Off-Canvas](/04-components/overlays/modal#offcanvas)-Variant:
 
 - Modal: Für kurze, fokussierte Prozesse – etwa einfache Formulare oder schnelle
   Einstellungen, die der User direkt erledigt.

--- a/apps/docs/src/content/04-components/actions/button/index.mdx
+++ b/apps/docs/src/content/04-components/actions/button/index.mdx
@@ -22,9 +22,10 @@ description:
 ## Button vs. Link
 
 Verwende für Navigation bevorzugt Links und für Aktionen Buttons. Eine Ausnahme
-können hervorgehobene [Call-to-Actions](/04-components/navigation/link#button)
-sein, bei denen ein Button-ähnliches Erscheinungsbild für eine Navigation
-sinnvoll ist.
+können hervorgehobene
+[Call-to-Actions](/04-components/navigation/link#kombiniere-mit-button) sein,
+bei denen ein Button-ähnliches Erscheinungsbild für eine Navigation sinnvoll
+ist.
 
 <DoAndDont>
   <Plain heading="Verwende Buttons, um z. B. ...">

--- a/apps/docs/src/content/04-components/navigation/link/index.mdx
+++ b/apps/docs/src/content/04-components/navigation/link/index.mdx
@@ -20,9 +20,10 @@ description:
 ## Link vs. Button
 
 Verwende für Navigation bevorzugt Links und für Aktionen Buttons. Eine Ausnahme
-können hervorgehobene [Call-to-Actions](/04-components/navigation/link#button)
-sein, bei denen ein Button-ähnliches Erscheinungsbild für eine Navigation
-sinnvoll ist.
+können hervorgehobene
+[Call-to-Actions](/04-components/navigation/link#kombiniere-mit-button) sein,
+bei denen ein Button-ähnliches Erscheinungsbild für eine Navigation sinnvoll
+ist.
 
 <DoAndDont>
   <Plain heading="Verwende Links, um z. B. ...">


### PR DESCRIPTION
Anchor links changed the URL hash but left the viewport where it was.

Two causes:

- `html { scroll-behavior: smooth }` animated every hash jump — roughly a second on a long page like Colors (7300 px). The MDX content renders on the client and keeps growing during that time, and Chrome aborts the running animation: the reader ended up 5000 px short of the heading, or didn't move at all on reload. Jumps are instant now.
- The catch-up scroll for the initial hash lived inside the IntersectionObserver callback and only ran when no anchor happened to be visible — never the case after a reload. It's a separate effect now that waits for the MDX content to be ready.

Four content links pointed at anchors that don't exist. Heading ids combine the H1 and H2 text, so the "Button" section on the Link page is `#kombiniere-mit-button`, not `#button`.

Verified in Chromium across four target anchors × direct load / reload / cross-page click, plus ToC clicks on the Colors page: all land on the heading.

Closes #2879

🤖 Generated with [Claude Code](https://claude.com/claude-code)