### PR TITLE
docs(homepage): build the developer experience example from loose components

### DIFF
--- a/apps/docs/src/app/_components/ComposingCodeExample/ComposingCodeExample.module.scss
+++ b/apps/docs/src/app/_components/ComposingCodeExample/ComposingCodeExample.module.scss
@@ -15,15 +15,50 @@
   .preview {
     // Reserve the room the tallest example needs — the empty state, whose
     // `IllustratedMessage` renders its icon at size l. Without it the tile and
-    // the page below it jump every time that example comes around. The editor
-    // keeps its height on its own: `buildAnimation` pads every frame to the
-    // line count of the longest step.
-    min-height: 18rem;
+    // the page below it jump every time that example comes around. How tall it
+    // gets depends on how far its text wraps, so the reserve is measured per
+    // layout: 331px in the narrowest pane (a 375px viewport), 310px once the
+    // two panes sit side by side. The editor keeps its height on its own —
+    // `buildAnimation` pads every frame to the line count of the longest step.
+    min-height: 21rem;
 
     // The shared preview centers whatever it renders. Here that would fake the
     // result: the whole point is that loose components stack in source order
     // until a Flow component arranges them.
     align-items: flex-start;
     justify-content: flex-start;
+  }
+
+  // The example always sits under the copy, so it has the whole card width to
+  // work with. From the column layout's l breakpoint up that is enough for two
+  // panes side by side, which halves the height of the tile and gives the code
+  // enough room to show its longest line.
+  @container (min-width: 850px) {
+    flex-direction: row;
+    overflow: hidden;
+
+    .preview {
+      min-height: 19.5rem;
+    }
+
+    .preview,
+    .editorContainer {
+      // `flex-basis: 0` is a content-box basis, so the preview's padding would
+      // be added on top of its share and the two panes would not be equal.
+      flex: 1 1 50%;
+      min-width: 0;
+    }
+
+    // The divider and the code background belong on the pane, not on the
+    // editor — the editor is only as tall as its lines, so both would stop
+    // short of the bottom edge.
+    .editorContainer {
+      border-inline-start: 1px solid var(--border-color);
+      background-color: var(--code-block--background-color);
+    }
+
+    .codeEditor {
+      border-block-start: 0;
+    }
   }
 }

