### PR TITLE
ci(dependabot): group every npm update and auto-merge on green CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,22 +4,79 @@ version: 2
 # breaking changes (build/runtime/API) that warrant a considered upgrade rather
 # than an auto-PR. To take a specific major, bump it manually (or temporarily
 # remove/relax the matching ignore).
+#
+# Everything proposed here is auto-merged by
+# `.github/workflows/dependabot-auto-merge.yml` once CI and the visual
+# regression suite are green — see CONTRIBUTE.md § Dependency updates. Two
+# consequences for this file:
+#
+# 1. NOTHING IS UNGROUPED. Every npm dependency falls into one of the groups
+#    below, so a week produces at most four lockfile PRs. Each merge invalidates
+#    `pnpm-lock.yaml` in every other open PR, which makes Dependabot rebase it
+#    and CI run again — with ~10 open PRs that cascade is quadratic, and it is
+#    why the old `dev-dependencies` PR grew to 29 updates without ever landing.
+# 2. A `cooldown` replaces the human as the filter against bad releases. It
+#    mirrors the `minimumReleaseAge` this repo used to set in
+#    `pnpm-workspace.yaml`, `@mittwald/*` exempt for the same reason: our own
+#    packages are published and consumed within the hour.
 updates:
   - package-ecosystem: npm
     directory: "/"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+      exclude:
+        - "@mittwald/*"
+    # First match wins, so the risk cluster is carved out before the catch-all.
     groups:
-      dev-dependencies:
+      # The accessibility foundation moves as one unit and breaks as one unit —
+      # a partial bump across these packages mixes incompatible internals.
+      react-aria:
+        patterns:
+          - "react-aria"
+          - "react-aria-components"
+          - "@react-aria/*"
+          - "@react-stately/*"
+          - "@react-types/*"
+          - "@internationalized/*"
+      # Everything that ships to consumers. Patch and minor together: with
+      # auto-merge nobody reviews them individually anyway, and splitting them
+      # only adds another PR to the rebase cascade.
+      production:
+        dependency-type: production
+      # Split, unlike production: the dev side carries the volume (~25 updates a
+      # week), and the boring patches should land even while a minor is red.
+      dev-patch:
         dependency-type: development
+        update-types:
+          - patch
+      dev-minor:
+        dependency-type: development
+        update-types:
+          - minor
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+      # Deliberate holds. Without these, Dependabot re-proposes them every week
+      # and each PR has to be closed by hand — Dependabot widens a `~`/`^` range
+      # rather than respecting it as a ceiling.
+      #
+      # recharts 3.10 breaks the `CartesianChart` public type surface. Taking it
+      # is its own PR, not a routine bump.
+      - dependency-name: "recharts"
+        versions: [">=3.8.0"]
+      # playwright 1.62 ships WebKit 2336, which stretches the LightBox image.
+      # Lift the hold only once that sizing is fixed.
+      - dependency-name: "playwright"
+        versions: [">=1.62.0"]
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
       actions:
         patterns:
@@ -31,6 +88,8 @@ updates:
     directory: "/apps/docs"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
@@ -38,6 +97,8 @@ updates:
     directory: "/packages/components"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,156 @@
