### PR TITLE
docs(migration): add ext-bridge and remote-core migration notes

### DIFF
--- a/packages/ext-bridge/MIGRATION.md
+++ b/packages/ext-bridge/MIGRATION.md
@@ -1,5 +1,120 @@
 # Migrations
 
+## From version 0.2.0-alpha.849 to version 0.2.0-alpha.850
+
+### `HostConfig` gained `theme`
+
+`ExtBridgeConfig` has a required `theme: "dark" | "light"`, contributed by the
+host. Reading it needs no change. Anything **constructing** a config from
+`ExtBridgeConfigInput` — mocks, test fixtures — must supply it:
+
+```diff
+  const config: ExtBridgeConfigInput = {
+    sessionId: "…",
+    userId: "…",
+    extensionId: "…",
+    extensionInstanceId: "…",
+    language: "de",
++   theme: "light",
+  };
+```
+
+This landed while the config type was unresolvable, so it only becomes visible
+once you upgrade to `>=0.2.0-alpha.1021` — see the `0.2.0-alpha.1021` entry
+above.
+
+---
+
+## From version 0.2.0-alpha.789 to version 0.2.0-alpha.790
+
+### Unknown config keys are no longer typed
+
+The catchall moved out of the exported `config` schema into `parseConfig`, so
+the result of `getConfig()` / `useConfig()` lost its index signature:
+
+```diff
+- [key: string]: string | null | undefined
++ (no index signature)
+```
+
+**Runtime behaviour is unchanged** — `parseConfig` still applies the catchall,
+so custom keys are still present in the returned object. Only the type stopped
+describing them, so dynamic reads fail to compile:
+
+```
+error TS7053: Element implicitly has an 'any' type because expression of type
+'string' can't be used to index type 'ExtBridgeConfig'.
+```
+
+Known keys (`sessionId`, `userId`, `extensionId`, `extensionInstanceId`,
+`variantKey`, `appInstallationId`, `projectId`, `customerId`) are unaffected.
+For custom keys, state the shape you expect:
+
+```diff
+- const value = config[key];
++ const value = (config as Record<string, string | null | undefined>)[key];
+```
+
+Like the entry above, this was masked until `>=0.2.0-alpha.1021`.
+
+---
+
+## From version 0.2.0-alpha.788 to version 0.2.0-alpha.789
+
+### `language` became a required `HostConfig` member
+
+`language` moved from the config schema into the new `HostConfig` interface, and
+`ExtBridgeConfig` became an intersection of the parsed environment config and
+the host-contributed values. `ExtBridgeConfigInput` was introduced alongside it.
+
+`HostConfig.language` has no default, so anything constructing a config must
+supply it:
+
+```diff
+  const config: ExtBridgeConfigInput = {
+    // …
++   language: "de",
+  };
+```
+
+This is also the version where the config type stopped resolving for consumers.
+
+---
+
+## From version 0.2.0-alpha.784 to version 0.2.0-alpha.785
+
+### `language` added to the config schema
+
+`language` was added as `z.string().default("de")`, so the **result** of
+`getConfig()` / `useConfig()` gained a required `language: string`. Constructing
+a config was unaffected at this point, because the default filled it in. That
+changed one version step later — see the entry above.
+
+---
+
+## From version 0.2.0-alpha.649 to version 0.2.0-alpha.650
+
+### Unknown config keys can be `null` or `undefined`
+
+The config schema's catchall changed from `z.string()` to
+`z.string().optional().nullable()` (#2276), widening the index signature:
+
+```diff
+- [key: string]: string
++ [key: string]: string | null | undefined
+```
+
+```diff
+- const value: string = config[key];
++ const value = config[key] ?? fallback;
+```
+
+Superseded by `0.2.0-alpha.790`, which removed the index signature from the type
+altogether. Migrating from below `0.2.0-alpha.650` straight to a current
+version? Then only that entry matters.
+
+---
+
 ## From version 0.2.0-alpha.150 to version 0.2.0-alpha.151
 
 This guide covers the key changes for migrating to the latest version of the

--- a/packages/remote-core/MIGRATION.md
+++ b/packages/remote-core/MIGRATION.md
@@ -1,0 +1,105 @@
+# Migrations
+
+Most entries here concern code that **implements or mocks** the connection
+protocol — a host renderer, a test double, an alternative host. If you only
+_call_ the exported functions from an extension, the interface members added
+below do not affect you; the `connectRemoteIframe` and `Version` changes do.
+
+---
+
+## From version `0.2.0-alpha.1006` to `>=0.2.0-alpha.1007`
+
+### `HostExports` requires `reportEvent`
+
+The host side reports component usage back to the host (#2765). Anything
+implementing `HostExports` must provide the new member.
+
+```diff
+  const hostExports: HostExports = {
+    getHostConfig,
+    reportDeprecation,
++   reportEvent,
+    // …
+  };
+```
+
+---
+
+## From version `0.2.0-alpha.913` to `>=0.2.0-alpha.914`
+
+### `Version` gained `v5`; `HostToRemoteConnection` requires `reportHostError`, `RemoteExports` requires `setHostError`
+
+Remote-side "No component found" errors are surfaced to the host (#2651).
+
+An exhaustive `switch` over `Version` stops compiling — add the new case:
+
+```diff
+  switch (connection.version) {
+    case Version.v3:
+    case Version.v4:
++   case Version.v5:
+      // …
+  }
+```
+
+Prefer a `default` branch over enumerating every member: the protocol version is
+expected to grow, so each new version would otherwise break the build.
+
+---
+
+## From version `0.2.0-alpha.904` to `>=0.2.0-alpha.905`
+
+### `HostExports` requires `reportDeprecation`
+
+Remote deprecation notices are forwarded to the host via `onDeprecation`
+(#2639). Anything implementing `HostExports` must provide the new member.
+
+---
+
+## From version `0.2.0-alpha.900` to `>=0.2.0-alpha.901`
+
+### `Version` gained `v4`; `RemoteReadyEvent` carries `packageVersion`
+
+The connection handshake exposes the remote package version (#2610). As with
+`v5` above, an exhaustive `switch` over `Version` needs the new case.
+
+`setIsReady` now takes `RemoteReadyEventInput` (`Version | RemoteReadyEvent`)
+instead of `Version`. Existing calls keep working — the parameter accepts
+strictly more than before.
+
+---
+
+## From version `0.2.0-alpha.788` to `>=0.2.0-alpha.789`
+
+### `connectRemoteIframe` requires `hostConfig`
+
+`connectRemoteIframe` and `connectRemoteIframeRef` gained a required
+`hostConfig` option, so the host can pass language and theme to the remote side.
+
+```diff
+  connectRemoteIframe({
+    connection,
+    iframe,
++   hostConfig: { language: "de", theme: "light" },
+  });
+```
+
+The type comes from `@mittwald/ext-bridge`:
+
+```ts
+import type { HostConfig } from "@mittwald/ext-bridge";
+```
+
+Note that on versions `0.2.0-alpha.789` through `0.2.0-alpha.1020` this type was
+not resolvable for consumers (#2826) — if you are migrating across that range,
+go to `>=0.2.0-alpha.1021`, where the import above works.
+
+### `extBridgeImplementation` retyped
+
+```diff
+- extBridgeImplementation?: ExtBridgeConnectionApi
++ extBridgeImplementation?: RemoteExtBridgeConnectionApi
+```
+
+Both types are exported from this package. The option stays optional and
+defaults to an empty implementation.


### PR DESCRIPTION
## What & why

The alpha-line migration record covers `packages/components`. `ext-bridge` had a
single entry from `alpha.151`, and `remote-core` had no `MIGRATION.md` at all —
yet both shipped breaking changes since `alpha.616`, the migration floor decided
in #2825. This fills those two gaps.

Refs #2825 (task 3 for these two packages).

### `packages/remote-core/MIGRATION.md` (new)

| Version | Change |
| --- | --- |
| `>=alpha.789` | `connectRemoteIframe` / `connectRemoteIframeRef` require `hostConfig`; `extBridgeImplementation` retyped |
| `>=alpha.901` | `Version.v4`, `RemoteReadyEvent.packageVersion` (#2610) |
| `>=alpha.905` | `HostExports.reportDeprecation` (#2639) |
| `>=alpha.914` | `Version.v5`, `HostToRemoteConnection.reportHostError`, `RemoteExports.setHostError` (#2651) |
| `>=alpha.1007` | `HostExports.reportEvent` (#2765) |

The file leads with who is affected, because most of it is not extension
developers: the added interface members only break code that **implements or
mocks** the protocol. The `Version` entries recommend a `default` branch over an
exhaustive `switch`, since the enum grew twice in 13 versions.

### `packages/ext-bridge/MIGRATION.md`

Four entries for the `getConfig()` / `useConfig()` result shape:

- **`>=alpha.650`** — catchall widened to `z.string().optional().nullable()`, so
  the index signature became `string | null | undefined` (#2276).
- **`>=alpha.790`** — the catchall was removed from the exported schema, so the
  type lost its index signature and dynamic reads stopped compiling (`TS7053`).
  **Runtime is unchanged**: `parseConfig` still applies the catchall, so custom
  keys are still in the returned object — only the type stopped describing them.
  This supersedes the `alpha.650` entry.
- **`>=alpha.785`** — `language` added to the schema as
  `z.string().default("de")`: required on the result, still optional to
  construct.
- **`>=alpha.789`** — `language` moved into `HostConfig` and lost its default, so
  it became required in `ExtBridgeConfigInput` too. `>=alpha.850` adds `theme`
  the same way.

## Notes for the reviewer

**Overlap with #2884.** That PR adds the `HostConfig` / `@mittwald/flow-core`
entry to the head of the same `ext-bridge/MIGRATION.md`. I deliberately left that
change out to avoid duplicating it, and my entries reference it. Both PRs insert
at the top of that file, so expect a textual conflict — whichever merges second
resolves it. Merging #2884 first keeps the cross-references valid.

**Heading style.** The new `ext-bridge` blocks follow #2884's style in that file
(`## From version X to version Y`) rather than the backticked `>=` form used in
`components/MIGRATION.md`, so the file stays internally consistent. The new
`remote-core` file has no legacy constraint and uses the `components` style. Say
the word if you'd rather have one of them flipped.

**Why these changes were undocumented.** Everything from `alpha.789` on was
invisible to consumers until `alpha.1021`: the unresolvable
`@mittwald/flow-core` import (#2826) degraded `ExtBridgeConfig` to `any`, so
`tsc` reported nothing. That is also why `alpha.790` and `alpha.850` were missing
from the audit in #2825 — the same masking hid them from the extraction. They all
surface on the single upgrade past `alpha.1021`, and the affected entries say so.

**How this was verified.** Version boundaries are pinned against the published
packages (`npm pack` per version, not inferred from commit dates), and the type
claims were checked by compiling a consumer against the published tarballs
rather than read off the source — that is how the `alpha.790` index-signature
removal and the `language` default-vs-required distinction turned up. Two of my
own first-draft claims were wrong and are corrected here.

## Checklist

- [x] PR title is a Conventional Commit and matches the base branch (`docs:` →
      `main`)
- [x] `pnpm format:check` clean (repo-wide); eslint/stylelint not applicable to a
      Markdown-only change, no tests affected
- [x] **Generated code is committed** — no generators touched
- [ ] User-facing strings — n/a, no UI text
- [x] Docs updated if a public API changed — this PR *is* the doc change
