### PR TITLE
docs(examples): replace SegmentedControl with Tabs and RadioGroup

### DIFF
--- a/apps/docs/src/content/03-patterns/01-patterns/detail-page/examples/detail-page.tsx
+++ b/apps/docs/src/content/03-patterns/01-patterns/detail-page/examples/detail-page.tsx
@@ -22,9 +22,8 @@ import {
   ModalTrigger,
   ProgressBar,
   Section,
-  Segment,
-  SegmentedControl,
   Switch,
+  Tab,
   Table,
   TableBody,
   TableCell,
@@ -32,14 +31,12 @@ import {
   TableHeader,
   TableRow,
   TabNavigation,
+  Tabs,
+  TabTitle,
   Text,
 } from "@mittwald/flow-react-components";
-import { useState } from "react";
 
 export default () => {
-  const [connectionType, setConnectionType] =
-    useState("IMAP");
-
   return (
     <Flex direction="column" gap="m">
       <Flex direction="column">
@@ -160,41 +157,48 @@ export default () => {
         </Section>
         <Section>
           <Heading>Verbindungsinformationen</Heading>
-          <SegmentedControl
-            defaultValue={connectionType}
-            onChange={setConnectionType}
-            aria-label="Verbindungsart"
-          >
-            <Segment value="IMAP">IMAP</Segment>
-            <Segment value="POP3">POP3</Segment>
-            <Segment value="SMTP">SMTP</Segment>
-          </SegmentedControl>
-          <Table aria-label="Verbindungsinformationen">
-            <TableHeader>
-              <TableColumn></TableColumn>
-              <TableColumn></TableColumn>
-            </TableHeader>
-            <TableBody>
-              <TableRow>
-                <TableCell rowHeader>
-                  Benutzername
-                </TableCell>
-                <TableCell>max@mustermann.de</TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell rowHeader>
-                  {connectionType} Port
-                </TableCell>
-                <TableCell>...</TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell rowHeader>
-                  {connectionType} Postausgang
-                </TableCell>
-                <TableCell>...</TableCell>
-              </TableRow>
-            </TableBody>
-          </Table>
+          <Tabs>
+            {["IMAP", "POP3", "SMTP"].map(
+              (connectionType) => (
+                <Tab
+                  key={connectionType}
+                  id={connectionType}
+                >
+                  <TabTitle>{connectionType}</TabTitle>
+                  <Table
+                    aria-label={`Verbindungsinformationen ${connectionType}`}
+                  >
+                    <TableHeader>
+                      <TableColumn></TableColumn>
+                      <TableColumn></TableColumn>
+                    </TableHeader>
+                    <TableBody>
+                      <TableRow>
+                        <TableCell rowHeader>
+                          Benutzername
+                        </TableCell>
+                        <TableCell>
+                          max@mustermann.de
+                        </TableCell>
+                      </TableRow>
+                      <TableRow>
+                        <TableCell rowHeader>
+                          {connectionType} Port
+                        </TableCell>
+                        <TableCell>...</TableCell>
+                      </TableRow>
+                      <TableRow>
+                        <TableCell rowHeader>
+                          {connectionType} Postausgang
+                        </TableCell>
+                        <TableCell>...</TableCell>
+                      </TableRow>
+                    </TableBody>
+                  </Table>
+                </Tab>
+              ),
+            )}
+          </Tabs>
         </Section>
         <Section>
           <Header>

--- a/apps/docs/src/content/03-patterns/01-patterns/forms/examples/form.tsx
+++ b/apps/docs/src/content/03-patterns/01-patterns/forms/examples/form.tsx
@@ -3,9 +3,9 @@ import {
   ColumnLayout,
   Heading,
   Label,
+  RadioButton,
+  RadioGroup,
   Section,
-  Segment,
-  SegmentedControl,
   Text,
   TextField,
 } from "@mittwald/flow-react-components";
@@ -57,10 +57,14 @@ export default () => {
         <Heading>Zahlungsinformationen</Heading>
         <Heading level={3}>Zahlungsart</Heading>
         <Field name="paymentMethod">
-          <SegmentedControl aria-label="Zahlungsart">
-            <Segment value="invoice">Rechnung</Segment>
-            <Segment value="debit">Lastschrift</Segment>
-          </SegmentedControl>
+          <RadioGroup l={[1, 1]} aria-label="Zahlungsart">
+            <RadioButton value="invoice">
+              Rechnung
+            </RadioButton>
+            <RadioButton value="debit">
+              Lastschrift
+            </RadioButton>
+          </RadioGroup>
         </Field>
 
         {watchedPaymentMethod === "invoice" && (

--- a/apps/docs/src/content/04-components/overlays/modal/examples/offCanvas.tsx
+++ b/apps/docs/src/content/04-components/overlays/modal/examples/offCanvas.tsx
@@ -13,8 +13,6 @@ import {
   RadioButton,
   RadioGroup,
   Section,
-  Segment,
-  SegmentedControl,
   Text,
   TextField,
 } from "@mittwald/flow-react-components";
@@ -49,13 +47,15 @@ import { sleepLong } from "@/content/04-components/actions/action/examples/lib";
           Wähle zwischen der Authentifikation per Passwort
           oder über einen SSH-Key.
         </Text>
-        <SegmentedControl
-          value="password"
+        <RadioGroup
+          defaultValue="password"
           aria-label="Authentifizierung"
         >
-          <Segment value="password">Passwort</Segment>
-          <Segment value="ssh">SSH-Key</Segment>
-        </SegmentedControl>
+          <RadioButton value="password">
+            Passwort
+          </RadioButton>
+          <RadioButton value="ssh">SSH-Key</RadioButton>
+        </RadioGroup>
         <ColumnLayout s={[1, 1]}>
           <TextField isRequired>
             <Label>Passwort</Label>

--- a/apps/docs/src/content/04-components/overlays/modal/examples/size.tsx
+++ b/apps/docs/src/content/04-components/overlays/modal/examples/size.tsx
@@ -15,8 +15,6 @@ import {
   RadioButton,
   RadioGroup,
   Section,
-  Segment,
-  SegmentedControl,
   Select,
   Switch,
   Text,
@@ -219,13 +217,17 @@ export default () => {
                 Wähle zwischen der Authentifikation per
                 Passwort oder über einen SSH-Key.
               </Text>
-              <SegmentedControl
-                value="password"
+              <RadioGroup
+                defaultValue="password"
                 aria-label="Authentifizierung"
               >
-                <Segment value="password">Passwort</Segment>
-                <Segment value="ssh">SSH-Key</Segment>
-              </SegmentedControl>
+                <RadioButton value="password">
+                  Passwort
+                </RadioButton>
+                <RadioButton value="ssh">
+                  SSH-Key
+                </RadioButton>
+              </RadioGroup>
               <ColumnLayout s={[1, 1]}>
                 <TextField isRequired>
                   <Label>Passwort</Label>


### PR DESCRIPTION
## What & why

Prepares the SegmentedControl deprecation: no example outside the component's own documentation uses it anymore.

- **Detail-page pattern** — the IMAP/POP3/SMTP switch becomes `Tabs`. It swaps content inside the page rather than being a form field, which is the distinction the Tabs docs already draw. The `useState` for the selected type is gone; the table is mapped over the three types.
- **Forms pattern** ("Zahlungsart") and **both Modal OffCanvas examples** ("Authentifizierung") — `RadioGroup` with `RadioButton`. The `Zahlungsart` group gets `l={[1, 1]}` so it lines up with the address fields below.

The SegmentedControl docs page, its wireframe, the react-hook-form `Field` story and the visual test keep using it.

Verified in the docs dev server: tabs switch the table, only the active panel is in the DOM, and selecting "Lastschrift" still reveals the IBAN fields (react-hook-form binding intact).

## Checklist

- [x] PR title is a Conventional Commit and matches the base branch above
- [x] `pnpm lint` is clean (pre-push hook) — `pnpm affected:test` not run locally, left to CI
- [x] **Generated code is committed** — no generators affected, docs content only
- [ ] User-facing strings added to **both** `de-DE` and `en-US` locale files — n/a, docs content only
- [x] Docs updated if a public API changed; intentional visual changes get updated snapshots / the `update-screenshots` label — no component code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)