### PR TITLE
ci: skip the release for docs- and CI-only merges

### DIFF
--- a/.github/scripts/release-relevance-guard.mjs
+++ b/.github/scripts/release-relevance-guard.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+// @ts-check
+/**
+ * Release-relevance guard — IO shell around release-relevance-lib.mjs.
+ *
+ * Reads the changed-file list on stdin (one repository-relative path per line)
+ * and writes `publish=true|false` to $GITHUB_OUTPUT.
+ *
+ * It never fails the run. The decision is a routing choice, not a policy
+ * violation: an empty or unreadable input yields `publish=true`, which is the
+ * behaviour before #2931.
+ */
+import { appendFileSync, readFileSync } from "node:fs";
+import { classifyChangedFiles } from "./release-relevance-lib.mjs";
+
+/** Read all of stdin; an unreadable stdin is an empty list (fail-safe). */
+function readStdin() {
+  try {
+    return readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+const files = readStdin()
+  .split("\n")
+  .map((line) => line.trim())
+  .filter((line) => line !== "");
+
+const { publish, reason, relevant, total } = classifyChangedFiles(files);
+
+// Cap the log: a large merge lists hundreds of files and the first few already
+// explain the decision.
+const SAMPLE = 20;
+
+if (publish) {
+  // `relevant` is empty on the fail-safe paths (unreadable file list), where
+  // "publishable change" would overstate what we actually know.
+  const headline = relevant.length > 0 ? "Publishable change" : "Publishing";
+  console.log(`::notice::${headline} — ${reason}.`);
+  if (relevant.length > 0) {
+    console.log(`Files that reach a published package (${relevant.length}):`);
+    for (const path of relevant.slice(0, SAMPLE)) console.log(`  ${path}`);
+    if (relevant.length > SAMPLE) {
+      console.log(`  … and ${relevant.length - SAMPLE} more`);
+    }
+  }
+} else {
+  console.log(
+    `::notice::No publishable change — ${reason}. ` +
+      "This push produces no npm publish, no version bump commit, no tag and " +
+      "no GitHub Release. Dispatch this workflow manually to publish anyway.",
+  );
+  console.log(`Changed files (${total}):`);
+  for (const path of files.slice(0, SAMPLE)) console.log(`  ${path}`);
+  if (files.length > SAMPLE) {
+    console.log(`  … and ${files.length - SAMPLE} more`);
+  }
+}
+
+const out = process.env.GITHUB_OUTPUT;
+const line = `publish=${publish}\n`;
+if (out) appendFileSync(out, line);
+else process.stdout.write(line);

--- a/.github/scripts/release-relevance-lib.mjs
+++ b/.github/scripts/release-relevance-lib.mjs
@@ -1,0 +1,155 @@
+// @ts-check
+/**
+ * Release-relevance classification — pure functions, no git / no IO.
+ *
+ * Answers one question: can this set of changed files reach a PUBLISHED
+ * package's tarball? Docs- and CI-only merges cannot, and must not produce a
+ * release — no npm publish, no `chore(release):` bump, no tag, no GitHub
+ * Release (#2931).
+ *
+ * The rule is a DENYLIST, and that direction is deliberate. Every published
+ * package ships `dist` (plus `*.md` for flow-react-components), so "what ends
+ * up in a tarball" spans nearly all of `packages/**` — source, locales, SCSS,
+ * tsconfigs, vite configs, generated code. An ALLOWLIST that forgets one of
+ * those paths silently swallows a real release. A DENYLIST that forgets a new
+ * docs directory merely publishes one needless version — exactly what happens
+ * today. So unknown paths are RELEVANT, and only paths that provably cannot
+ * reach a tarball are listed below.
+ */
+
+/**
+ * Directory prefixes whose contents never reach a published tarball.
+ *
+ * - `.github/` — workflows, scripts, templates.
+ * - `apps/` — docs site and remote-dom demo. Both are private and never
+ *   published; no published package depends on them.
+ * - `docs/` — repository docs and ADRs.
+ * - `dev/` — preview-deployment tooling, run only by CI workflows.
+ * - `.idea/`, `.vscode/`, `.claude/` — editor and agent configuration.
+ */
+const IRRELEVANT_PREFIXES = [
+  ".github/",
+  "apps/",
+  "docs/",
+  "dev/",
+  ".idea/",
+  ".vscode/",
+  ".claude/",
+];
+
+/**
+ * Root-level files that never reach a published tarball.
+ *
+ * Deliberately NOT here: `package.json`, `pnpm-lock.yaml`,
+ * `pnpm-workspace.yaml`, `nx.json`, `lerna.json`, `eslint.config.js`,
+ * `stylelint.config.mjs` and `patches/**` — a dependency, resolution or build
+ * wiring change can move the built output, so those stay relevant.
+ */
+const IRRELEVANT_ROOT_FILES = new Set([
+  "LICENSE",
+  ".dockerignore",
+  ".gitattributes",
+  ".gitignore",
+  ".prettierignore",
+  ".prettierrc.json",
+  ".stylelintignore",
+]);
+
+/**
+ * Can a change to `path` reach a published package's tarball?
+ *
+ * Note that `packages/**` is relevant WHOLESALE, Markdown included:
+ * `@mittwald/flow-react-components` ships `["*.md", "dist"]`, so a
+ * package-local `.md` really is part of the published artifact. Only Markdown
+ * OUTSIDE `packages/` (root `README.md`, `AGENTS.md`, `CHANGELOG.md`, …) is
+ * irrelevant.
+ *
+ * @param {string} path Repository-relative, forward-slash separated.
+ * @returns {boolean}
+ */
+export function isPublishRelevant(path) {
+  const p = path.trim();
+  if (p === "") return false;
+
+  if (IRRELEVANT_PREFIXES.some((prefix) => p.startsWith(prefix))) return false;
+
+  const isRootFile = !p.includes("/");
+  if (isRootFile && (IRRELEVANT_ROOT_FILES.has(p) || p.endsWith(".md"))) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Could `line` be a repository path the compare API produced?
+ *
+ * `gh api` prints the error BODY to stdout on a non-2xx response, so a failed
+ * call can hand us a JSON blob. Mistaking one for a filename would classify it
+ * silently — as publishable, or worse, as not.
+ *
+ * Only `{`, `}` and `"` are rejected: no tracked path contains them, while
+ * square brackets are legitimate (`apps/docs/src/app/[...slug]/page.tsx`).
+ *
+ * @param {string} line
+ * @returns {boolean}
+ */
+function looksLikePath(line) {
+  return !/["{}]/.test(line);
+}
+
+/**
+ * Decide whether a push publishes.
+ *
+ * Fails SAFE: an empty file list means we could not determine what changed
+ * (unreachable `before` sha, a force push, a compare response we could not
+ * read), and the answer is then "publish" — the behaviour before #2931.
+ *
+ * @param {string[]} paths Changed files, repository-relative.
+ * @returns {{
+ *   publish: boolean;
+ *   reason: string;
+ *   relevant: string[];
+ *   total: number;
+ * }}
+ */
+export function classifyChangedFiles(paths) {
+  const files = paths.map((p) => p.trim()).filter((p) => p !== "");
+
+  if (!files.every(looksLikePath)) {
+    return {
+      publish: true,
+      reason:
+        "the changed-file list is not a list of paths (fail-safe default)",
+      relevant: [],
+      total: files.length,
+    };
+  }
+
+  if (files.length === 0) {
+    return {
+      publish: true,
+      reason: "no changed files could be determined (fail-safe default)",
+      relevant: [],
+      total: 0,
+    };
+  }
+
+  const relevant = files.filter(isPublishRelevant);
+
+  if (relevant.length === 0) {
+    return {
+      publish: false,
+      reason: `all ${files.length} changed file(s) are docs/CI/tooling only — nothing reaches a published package`,
+      relevant,
+      total: files.length,
+    };
+  }
+
+  return {
+    publish: true,
+    reason: `${relevant.length} of ${files.length} changed file(s) affect published packages`,
+    relevant,
+    total: files.length,
+  };
+}

--- a/.github/scripts/release-relevance-lib.test.mjs
+++ b/.github/scripts/release-relevance-lib.test.mjs
@@ -1,0 +1,166 @@
+// @ts-check
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  isPublishRelevant,
+  classifyChangedFiles,
+} from "./release-relevance-lib.mjs";
+
+test("isPublishRelevant: docs, CI and tooling paths are irrelevant", () => {
+  for (const path of [
+    ".github/workflows/publish.yml",
+    ".github/scripts/release-relevance-lib.mjs",
+    ".github/ISSUE_TEMPLATE/bug_report.yml",
+    "apps/docs/src/content/04-components/button.mdx",
+    "apps/remote-dom-demo/src/App.tsx",
+    "docs/adr/0005-semver-contract.md",
+    "docs/remote-ui.md",
+    "dev/deploy-review.ts",
+    ".idea/vcs.xml",
+    ".vscode/settings.json",
+    ".claude/settings.json",
+    "README.md",
+    "AGENTS.md",
+    "CLAUDE.md",
+    "CHANGELOG.md",
+    "CONTRIBUTE.md",
+    "LICENSE",
+    ".prettierrc.json",
+    ".prettierignore",
+    ".stylelintignore",
+    ".gitattributes",
+    ".gitignore",
+    ".dockerignore",
+  ]) {
+    assert.equal(isPublishRelevant(path), false, path);
+  }
+});
+
+test("isPublishRelevant: anything reaching a tarball is relevant", () => {
+  for (const path of [
+    "packages/components/src/components/Button/Button.tsx",
+    "packages/components/src/components/Button/Button.module.scss",
+    "packages/components/src/components/Button/locales/de-DE.locale.json",
+    "packages/design-tokens/src/color.yaml",
+    "packages/remote-core/src/index.ts",
+    "packages/components/package.json",
+    "packages/components/project.json",
+    "packages/components/vite.config.ts",
+  ]) {
+    assert.equal(isPublishRelevant(path), true, path);
+  }
+});
+
+test("isPublishRelevant: Markdown INSIDE packages is relevant", () => {
+  // @mittwald/flow-react-components ships `["*.md", "dist"]` — a package-local
+  // Markdown file really is part of the published artifact.
+  assert.equal(isPublishRelevant("packages/components/README.md"), true);
+  assert.equal(isPublishRelevant("packages/components/AGENTS.md"), true);
+  assert.equal(isPublishRelevant("packages/components/MIGRATION.md"), true);
+});
+
+test("isPublishRelevant: build wiring and dependencies stay relevant", () => {
+  for (const path of [
+    "package.json",
+    "pnpm-lock.yaml",
+    "pnpm-workspace.yaml",
+    "nx.json",
+    "lerna.json",
+    "eslint.config.js",
+    "stylelint.config.mjs",
+    "patches/@sigstore__sign@4.1.1.patch",
+  ]) {
+    assert.equal(isPublishRelevant(path), true, path);
+  }
+});
+
+test("isPublishRelevant: unknown paths are relevant (fail-safe denylist)", () => {
+  assert.equal(isPublishRelevant("packages/brand-new/src/index.ts"), true);
+  assert.equal(isPublishRelevant("new-top-level-dir/thing.ts"), true);
+  assert.equal(isPublishRelevant("some-new-root-file.ts"), true);
+});
+
+test("classifyChangedFiles: an undeterminable file list publishes", () => {
+  assert.equal(classifyChangedFiles([]).publish, true);
+  assert.equal(classifyChangedFiles(["", "  "]).publish, true);
+});
+
+test("classifyChangedFiles: docs-only and CI-only pushes do not publish", () => {
+  // #2870 "docs: fix heading spacing" → 0.2.0-alpha.1044
+  assert.equal(
+    classifyChangedFiles([
+      "apps/docs/src/content/01-foundations/typography.mdx",
+      "apps/docs/src/app/globals.css",
+    ]).publish,
+    false,
+  );
+  // #2906 "chore(ci): purge CODEOWNERS def" → 0.2.0-alpha.1055
+  assert.equal(
+    classifyChangedFiles([".github/CODEOWNERS", ".github/workflows/test.yml"])
+      .publish,
+    false,
+  );
+  // #2873 "chore(docs): correct lint git hook to pre-push" → 0.2.0-alpha.1049
+  assert.equal(classifyChangedFiles(["AGENTS.md"]).publish, false);
+});
+
+test("classifyChangedFiles: a mixed push publishes", () => {
+  const result = classifyChangedFiles([
+    "apps/docs/src/content/04-components/button.mdx",
+    ".github/workflows/test.yml",
+    "packages/components/src/components/Button/Button.tsx",
+  ]);
+  assert.equal(result.publish, true);
+  assert.deepEqual(result.relevant, [
+    "packages/components/src/components/Button/Button.tsx",
+  ]);
+  assert.equal(result.total, 3);
+});
+
+test("classifyChangedFiles: a promotion merge publishes", () => {
+  // A release/x.y.0 -> main promotion carries the version bump and changelogs.
+  // `packages/*/package.json` is relevant, so the graduation always publishes.
+  assert.equal(
+    classifyChangedFiles([
+      "lerna.json",
+      "CHANGELOG.md",
+      "packages/components/package.json",
+      "packages/components/CHANGELOG.md",
+    ]).publish,
+    true,
+  );
+});
+
+test("classifyChangedFiles: the reason names the counts", () => {
+  assert.match(
+    classifyChangedFiles(["apps/docs/a.mdx", "docs/b.md"]).reason,
+    /all 2 changed file\(s\) are docs\/CI\/tooling only/,
+  );
+  assert.match(
+    classifyChangedFiles(["apps/docs/a.mdx", "packages/components/src/a.ts"])
+      .reason,
+    /1 of 2 changed file\(s\) affect published packages/,
+  );
+});
+
+test("classifyChangedFiles: a non-path input publishes instead of being classified", () => {
+  // `gh api` prints the error body to stdout on a non-2xx; it must never be
+  // mistaken for a filename.
+  const result = classifyChangedFiles([
+    '{"message":"Not Found","status":"404"}',
+  ]);
+  assert.equal(result.publish, true);
+  assert.match(result.reason, /not a list of paths/);
+  assert.deepEqual(result.relevant, []);
+});
+
+test("classifyChangedFiles: square brackets are legitimate path characters", () => {
+  // Next.js dynamic routes in the docs app — docs-only, must still skip.
+  assert.equal(
+    classifyChangedFiles([
+      "apps/docs/src/app/04-components/[group]/[component]/develop/page.tsx",
+      "apps/docs/src/app/01-get-started/[...slug]/page.tsx",
+    ]).publish,
+    false,
+  );
+});

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -36,6 +36,72 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Same release-relevance gate as publish.yml (#2931): a change that cannot
+  # reach a published package produces no `next` prerelease — no npm publish, no
+  # `chore(release):` version bump commit, no tag, no GitHub Release.
+  #
+  # On this line the push is usually the `chore(sync):` forward-merge commit, so
+  # the classified file set is what the merge carried over from `main`. A
+  # docs-only fix therefore skips here exactly as it skipped on `main`, and the
+  # two lines stay symmetric.
+  decide:
+    name: Release relevance
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      publish: ${{ steps.relevance.outputs.publish }}
+    steps:
+      - name: Checkout ⬇️
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: next
+
+      - name: Self-test the classifier
+        run: node --test .github/scripts/release-relevance-lib.test.mjs
+
+      - name: Classify the changed paths 🔎
+        id: relevance
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" != "push" ]; then
+            echo "::notice::Manual dispatch — publishing regardless of changed paths."
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # No usable base (branch creation, force push) means we cannot tell
+          # what changed. Publish — the behaviour before #2931.
+          if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            echo "::notice::No usable base sha — publishing (fail-safe default)."
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # The compare API, not `git diff`: it needs no history, so this job
+          # stays a shallow checkout.
+          #
+          # `gh api` prints the error BODY to stdout on a non-2xx and exits
+          # non-zero, so the EXIT STATUS decides whether the list is usable —
+          # never the output. Discarding it hands the guard an empty list, which
+          # is its fail-safe "publish" input.
+          if ! files="$(gh api --paginate \
+            "repos/${REPO}/compare/${BEFORE}...${AFTER}" \
+            --jq '.files[]?.filename')"; then
+            echo "::warning::Could not read the changed-file list from the compare API — publishing (fail-safe default)."
+            files=""
+          fi
+
+          printf '%s\n' "$files" \
+            | node .github/scripts/release-relevance-guard.mjs
+
   publish:
     # Publish on manual dispatch, or on any push to `next` EXCEPT the release
     # commit this workflow pushes itself (guarded below to avoid an infinite
@@ -45,9 +111,16 @@ jobs:
     # As in publish.yml, the trigger is `push: next`, NOT
     # `pull_request_target: closed`: npm's Trusted Publisher only accepts the
     # OIDC token when its ref is a branch ref (refs/heads/next).
+    #
+    # `needs.decide` adds the release-relevance gate (#2931): a docs- or CI-only
+    # push produces no prerelease at all.
+    needs: decide
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      !startsWith(github.event.head_commit.message, 'chore(release):')
+      needs.decide.outputs.publish == 'true' &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        !startsWith(github.event.head_commit.message, 'chore(release):')
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,75 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Does this push carry anything that can reach a PUBLISHED package? Docs- and
+  # CI-only merges cannot, and must not produce a release (#2931): the publish
+  # job below is skipped whole, so there is no npm publish, no
+  # `chore(release):` version bump commit, no tag and no GitHub Release.
+  #
+  # This is a separate job rather than a step inside `publish` on purpose. The
+  # run then shows `decide` green and `publish` skipped, with a notice naming the
+  # rule that fired. `paths-ignore` on the trigger would skip the run entirely
+  # and explain nothing — and its globs cannot express "Markdown inside
+  # packages/ still ships" (flow-react-components publishes `["*.md", "dist"]`).
+  #
+  # A manual dispatch always publishes: that is the escape hatch for releasing a
+  # docs-only change deliberately.
+  decide:
+    name: Release relevance
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      publish: ${{ steps.relevance.outputs.publish }}
+    steps:
+      - name: Checkout ⬇️
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Self-test the classifier
+        run: node --test .github/scripts/release-relevance-lib.test.mjs
+
+      - name: Classify the changed paths 🔎
+        id: relevance
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" != "push" ]; then
+            echo "::notice::Manual dispatch — publishing regardless of changed paths."
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # No usable base (branch creation, force push) means we cannot tell
+          # what changed. Publish — the behaviour before #2931.
+          if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            echo "::notice::No usable base sha — publishing (fail-safe default)."
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # The compare API, not `git diff`: it needs no history, so this job
+          # stays a shallow checkout.
+          #
+          # `gh api` prints the error BODY to stdout on a non-2xx and exits
+          # non-zero, so the EXIT STATUS decides whether the list is usable —
+          # never the output. Discarding it hands the guard an empty list, which
+          # is its fail-safe "publish" input.
+          if ! files="$(gh api --paginate \
+            "repos/${REPO}/compare/${BEFORE}...${AFTER}" \
+            --jq '.files[]?.filename')"; then
+            echo "::warning::Could not read the changed-file list from the compare API — publishing (fail-safe default)."
+            files=""
+          fi
+
+          printf '%s\n' "$files" \
+            | node .github/scripts/release-relevance-guard.mjs
+
   publish:
     # Publish on manual dispatch, or on any push to main EXCEPT the release
     # commit this workflow pushes itself (guarded below to avoid an infinite
@@ -42,11 +111,18 @@ jobs:
     # npm rejects — the publish then falls back to an anonymous request and npm
     # returns a misleading 404. A push to main carries refs/heads/main and
     # authenticates correctly.
+    #
+    # `needs.decide` adds the third gate (#2931): a docs- or CI-only push
+    # produces no release at all.
+    needs: decide
     if: >-
-      github.event_name == 'workflow_dispatch' ||
+      needs.decide.outputs.publish == 'true' &&
       (
-        vars.AUTO_PUBLISH_ENABLED == 'true' &&
-        !startsWith(github.event.head_commit.message, 'chore(release):')
+        github.event_name == 'workflow_dispatch' ||
+        (
+          vars.AUTO_PUBLISH_ENABLED == 'true' &&
+          !startsWith(github.event.head_commit.message, 'chore(release):')
+        )
       )
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,12 @@ jobs:
       - name: Lint & check formatting
         run: pnpm lint
 
+      # The CI guard scripts are plain node:test files outside the nx graph, so
+      # `pnpm affected:test` never sees them. Run them here so a broken
+      # classifier fails the PR rather than the next release.
+      - name: Test the CI guard scripts
+        run: node --test .github/scripts/*.test.mjs
+
       - name: Run unit tests
         run: pnpm affected:test
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,7 +153,11 @@ and commit the results.
 - **Conventional Commits** with component/package scope — `fix(Button): …`,
   `feat(components): …`. Releases and changelogs are generated from them.
 - Merged PRs trigger the publish workflow (lerna-lite, fixed versioning across
-  packages).
+  packages) — **unless the merge is docs-, CI- or tooling-only**, which
+  publishes nothing at all (no npm release, no version bump commit, no tag, no
+  GitHub Release). The rule lives in
+  `.github/scripts/release-relevance-lib.mjs`; see
+  [docs/release-workflow.md](docs/release-workflow.md).
 - **Maintain the nx wiring for scripts.** Every package script that nx
   orchestrates needs correct target metadata: `dependsOn` (ordering),
   `inputs`/`outputs` (caching, affected detection) in the package's

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -67,6 +67,22 @@ flowchart LR
   guard that Lerna-Lite 5's changelog config trips over (it recompiles the
   preset's template itself), and the guard then aborts `lerna version`. Re-check
   on the next Lerna-Lite major.
+- **Not every merge releases.** A push to a release line only publishes when it
+  carries a change that can reach a **published package**. Docs-, CI- and
+  repo-tooling-only merges (`apps/**`, `docs/**`, `.github/**`, `dev/**`, root
+  Markdown and editor config) are skipped whole: no npm publish, no
+  `chore(release):` version bump commit, no tag, no GitHub Release (#2931). The
+  decision is made by the `decide` job in `publish.yml` / `publish-next.yml`,
+  which classifies the pushed file set with
+  `.github/scripts/release-relevance-lib.mjs`. Two properties matter when you
+  touch that list:
+  - It is a **denylist** — anything not provably docs/CI/tooling counts as
+    publishable. Forgetting a docs path costs one needless version; forgetting a
+    source path would silently swallow a real release. So `packages/**` is
+    relevant wholesale, Markdown included: `@mittwald/flow-react-components`
+    ships `["*.md", "dist"]`.
+  - A **`workflow_dispatch` run always publishes.** That is the escape hatch
+    when a docs-only change has to go out as a release anyway.
 - **Forward-merge cascade.** Every push to `main` is automatically merged up
   into `next` (and `next` into the major line when it exists), so the higher
   lines are always a superset of the lower ones — no cherry-picking. Merge


### PR DESCRIPTION
## What & why

Closes #2931.

Every push to a release line published all 12 packages, whether or not anything publishable changed. Over the last **200** non-release commits on `main`, **76 (38 %)** touched only `apps/**`, `docs/**`, `.github/**` or root tooling — each produced a `chore(release):` bump, a tag, a GitHub Release and 12 npm versions that ship no code. After the 1.0.0 cut the same path would publish a stable `1.0.x` under `latest` for a docs typo.

Two causes, both deliberate on their own: `publish.yml` had no path filter, and `lerna version --force-publish` bypasses lerna's changed-package detection (fixed versioning — #2887 traced the exact-peer-pin breakage to packages being skipped). So conventional-commits' "`docs`/`ci`/`chore` does not bump" rule never got a chance to apply.

A `decide` job now classifies the pushed file set and gates the publish job through `needs`. **A skipped push produces no npm publish, no version bump commit, no tag and no GitHub Release.**

## What a reviewer should know

**Why a job and not `paths-ignore`.** The run shows `decide` green and `publish` skipped, with a notice naming the rule that fired. `paths-ignore` would suppress the run and explain nothing — and its globs cannot express that Markdown *inside* `packages/` still ships: `@mittwald/flow-react-components` publishes `["*.md", "dist"]`.

**The rule is a denylist, on purpose.** A forgotten docs path costs one needless version; a forgotten source path would silently swallow a real release. So unknown paths count as publishable and `packages/**` counts wholesale. Dependency bumps (`pnpm-lock.yaml`) therefore still publish — they change real deps.

**`workflow_dispatch` always publishes** — the escape hatch when a docs-only change has to go out as a release anyway.

**Everything unreadable publishes.** No usable base sha, a failed compare call, or a response that is not a list of paths → publish. `gh api` prints its error body to *stdout* on a non-2xx, so the exit status decides whether the list is usable, and the classifier rejects a JSON blob outright instead of counting it as a filename.

**`publish-next.yml` gets the same gate**, so a forward-merged docs fix skips on `next` exactly as it skipped on `main`.

**This PR demonstrates itself:** it is CI-only, so merging it triggers no release.

## Verification

The shipped step script was extracted from the YAML (not re-typed) and run against real commits and the real compare API:

| Case | Result |
| --- | --- |
| `docs: fix heading spacing` (#2870) | `publish=false` |
| `fix(Link): stick link icon…` (#2869) | `publish=true` (7/7 relevant) |
| `chore(ci): purge CODEOWNERS def` (#2906) | `publish=false` |
| unreachable base sha | `publish=true` (fail-safe) |
| branch creation / force push | `publish=true` (fail-safe) |
| manual dispatch | `publish=true` |

Replayed over 200 non-release commits on `main`: **76 would be skipped, 0 false skips** — no commit touching `packages/**` is ever skipped.

`test.yml` now runs `node --test .github/scripts/*.test.mjs`, so a broken classifier fails the PR rather than the next release. The guard scripts sit outside the nx graph, so `pnpm affected:test` never saw them.

## Checklist

- [x] PR title is a Conventional Commit and matches the base branch above
- [x] `pnpm lint` is clean and `pnpm affected:test` passes (browser tests if
      behavior changed)
- [x] **Generated code is committed** (`git diff` is empty after the relevant
      `build:*` targets)
- [x] User-facing strings added to **both** `de-DE` and `en-US` locale files
- [x] Docs updated if a public API changed; intentional visual changes get
      updated snapshots / the `update-screenshots` label

<sub>No package code changes, so no locale, snapshot or generated-code work applies; `pnpm lint` is clean and the 24 guard tests pass.</sub>