+# Auto-merges Dependabot PRs once the visual regression suite is green.
+#
+# Why this hangs off `workflow_run` instead of `pull_request`:
+#
+#   - `pull_request` on a Dependabot PR gets a READ-ONLY `GITHUB_TOKEN`, so it
+#     cannot comment.
+#   - `pull_request_target` would give a write token to a run that checks out
+#     dependency code. This workflow never checks anything out.
+#   - `workflow_run` runs from the default branch with a write token and only
+#     reads API state. Note the consequence: it is inert until it lands on
+#     `main`, so it cannot be exercised from the PR that introduces it.
+#
+# The merge itself is left to Dependabot (`@dependabot squash and merge`), which
+# waits for the required `main` check before merging. Dependabot is the actor
+# with the ruleset bypass — see CONTRIBUTE.md § Dependency updates. Do NOT
+# switch this to `gh pr merge --auto`: that merges as `github-actions[bot]`,
+# which would need the bypass instead, widening it to every workflow that holds
+# a write token.
+name: Dependabot auto-merge
+
+on:
+  workflow_run:
+    workflows: ["Run Visual Regression Tests"]
+    types:
+      - completed
+
+permissions: {}
+
+jobs:
+  auto-merge:
+    # Visual is the gate this workflow owns. The required `main` check is
+    # enforced by Dependabot when it processes the merge command, and by the
+    # ruleset, which does NOT grant Dependabot a bypass on status checks.
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      startsWith(github.event.workflow_run.head_branch, 'dependabot/')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    concurrency:
+      group: dependabot-auto-merge@${{ github.event.workflow_run.head_branch }}
+      cancel-in-progress: false
+
+    permissions:
+      contents: read
+      pull-requests: write # comments the merge command
+
+    steps:
+      - name: Verify the PR and ask Dependabot to merge
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const run = context.payload.workflow_run;
+            const { owner, repo } = context.repo;
+
+            const decline = (reason) => {
+                core.info(`not merging: ${reason}`);
+                core.summary.addRaw(`Not merging \`${run.head_branch}\`: ${reason}`).write();
+            };
+
+            // `workflow_run.pull_requests` is populated for same-repo branches,
+            // which Dependabot branches are — the lookup is only a fallback.
+            let number = run.pull_requests?.[0]?.number;
+            if (!number) {
+                const { data } = await github.rest.pulls.list({
+                    owner,
+                    repo,
+                    state: "open",
+                    head: `${owner}:${run.head_branch}`,
+                });
+                number = data[0]?.number;
+            }
+            if (!number) {
+                return decline("no open PR found for this branch");
+            }
+
+            const { data: pr } = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: number,
+            });
+
+            if (pr.user.login !== "dependabot[bot]") {
+                return decline(`PR #${number} was opened by ${pr.user.login}`);
+            }
+
+            // A rebase may have landed while the suite was running. Merging on a
+            // stale green would merge code the suite never saw.
+            if (run.head_sha !== pr.head.sha) {
+                return decline(
+                    `run tested ${run.head_sha.slice(0, 7)}, PR head is now ${pr.head.sha.slice(0, 7)}`,
+                );
+            }
+
+            const commits = await github.paginate(github.rest.pulls.listCommits, {
+                owner,
+                repo,
+                pull_number: number,
+            });
+
+            // The one real hole in granting Dependabot a ruleset bypass: anyone
+            // with write access can push onto an open `dependabot/*` branch, and
+            // that commit would reach main without a code owner review.
+            // Dependabot signs its commits, so a foreign push fails here.
+            for (const commit of commits) {
+                if (commit.author?.login !== "dependabot[bot]") {
+                    return decline(
+                        `${commit.sha.slice(0, 7)} is authored by ${commit.author?.login ?? "an unknown user"}`,
+                    );
+                }
+                if (!commit.commit.verification?.verified) {
+                    return decline(`${commit.sha.slice(0, 7)} has no verified signature`);
+                }
+            }
+
+            // Belt and braces: dependabot.yml ignores majors across every
+            // ecosystem, so reaching this means the config was relaxed.
+            const major = commits.find((commit) =>
+                commit.commit.message.includes("update-type: version-update:semver-major"),
+            );
+            if (major) {
+                return decline("the PR carries a major version update");
+            }
+
+            // Every rebase produces a fresh run, so only skip a command that was
+            // already issued for THIS head commit.
+            const command = "@dependabot squash and merge";
+            const headCommittedAt = commits.at(-1).commit.committer.date;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: number,
+            });
+            const alreadyAsked = comments.some(
+                (comment) =>
+                    comment.user?.login === "github-actions[bot]" &&
+                    comment.body?.includes(command) &&
+                    comment.created_at > headCommittedAt,
+            );
+            if (alreadyAsked) {
+                return decline("the merge command was already issued for this head commit");
+            }
+
+            await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: number,
+                body: command,
+            });
+
+            core.info(`asked Dependabot to merge #${number}`);
+            core.summary
+                .addRaw(`Asked Dependabot to squash and merge #${number} — it merges once \`main\` is green.`)
+                .write();

--- a/.github/workflows/test-visual-label.yml
+++ b/.github/workflows/test-visual-label.yml
@@ -5,15 +5,23 @@ on:
   pull_request:
     types:
       - labeled
+      # Dependabot PRs run the suite unconditionally rather than on a label.
+      # It is the gate `dependabot-auto-merge.yml` waits for, and labelling from
+      # a workflow would not work anyway: events created with `GITHUB_TOKEN` do
+      # not start new workflow runs.
+      - opened
+      - reopened
+      - synchronize
 
 jobs:
   run-visual-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     if: >
-      github.event_name == 'workflow_dispatch' || (github.event.label.name ==
-      'run-visual-tests' &&
-       github.head_ref != github.event.repository.default_branch)
+      github.event_name == 'workflow_dispatch' ||
+      (github.head_ref != github.event.repository.default_branch &&
+       (github.event.label.name == 'run-visual-tests' ||
+        github.event.pull_request.user.login == 'dependabot[bot]'))
 
     # one at a time per branch; re-labeling supersedes an in-flight run
     concurrency:
@@ -26,7 +34,10 @@ jobs:
 
     steps:
       - name: Remove label if exists