--- a/apps/docs/src/app/_components/ComposingCodeExample/ComposingCodeExample.module.scss
+++ b/apps/docs/src/app/_components/ComposingCodeExample/ComposingCodeExample.module.scss
@@ -1,4 +1,17 @@
 .example {
+  // The code block never wraps a line, so its min-content width is the longest
+  // line of the longest example. As a grid item that width wins over the column
+  // and pushes the tile open — `min-width: 0` lets it shrink instead, so the
+  // editor's own `overflow-x` scrolls the long lines.
+  min-width: 0;
+
+  // Same reason: the code block is a flex item of the example, and a flex item
+  // does not shrink below its content either. Without this its `overflow-x`
+  // never scrolls and the code runs out over the tile's right edge.
+  .editorContainer {
+    min-width: 0;
+  }
+
   .preview {
     // Reserve the room the tallest example needs — the empty state, whose
     // `IllustratedMessage` renders its icon at size l. Without it the tile and

--- a/apps/docs/src/app/_components/ComposingCodeExample/ComposingCodeExample.module.scss
+++ b/apps/docs/src/app/_components/ComposingCodeExample/ComposingCodeExample.module.scss
@@ -1,0 +1,16 @@
+.example {
+  .preview {
+    // Reserve the room the tallest example needs — the empty state, whose
+    // `IllustratedMessage` renders its icon at size l. Without it the tile and
+    // the page below it jump every time that example comes around. The editor
+    // keeps its height on its own: `buildAnimation` pads every frame to the
+    // line count of the longest step.
+    min-height: 18rem;
+
+    // The shared preview centers whatever it renders. Here that would fake the
+    // result: the whole point is that loose components stack in source order
+    // until a Flow component arranges them.
+    align-items: flex-start;
+    justify-content: flex-start;
+  }
+}

--- a/apps/docs/src/app/_components/ComposingCodeExample/ComposingCodeExample.tsx
+++ b/apps/docs/src/app/_components/ComposingCodeExample/ComposingCodeExample.tsx
@@ -164,7 +164,7 @@ export const ComposingCodeExample: FC<Props> = (props) => {
           <LiveEditor
             tabMode="focus"
             theme={flowTheme}
-            className={codeStyles.editor}
+            className={clsx(codeStyles.editor, styles.codeEditor)}
             code={editorCode}
             onChange={handleEditorChange}
           />

--- a/apps/docs/src/app/_components/ComposingCodeExample/ComposingCodeExample.tsx
+++ b/apps/docs/src/app/_components/ComposingCodeExample/ComposingCodeExample.tsx
@@ -158,7 +158,9 @@ export const ComposingCodeExample: FC<Props> = (props) => {
       >
         <LivePreview className={clsx(codeStyles.preview, styles.preview)} />
 
-        <div className={codeStyles.editorContainer}>
+        <div
+          className={clsx(codeStyles.editorContainer, styles.editorContainer)}
+        >
           <LiveEditor
             tabMode="focus"
             theme={flowTheme}

--- a/apps/docs/src/app/_components/ComposingCodeExample/ComposingCodeExample.tsx
+++ b/apps/docs/src/app/_components/ComposingCodeExample/ComposingCodeExample.tsx
@@ -1,0 +1,175 @@
+"use client";
+import {
+  LiveEditor,
+  LivePreview,
+  LiveProvider,
+} from "@mfalkenberg/react-live-ssr";
+import clsx from "clsx";
+import type { FC } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import codeStyles from "@/lib/liveCode/components/LiveCodeEditor/LiveCodeEditor.module.css";
+import extractDefaultExport from "@/lib/liveCode/components/LiveCodeEditor/lib/extractDefaultExport";
+import { extractEditorScope } from "@/lib/liveCode/components/LiveCodeEditor/lib/extractEditorScope";
+import { flowTheme } from "@/lib/liveCode/components/LiveCodeEditor/lib/flowTheme";
+import { buildAnimation } from "./buildFrames";
+import { composingCodeExamples, exampleImports } from "./steps";
+import styles from "./ComposingCodeExample.module.scss";
+
+const { frames, restingIndex } = buildAnimation(composingCodeExamples);
+const lastFrameIndex = frames.length - 1;
+
+/** The frame the given one runs into when the animation is cut short. */
+const endOfExample = (index: number) => {
+  for (let candidate = index; candidate <= lastFrameIndex; candidate++) {
+    if (frames[candidate]?.isExampleEnd) {
+      return candidate;
+    }
+  }
+  return lastFrameIndex;
+};
+
+// Stable identities: `LiveProvider` re-transpiles whenever `scope` or
+// `transformCode` change identity, which would loop endlessly on re-render.
+const transformCode = (code: string) => {
+  try {
+    return extractDefaultExport(code);
+  } catch (error) {
+    return `<p><em>Example could not be parsed:</em> ${String(error)}</p>`;
+  }
+};
+
+const reducedMotionQuery = "(prefers-reduced-motion: reduce)";
+
+interface Props {
+  className?: string;
+}
+
+/**
+ * The homepage example that assembles itself, cycling through the examples in
+ * `steps.ts`: loose components, rendered one below the other in the order they
+ * are written, are nested step by step until Flow arranges them on its own.
+ *
+ * The first example, finished, is what renders on the server and for anyone who
+ * prefers reduced motion. Otherwise the build-up rewinds after hydration and
+ * runs whenever the tile is on screen. Interacting with the editor completes
+ * the current example and ends the loop, so the example stays freely editable.
+ */
+export const ComposingCodeExample: FC<Props> = (props) => {
+  const { className } = props;
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const hasInteracted = useRef(false);
+  const [frameIndex, setFrameIndex] = useState(restingIndex);
+  const [isArmed, setIsArmed] = useState(false);
+  const [isOnScreen, setIsOnScreen] = useState(false);
+  const [editedCode, setEditedCode] = useState<string>();
+
+  const frame = frames[frameIndex] ?? frames[restingIndex];
+  const editorCode = frame?.editorCode ?? "";
+  const previewCode = editedCode ?? frame?.previewCode ?? "";
+  const frameDelay = frame?.delay ?? 0;
+
+  const scope = useMemo(() => extractEditorScope(exampleImports), []);
+
+  const stop = useCallback(() => {
+    setIsArmed(false);
+    setFrameIndex(endOfExample);
+  }, []);
+
+  const skipToEnd = useCallback(() => {
+    hasInteracted.current = true;
+    stop();
+  }, [stop]);
+
+  // Rewind to the first step only after hydration, so a finished example is
+  // what gets server rendered. Reduced motion keeps it that way — including
+  // when the setting is flipped while the page is open.
+  useEffect(() => {
+    const query = window.matchMedia(reducedMotionQuery);
+
+    const sync = () => {
+      if (query.matches) {
+        stop();
+      } else if (!hasInteracted.current) {
+        setFrameIndex(0);
+        setIsArmed(true);
+      }
+    };
+
+    sync();
+    query.addEventListener("change", sync);
+
+    return () => query.removeEventListener("change", sync);
+  }, [stop]);
+
+  // Nothing animates off screen — the build-up pauses and picks up again when
+  // the tile scrolls back in.
+  useEffect(() => {
+    const container = containerRef.current;
+
+    if (!container) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => setIsOnScreen(entry?.isIntersecting ?? false),
+      { threshold: 0.25 },
+    );
+
+    observer.observe(container);
+
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (!isArmed || !isOnScreen) {
+      return;
+    }
+
+    const timeout = setTimeout(
+      () => setFrameIndex((index) => (index >= lastFrameIndex ? 0 : index + 1)),
+      frameDelay,
+    );
+
+    return () => clearTimeout(timeout);
+  }, [isArmed, isOnScreen, frameIndex, frameDelay]);
+
+  const handleEditorChange = (code: string) => {
+    // The editor also reports back the code we typed into it ourselves.
+    if (code === editorCode) {
+      return;
+    }
+    hasInteracted.current = true;
+    setIsArmed(false);
+    setEditedCode(code);
+  };
+
+  return (
+    <LiveProvider
+      transformCode={transformCode}
+      code={previewCode}
+      scope={scope}
+    >
+      <div
+        ref={containerRef}
+        className={clsx(codeStyles.liveCodeEditor, styles.example, className)}
+        onPointerDown={skipToEnd}
+        onFocus={skipToEnd}
+      >
+        <LivePreview className={clsx(codeStyles.preview, styles.preview)} />
+
+        <div className={codeStyles.editorContainer}>
+          <LiveEditor
+            tabMode="focus"
+            theme={flowTheme}
+            className={codeStyles.editor}
+            code={editorCode}
+            onChange={handleEditorChange}
+          />
+        </div>
+      </div>
+    </LiveProvider>
+  );
+};
+
+export default ComposingCodeExample;

--- a/apps/docs/src/app/_components/ComposingCodeExample/buildFrames.ts
+++ b/apps/docs/src/app/_components/ComposingCodeExample/buildFrames.ts
@@ -1,0 +1,134 @@
+export interface AnimationFrame {
+  /** Code shown in the editor — the last line may still be half typed. */
+  editorCode: string;
+  /** Last code that was complete and parseable; what the preview renders. */
+  previewCode: string;
+  /** How long this frame stays on screen. */
+  delay: number;
+  /** Whether this frame completes an example. */
+  isExampleEnd: boolean;
+}
+
+export interface Animation {
+  frames: AnimationFrame[];
+  /** The frame to rest on when nothing animates: the first example, finished. */
+  restingIndex: number;
+}
+
+/** Delay between two typed characters. */
+const typeDelay = 16;
+/** Pause after a finished line. */
+const linePause = 240;
+/** Pause after a finished composition step, so the preview can be read. */
+const stepPause = 1400;
+/** Pause on a finished example before the next one starts. */
+const examplePause = 5_000;
+
+const isDefined = (value: string | undefined): value is string =>
+  value !== undefined;
+
+const countLines = (code: string) => code.split("\n").length;
+
+/**
+ * Expands the composition steps of every example into the frames of the
+ * build-up animation, played back as one loop.
+ *
+ * Per step transition every line carried over from the previous step snaps into
+ * its new place at once — only new lines are typed out, character by character,
+ * in source order. The preview lags behind by design: it keeps rendering the
+ * previous (complete) step until the current one is fully typed, so it never
+ * has to render half-written JSX.
+ *
+ * Every frame is padded with blank lines to the length of the longest step of
+ * any example, so the editor keeps one height for the whole loop and neither
+ * the tile nor the page below it ever jumps.
+ */
+export const buildAnimation = (examples: string[][]): Animation => {
+  const steps = examples.flat();
+  const maxLines = Math.max(1, ...steps.map(countLines));
+  const padToMaxLines = (code: string) =>
+    code + "\n".repeat(Math.max(0, maxLines - countLines(code)));
+
+  const frames: AnimationFrame[] = [];
+
+  for (const example of examples) {
+    const [firstStep, ...nextSteps] = example;
+
+    if (firstStep === undefined) {
+      continue;
+    }
+
+    let previewCode = firstStep;
+    let previousStep = firstStep;
+
+    frames.push({
+      editorCode: padToMaxLines(firstStep),
+      previewCode,
+      delay: stepPause,
+      isExampleEnd: false,
+    });
+
+    for (const step of nextSteps) {
+      const carriedLines = new Set(
+        previousStep
+          .split("\n")
+          .map((line) => line.trim())
+          .filter(Boolean),
+      );
+
+      const lines = step.split("\n");
+      const visibleLines = lines.map((line) =>
+        carriedLines.has(line.trim()) ? line : undefined,
+      );
+
+      const pushFrame = (delay: number) =>
+        frames.push({
+          editorCode: padToMaxLines(visibleLines.filter(isDefined).join("\n")),
+          previewCode,
+          delay,
+          isExampleEnd: false,
+        });
+
+      pushFrame(linePause);
+
+      lines.forEach((line, index) => {
+        if (visibleLines[index] !== undefined) {
+          return;
+        }
+
+        // Indentation appears at once — typing invisible spaces looks stalled,
+        // and a frame showing nothing but an empty line reads as a glitch.
+        const indentation = line.length - line.trimStart().length;
+        const start = line.length === 0 ? 0 : Math.max(indentation, 1);
+
+        for (let length = start; length <= line.length; length++) {
+          visibleLines[index] = line.slice(0, length);
+          pushFrame(length === line.length ? linePause : typeDelay);
+        }
+      });
+
+      previewCode = step;
+      previousStep = step;
+
+      const stepEnd = frames.at(-1);
+      if (stepEnd) {
+        stepEnd.previewCode = previewCode;
+        stepEnd.delay = stepPause;
+      }
+    }
+
+    const exampleEnd = frames.at(-1);
+    if (exampleEnd) {
+      exampleEnd.delay = examplePause;
+      exampleEnd.isExampleEnd = true;
+    }
+  }
+
+  return {
+    frames,
+    restingIndex: Math.max(
+      0,
+      frames.findIndex((frame) => frame.isExampleEnd),
+    ),
+  };
+};

--- a/apps/docs/src/app/_components/ComposingCodeExample/index.ts
+++ b/apps/docs/src/app/_components/ComposingCodeExample/index.ts
@@ -1,0 +1,1 @@
+export { ComposingCodeExample } from "./ComposingCodeExample";

--- a/apps/docs/src/app/_components/ComposingCodeExample/steps.ts
+++ b/apps/docs/src/app/_components/ComposingCodeExample/steps.ts
@@ -1,0 +1,148 @@
+/**
+ * The examples the homepage tile cycles through. Each one runs the same story:
+ * loose components — rendered one below the other, in the order they are
+ * written — get nested step by step until Flow arranges them on its own.
+ *
+ * Every step must be a valid, self-contained example: it is what the preview
+ * renders while the next step is being typed. Multi-root steps need the
+ * fragment, and it doubles as the placeholder the wrapper later replaces.
+ *
+ * Lines that already exist in the previous step (compared without indentation)
+ * are carried over instantly — only genuinely new lines are typed out. Keep
+ * lines textually identical across steps so they are recognized.
+ */
+
+const indent = (lines: string) =>
+  lines
+    .split("\n")
+    .map((line) => `  ${line}`)
+    .join("\n");
+
+const lines = (...parts: string[]) => parts.join("\n");
+
+// A section header lifts the button up next to the heading; `LabeledValue` ties
+// the label to its value.
+const profileHeading = `  <Heading>Profil</Heading>`;
+const profileButton = lines(
+  `  <Button color="secondary" variant="soft">`,
+  `    Bearbeiten`,
+  `  </Button>`,
+);
+const profileLabel = `  <Label>E-Mail-Adresse</Label>`;
+const profileValue = `  <Content>max@mustermann.de</Content>`;
+
+const profileExample = [
+  lines("<>", profileHeading, profileButton, "</>"),
+
+  lines("<>", profileHeading, profileButton, profileLabel, profileValue, "</>"),
+
+  lines(
+    "<>",
+    profileHeading,
+    profileButton,
+    "  <LabeledValue>",
+    indent(profileLabel),
+    indent(profileValue),
+    "  </LabeledValue>",
+    "</>",
+  ),
+
+  lines(
+    "<Section>",
+    "  <Header>",
+    indent(profileHeading),
+    indent(profileButton),
+    "  </Header>",
+    "  <LabeledValue>",
+    indent(profileLabel),
+    indent(profileValue),
+    "  </LabeledValue>",
+    "</Section>",
+  ),
+];
+
+// `Combine` puts avatar and text side by side, aligned and spaced.
+const initials = "<Initials>Max Mustermann</Initials>";
+const avatar = lines("<Avatar>", indent(initials), "</Avatar>");
+const person = lines(
+  "<Text>",
+  "  <strong>Max Mustermann</strong>",
+  "  Organisationsinhaber",
+  "</Text>",
+);
+
+const combineExample = [
+  initials,
+
+  avatar,
+
+  lines("<>", indent(avatar), indent(person), "</>"),
+
+  lines("<Combine>", indent(avatar), indent(person), "</Combine>"),
+];
+
+// `IllustratedMessage` centers the group, sizes the icon and spaces the parts.
+const emptyStateIcon = `  <IconApp />`;
+const emptyStateHeading = `  <Heading>Keine Apps installiert</Heading>`;
+const emptyStateText = lines(
+  "  <Text>",
+  "    Lege deine erste App an, um mit der Arbeit an deiner",
+  "    Webseite loszulegen.",
+  "  </Text>",
+);
+const emptyStateButton = `  <Button>App anlegen</Button>`;
+
+const emptyStateExample = [
+  emptyStateIcon.trim(),
+
+  lines("<>", emptyStateIcon, emptyStateHeading, "</>"),
+
+  lines("<>", emptyStateIcon, emptyStateHeading, emptyStateText, "</>"),
+
+  lines(
+    "<>",
+    emptyStateIcon,
+    emptyStateHeading,
+    emptyStateText,
+    emptyStateButton,
+    "</>",
+  ),
+
+  lines(
+    "<IllustratedMessage>",
+    emptyStateIcon,
+    emptyStateHeading,
+    emptyStateText,
+    emptyStateButton,
+    "</IllustratedMessage>",
+  ),
+];
+
+export const composingCodeExamples: string[][] = [
+  profileExample,
+  combineExample,
+  emptyStateExample,
+];
+
+/**
+ * The examples themselves show only the JSX — the tile is about composition,
+ * and an import block for a dozen components would more than double its height.
+ * The editor scope is built from this instead.
+ */
+export const exampleImports = lines(
+  "import {",
+  "  Avatar,",
+  "  Button,",
+  "  Combine,",
+  "  Content,",
+  "  Header,",
+  "  Heading,",
+  "  IconApp,",
+  "  IllustratedMessage,",
+  "  Initials,",
+  "  Label,",
+  "  LabeledValue,",
+  "  Section,",
+  "  Text,",
+  `} from "@mittwald/flow-react-components";`,
+);

--- a/apps/docs/src/app/_components/ComposingCodeExample/steps.ts
+++ b/apps/docs/src/app/_components/ComposingCodeExample/steps.ts
@@ -32,6 +32,8 @@ const profileLabel = `  <Label>E-Mail-Adresse</Label>`;
 const profileValue = `  <Content>max@mustermann.de</Content>`;
 
 const profileExample = [
+  profileHeading.trim(),
+
   lines("<>", profileHeading, profileButton, "</>"),
 
   lines("<>", profileHeading, profileButton, profileLabel, profileValue, "</>"),

--- a/apps/docs/src/app/page.module.scss
+++ b/apps/docs/src/app/page.module.scss
@@ -44,6 +44,11 @@
 .codeTile {
   :global(.flow--column-layout) {
     align-items: center;
+
+    // The copy starts at the top of the tile, not centered next to the example.
+    :global(.flow--section) {
+      align-self: start;
+    }
   }
 }
 
@@ -85,6 +90,11 @@
 
   :global(.flow--column-layout) {
     align-items: center;
+
+    // The copy starts at the top of the tile, not centered next to the image.
+    :global(.flow--section) {
+      align-self: start;
+    }
   }
 }
 

--- a/apps/docs/src/app/page.module.scss
+++ b/apps/docs/src/app/page.module.scss
@@ -41,17 +41,6 @@
   );
 }
 
-.codeTile {
-  :global(.flow--column-layout) {
-    align-items: center;
-
-    // The copy starts at the top of the tile, not centered next to the example.
-    :global(.flow--section) {
-      align-self: start;
-    }
-  }
-}
-
 .imageTile {
   position: relative;
 

--- a/apps/docs/src/app/page.tsx
+++ b/apps/docs/src/app/page.tsx
@@ -19,36 +19,10 @@ import { FlowLogo } from "@/app/_components/layout/Header/FlowLogo";
 import darkmodeBg from "../../public/assets/darkmode-bg.png";
 import developerTile from "../../public/assets/developer-tile.png";
 import extensionsTile from "../../public/assets/extensions-tile.webp";
-import clsx from "clsx";
-import codeStyles from "@/lib/liveCode/components/LiveCodeEditor/LiveCodeEditor.module.css";
-import {
-  LiveEditor,
-  LivePreview,
-  LiveProvider,
-} from "@mfalkenberg/react-live-ssr";
-import { flowTheme } from "@/lib/liveCode/components/LiveCodeEditor/lib/flowTheme";
-import extractDefaultExport from "@/lib/liveCode/components/LiveCodeEditor/lib/extractDefaultExport";
-import { extractEditorScope } from "@/lib/liveCode/components/LiveCodeEditor/lib/extractEditorScope";
+import { ComposingCodeExample } from "@/app/_components/ComposingCodeExample";
 import styles from "./page.module.scss";
 
 const Home: FC = () => {
-  const transformCode = (code: string) => {
-    try {
-      return extractDefaultExport(code);
-    } catch (error) {
-      return `<p><em>Example could not be parsed:</em> ${String(error)}</p>`;
-    }
-  };
-
-  const code =
-    'import { Button } from "@mittwald/flow-react-components";\n' +
-    "\n" +
-    '<Button color="primary"> \n' +
-    "  Button\n" +
-    "</Button>";
-
-  const scope = extractEditorScope(code);
-
   return (
     <Flex direction="column" className={styles.wrapper} align="center">
       <Flex
@@ -116,19 +90,7 @@ const Home: FC = () => {
               Zu den Components
             </Link>
           </Section>
-          <LiveProvider transformCode={transformCode} code={code} scope={scope}>
-            <div className={clsx(codeStyles.liveCodeEditor)}>
-              <LivePreview className={clsx(codeStyles.preview)} />
-
-              <div className={codeStyles.editorContainer}>
-                <LiveEditor
-                  tabMode="focus"
-                  theme={flowTheme}
-                  className={codeStyles.editor}
-                />
-              </div>
-            </div>
-          </LiveProvider>
+          <ComposingCodeExample />
         </ColumnLayout>
       </LayoutCard>
 

--- a/apps/docs/src/app/page.tsx
+++ b/apps/docs/src/app/page.tsx
@@ -72,8 +72,8 @@ const Home: FC = () => {
         </LayoutCard>
       </ColumnLayout>
 
-      <LayoutCard className={styles.codeTile}>
-        <ColumnLayout l={[1, 1]} s={[1]} m={[1]} gap="xl">
+      <LayoutCard>
+        <ColumnLayout l={[1]} m={[1]} s={[1]} gap="xl">
           <Section>
             <Heading>Fokus auf Developer Experience</Heading>
             <Text>


### PR DESCRIPTION
Closes #2824. Alternative to #2829 — same problem, a different story.

The "Fokus auf Developer Experience" tile claimed nested components, automatic spacing and design system conformance while showing a single plain `Button`. None of the three was visible.

## The story

The example does not grow out of a wrapper — it starts **without one**: the components as siblings in a fragment, rendered one below the other in the order they are written. That is the honest "before" picture. The nesting step is then the moment the automation becomes visible, not a claim the reader has to take on faith.

Three examples run in sequence, each with the same beat — loose, then nested — and each finished example holds 5s before the next starts:

1. **Profile section** — `<Heading>` + `<Button>` + `<Label>` + `<Content>`, stacked → `<LabeledValue>` ties the label to its value → `<Section>` + `<Header>` lift the button up next to the heading and shrink it to the header size.
2. **Combine** — `<Initials>` on its own → wrapped in `<Avatar>` → next to a `<Text>` → `<Combine>` puts them side by side, aligned and spaced.
3. **Empty state** — `<IconApp />` → + `<Heading>` → + `<Text>` → + `<Button>`, all stacked → `<IllustratedMessage>` centers the group and sizes the icon.

The tile links to `action-group`; the profile example is the section pattern that link leads into.

The examples show only their JSX. Spelled out, the import block for these thirteen components would be taller than the examples themselves. The editor scope comes from a real import statement in `steps.ts`, just one the reader never sees.

## How it behaves

- **Runs while the tile is on screen.** The tile sits below the fold, so an IntersectionObserver (25 %) starts it; scrolling away pauses it, scrolling back picks it up.
- **Nothing moves.** Every frame is padded with blank lines to the line count of the longest step of any example, so the code block has its final height from the first frame — no measuring on mount. The preview reserves the height of the tallest example. Sampled every 200 ms across a full cycle: preview 288 px, code block 285 px, tile 625 px, constant throughout.
- **The preview never sees half-typed code.** Editor and preview run on two strings: `<LiveEditor code>` gets the half-typed frame, `<LiveProvider code>` keeps the last completed step. A parse error from a real edit still surfaces — unlike a `transformCode` that falls back to the last parsable result.
- **`prefers-reduced-motion`:** the first example, finished, and nothing else. Subscribed to the media query, so flipping the setting on an open page stops the loop too.
- **Stays a live example.** Clicking or focusing the editor completes the current example and ends the loop; editing works as before.
- **Narrow viewports.** The code block never wraps a line, so it scrolls horizontally inside the tile rather than pushing it open — `min-width: 0` on the grid and flex item is what lets it. No horizontal page scrolling at 375 px.
- **The shared preview no longer centers.** `LiveCodeEditor.module.css` centers whatever an example renders — here that would fake the result, since the point is that loose components stack in source order. Overridden for this tile only, so no other docs example changes.

## Implementation

`page.tsx` renders `<ComposingCodeExample />` instead of building the `LiveProvider` inline, which keeps the animation's re-renders out of the page component.

- `steps.ts` — the three examples as their composition steps, plus the import statement the scope is derived from.
- `buildFrames.ts` — expands the steps into the frames of one loop. Per transition, every line that already exists in the previous step (compared without indentation) snaps into place at once; only new lines are typed out, character by character, in source order. So a step may change any line, not just insert one block at one position.
- `ComposingCodeExample.tsx` — playback, visibility, reduced motion, interaction.

Also in here: the copy in the "Developer Experience", "Developer Portal" and "Extensions" tiles now starts at the top of its tile instead of sitting vertically centered next to a much taller neighbour.

## Verified

`tsc --noEmit`, `eslint`, `stylelint` and `prettier --check` pass. Behaviour checked in the browser against `pnpm nx dev docs`, sampled across full cycles: all three examples run through every step, no parse error at any frame, heights constant, and the loop wraps back to the first example. Same at 375 px: no horizontal page scrolling, the code block scrolls inside the tile.

Known: at 375 px the empty state's preview is 331 px against the 288 px reserve, so the tile grows by ~43 px on that one example. The reserve is a fixed `min-height`, and how far `IllustratedMessage`'s text wraps depends on the width. Fixable with a breakpoint bump or by shortening the empty-state copy — say if it should go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