-        if: github.event_name == 'pull_request'
+        # Only the labelled path has a label to remove — and only that path may
+        # write: a `pull_request` event on a Dependabot PR gets a read-only
+        # `GITHUB_TOKEN`, so this call would 403 and fail the whole job.
+        if: github.event.action == 'labeled'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ github.token }}
@@ -108,7 +119,10 @@ jobs:
           cat "$RUNNER_TEMP/visual-summary.md" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Comment summary on PR
-        if: always() && github.event_name == 'pull_request'
+        # Same read-only-token reason as above. On a Dependabot PR the check run
+        # and its step summary are the signal; nothing auto-merges while it is
+        # red.
+        if: always() && github.event.action == 'labeled'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ github.token }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,6 +173,11 @@ and commit the results.
   `.md`/`.json`/`.yml` blocks the push, not the commit; `pnpm format` fixes it.
 - **New dependencies:** pnpm enforces a `minimumReleaseAge` of one week (exempt:
   `@mittwald/*`) — brand-new versions won't resolve.
+- **Dependency updates run themselves.** Dependabot opens four grouped npm PRs a
+  week and merges them itself once CI and the visual suite are green — see
+  [CONTRIBUTE.md § Dependency updates](CONTRIBUTE.md#dependency-updates). A
+  deliberate hold belongs in `.github/dependabot.yml` as an `ignore` entry; a
+  closed PR only makes it come back next week.
 - **Breaking changes for consumers** ship with a `MIGRATION.md` entry and,
   ideally, a codemod in `packages/codemods` (tedious by hand — a great agent
   task).

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -28,6 +28,7 @@ coding agents, but great reference docs for humans too.
 - [Choosing the base branch](#choosing-the-base-branch)
 - [Opening a pull request](#opening-a-pull-request)
 - [Releases](#releases)
+- [Dependency updates](#dependency-updates)
 - [Getting help](#getting-help)
 
 ## Prerequisites
@@ -756,6 +757,55 @@ branches, the forward-merge cascade, promotion, and the 1.0.0 cut), with
 model and [ADR 0004](docs/adr/0004-forward-merge-main-into-next.md) for the
 forward-merge mechanics. (The `next` line and its publishing go live with the
 1.0.0 cut; until then every merge into `main` releases as it does today.)
+
+## Dependency updates
+
+Dependabot proposes minor and patch updates weekly and **merges them itself** —
+nobody approves a dependency bump by hand. Majors are never proposed; take one
+deliberately by bumping it manually. The moving parts:
+
+- [`.github/dependabot.yml`](.github/dependabot.yml) puts every npm dependency
+  into one of four groups (`react-aria`, `production`, `dev-patch`, `dev-minor`)
+  and holds versions younger than 7 days back (`cooldown`, `@mittwald/*`
+  exempt). Nothing is left ungrouped on purpose: every merge invalidates
+  `pnpm-lock.yaml` in every other open PR, which makes Dependabot rebase it and
+  CI run again, so the number of open PRs is what drives that cascade.
+- The **visual regression suite runs on every Dependabot PR**, not on a label. A
+  `playwright`, `vitest` or `react-aria` bump moves snapshots, and the label
+  route is not even available to a workflow: events created with `GITHUB_TOKEN`
+  do not start new workflow runs.
+- [`dependabot-auto-merge.yml`](.github/workflows/dependabot-auto-merge.yml)
+  waits for that suite, re-checks the PR, and comments
+  `@dependabot squash and merge`. Dependabot merges once the required `main`
+  check is green.
+
+**When one goes red.** Nothing merges. Find the culprit in the group, then
+either fix the code or park the dependency with
+`@dependabot ignore <name> <version>` — which writes nothing to
+`dependabot.yml`, so add an `ignore` entry there for a hold that should outlive
+the PR (see `recharts` and `playwright`).
+
+**Why this is allowed to skip review.** The `main` ruleset requires a code owner
+approval, so Dependabot needs a bypass. That bypass is deliberately narrow, and
+it needs **two rulesets** — a bypass list covers every rule in its ruleset, not
+one rule:
+
+| Ruleset | Rules                                                                | Dependabot bypass |
+| ------- | -------------------------------------------------------------------- | ----------------- |
+| A       | `pull_request` (review requirement)                                  | yes               |
+| B       | `required_status_checks`, `deletion`, `creation`, `non_fast_forward` | **no**            |
+
+So Dependabot may skip the review, never CI. This is repository configuration,
+not a file in this repo — a maintainer sets it up once.
+
+The one hole the bypass opens is that anyone with write access can push a commit
+onto an open `dependabot/*` branch, which would then reach `main` unreviewed.
+`dependabot-auto-merge.yml` closes it: it merges only when every commit in the
+PR is authored by `dependabot[bot]` **and** carries a verified signature.
+
+Bumps that land are published — the standing prerelease line publishes on every
+push to `main` — which is why the cooldown is the safety gate that matters most
+here, not the review it replaces.
 
 ## Getting help
 


### PR DESCRIPTION
Dependency updates had stopped landing. Since 2026-07-24 not a single `dev-dependencies` group PR merged — it was recreated every week and grew 12 → 16 → 17 → 23 → 24 → **29 updates** — while ~8 ungrouped production PRs opened alongside it every Monday.

The mechanism is quadratic, not accidental: each merge invalidates `pnpm-lock.yaml` in every other open PR, Dependabot rebases them, CI runs again. With ~10 open PRs that cascade never drains — and each one still needs a code owner approval by hand.

## What changes

**Four npm PRs a week instead of ten.** Every npm dependency falls into a group; nothing is left ungrouped:

| Group | Contents | Why separate |
| --- | --- | --- |
| `react-aria` | `react-aria*`, `@react-aria/*`, `@react-stately/*`, `@react-types/*`, `@internationalized/*` | Moves as one unit, breaks as one unit — a partial bump mixes incompatible internals |
| `production` | everything else that ships, patch + minor | Low volume; splitting it only adds another PR to the cascade |
| `dev-patch` / `dev-minor` | dev dependencies, split by update type | The dev side carries the volume (~25/week); the boring patches should land even while a minor is red |

**A 7-day `cooldown`** replaces the human as the filter against bad releases, mirroring the `minimumReleaseAge` this repo used to set in `pnpm-workspace.yaml` (`@mittwald/*` exempt for the same reason). Plus explicit `ignore` entries for the two deliberate holds, so they stop coming back weekly: `recharts >=3.8.0` (breaks the `CartesianChart` public type surface) and `playwright >=1.62.0` (WebKit 2336 stretches the LightBox image).

**`dependabot-auto-merge.yml`** waits for the visual suite, re-verifies the PR, and comments `@dependabot squash and merge`. Dependabot merges once the required `main` check is green.

**The visual suite now runs on every Dependabot PR** instead of on the `run-visual-tests` label. A `playwright`, `vitest` or `react-aria` bump moves snapshots — and a workflow cannot use the label route anyway: events created with `GITHUB_TOKEN` do not start new workflow runs. Its two writing steps are narrowed to the labelled path, because on a Dependabot PR the read-only token would 403 and fail the job — blocking the very merge it gates.

## ⚠️ This is inert until a maintainer changes the ruleset

The `main` ruleset requires a code owner approval, so nothing auto-merges until Dependabot has a bypass. A bypass list covers **every rule in its ruleset**, so ruleset `467449` has to be split in two — otherwise Dependabot could also skip CI:

| Ruleset | Rules | Dependabot bypass |
| --- | --- | --- |
| A | `pull_request` | yes |
| B | `required_status_checks`, `deletion`, `creation`, `non_fast_forward` | **no** |

Merging this PR without that split is safe — it just does nothing.

## Security trade-off, stated plainly

Trading the code owner approval for automation is deliberate. An approval on *"bump framer-motion 12.42.2 → 12.43.0"* does not detect a compromised release; nobody reads the dependency diff. The gates that actually can are mechanical: the cooldown, majors staying ignored, full CI, the visual suite, and a signature check. Given that merges to `main` publish on the standing prerelease line, the cooldown is the gate that matters most here.

The bypass opens exactly one hole: anyone with write access can push a commit onto an open `dependabot/*` branch, and `require_last_push_approval` no longer stops it. The workflow closes it — it merges only when **every** commit in the PR is authored by `dependabot[bot]` *and* carries a verified signature. It also refuses a stale green (a rebase landing mid-run), a major, and a command already issued for the same head commit.

## Known limits

- **`workflow_run` only fires from the default branch**, so the auto-merge workflow cannot be exercised from this PR. First real verification is the next Dependabot batch.
- **Whether Dependabot accepts merge commands from `github-actions[bot]` is undocumented.** GitHub's docs suggest `gh pr merge --auto` instead — but that merges as `github-actions[bot]`, which would then need the bypass, widening it to every workflow holding a write token. If Dependabot ignores the comment, the fix is a dedicated App token for the *comment*, not the broader bypass. There's a code comment saying so.
- **Human PRs will now show a skipped "Run Visual Regression Tests" run.** The author cannot be filtered at the `on:` level. Removing that cosmetic noise would mean refactoring the visual workflow into a `workflow_call` reusable plus two thin callers — deliberately not done here, because it would put churn on the label flow the team uses daily.
- **`CONTRIBUTE.md` ground rule 5 and `AGENTS.md` still claim pnpm enforces `minimumReleaseAge`.** It was deleted from `pnpm-workspace.yaml` in `de72c8037` (#2827, "prepare for typescript 7"), apparently by accident. Left untouched here because the fix depends on a decision — restore it or drop the claim — and is being filed as its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)