### PR TITLE
docs: badge and order the component overview like the navigation

### DIFF
--- a/apps/docs/src/app/04-components/_components/ComponentCard.module.scss
+++ b/apps/docs/src/app/04-components/_components/ComponentCard.module.scss
@@ -1,8 +1,5 @@
 .card {
   position: relative;
-
-  /* Keeps the badge's z-index from competing with the page around the tile —
-     without it the badge paints over the sticky header while scrolling. */
   isolation: isolate;
   display: flex;
   flex-direction: column;

--- a/apps/docs/src/app/04-components/_components/ComponentCard.module.scss
+++ b/apps/docs/src/app/04-components/_components/ComponentCard.module.scss
@@ -1,4 +1,9 @@
 .card {
+  position: relative;
+
+  /* Keeps the badge's z-index from competing with the page around the tile —
+     without it the badge paints over the sticky header while scrolling. */
+  isolation: isolate;
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -26,4 +31,11 @@
   flex-direction: column;
   gap: var(--size-px--xs);
   padding: var(--size-px--m);
+}
+
+.badge {
+  position: absolute;
+  z-index: 1;
+  top: var(--size-px--s);
+  inset-inline-end: var(--size-px--s);
 }

--- a/apps/docs/src/app/04-components/_components/ComponentCard.tsx
+++ b/apps/docs/src/app/04-components/_components/ComponentCard.tsx
@@ -3,6 +3,7 @@ import type { FC } from "react";
 import { Heading, Text } from "@mittwald/flow-react-components";
 import type { ComponentLink } from "@/app/04-components/_components/ComponentsList";
 import { getWireframe } from "@/app/04-components/_components/wireframe/registry";
+import { ComponentStatusBadge } from "@/lib/componentStatus";
 import styles from "./ComponentCard.module.scss";
 
 interface Props {
@@ -15,6 +16,12 @@ export const ComponentCard: FC<Props> = (props) => {
 
   return (
     <div className={styles.card}>
+      {component.component && (
+        <ComponentStatusBadge
+          name={component.component}
+          className={styles.badge}
+        />
+      )}
       <div className={styles.media} aria-hidden>
         <Wireframe />
       </div>

--- a/apps/docs/src/app/04-components/_components/ComponentsList.tsx
+++ b/apps/docs/src/app/04-components/_components/ComponentsList.tsx
@@ -8,6 +8,8 @@ export interface ComponentLink {
   group: string;
   slug: string;
   name: string;
+  /** Component display name, for the status registry lookup. */
+  component?: string;
   description?: string;
   href: string;
 }

--- a/apps/docs/src/app/04-components/_components/ComponentsOverview.module.scss
+++ b/apps/docs/src/app/04-components/_components/ComponentsOverview.module.scss
@@ -1,0 +1,8 @@
+/* Integrations follows a grouping-view wrapper rather than a sibling section, so
+   Flow's own section-to-section separator does not apply. Same tokens. */
+.integrations {
+  margin-block-start: var(--section--section-to-section-spacing);
+  padding-block-start: var(--section--section-to-section-spacing);
+  border-block-start: var(--separator--height) var(--border-style--default)
+    var(--separator--color);
+}

--- a/apps/docs/src/app/04-components/_components/ComponentsOverview.tsx
+++ b/apps/docs/src/app/04-components/_components/ComponentsOverview.tsx
@@ -6,38 +6,58 @@ import type { ComponentLink } from "@/app/04-components/_components/ComponentsLi
 import { ComponentsList } from "@/app/04-components/_components/ComponentsList";
 import { ComponentGroupingView } from "@/app/_components/ComponentGroupingView/ComponentGroupingView";
 import { extractTextFromPath } from "@/app/_lib/extractTextFromPath";
-import { compareGroupPaths, compareLabels } from "@/app/_lib/compareLabels";
-import { compareDeprecatedLast } from "@/lib/componentStatus";
+import { compareEntries } from "@/app/_lib/compareEntries";
+import { isIntegrationGroup } from "@/app/_lib/integrationGroups";
 
 interface Props {
   components: ComponentLink[];
 }
 
-/** Mirrors the navigation's order: deprecated last, then by label. */
-const compareComponents = (a: ComponentLink, b: ComponentLink): number =>
-  compareDeprecatedLast(a.component, b.component) ||
-  compareLabels(a.name, b.name);
+const sortableComponent = (component: ComponentLink) => ({
+  label: component.name,
+  pathSegment: component.slug,
+  component: component.component,
+});
+
+const sortableGroup = (group: string) => ({
+  label: extractTextFromPath(group),
+  pathSegment: group,
+});
+
+const toGroups = (components: ComponentLink[]): [string, ComponentLink[]][] =>
+  Object.entries(groupBy(components, (c) => c.group)).sort(([a], [b]) =>
+    compareEntries(sortableGroup(a), sortableGroup(b)),
+  );
+
+const GroupSections: FC<Props> = (props) =>
+  toGroups(props.components).map(([group, groupComponents]) => (
+    <Section key={group}>
+      <Heading>{extractTextFromPath(group)}</Heading>
+      <ComponentsList components={groupComponents} />
+    </Section>
+  ));
 
 export const ComponentsOverview: FC<Props> = (props) => {
-  const components = [...props.components].sort(compareComponents);
-
-  const groups = Object.entries(groupBy(components, (c) => c.group)).sort(
-    ([a], [b]) => compareGroupPaths(a, b),
+  const sorted = [...props.components].sort((a, b) =>
+    compareEntries(sortableComponent(a), sortableComponent(b)),
   );
+  const components = sorted.filter((c) => !isIntegrationGroup(c.group));
+  const integrations = sorted.filter((c) => isIntegrationGroup(c.group));
 
   return (
     <>
       <ComponentGroupingView view="grouped">
-        {groups.map(([group, groupComponents]) => (
-          <Section key={group}>
-            <Heading>{extractTextFromPath(group)}</Heading>
-            <ComponentsList components={groupComponents} />
-          </Section>
-        ))}
+        <GroupSections components={components} />
       </ComponentGroupingView>
       <ComponentGroupingView view="alphabetical">
         <ComponentsList components={components} aria-label="Components" />
       </ComponentGroupingView>
+      {integrations.length > 0 && (
+        <Section>
+          <Heading>Integrations</Heading>
+          <GroupSections components={integrations} />
+        </Section>
+      )}
     </>
   );
 };

--- a/apps/docs/src/app/04-components/_components/ComponentsOverview.tsx
+++ b/apps/docs/src/app/04-components/_components/ComponentsOverview.tsx
@@ -8,6 +8,7 @@ import { ComponentGroupingView } from "@/app/_components/ComponentGroupingView/C
 import { extractTextFromPath } from "@/app/_lib/extractTextFromPath";
 import { compareEntries } from "@/app/_lib/compareEntries";
 import { isIntegrationGroup } from "@/app/_lib/integrationGroups";
+import styles from "./ComponentsOverview.module.scss";
 
 interface Props {
   components: ComponentLink[];
@@ -58,7 +59,7 @@ export const ComponentsOverview: FC<Props> = (props) => {
         <ComponentsList components={components} aria-label="Components" />
       </ComponentGroupingView>
       {integrations.length > 0 && (
-        <Section>
+        <Section className={styles.integrations}>
           <Heading>Integrations</Heading>
           <GroupSections components={integrations} headingLevel={3} />
         </Section>

--- a/apps/docs/src/app/04-components/_components/ComponentsOverview.tsx
+++ b/apps/docs/src/app/04-components/_components/ComponentsOverview.tsx
@@ -1,3 +1,4 @@
+"use client";
 import type { FC } from "react";
 import { Heading, Section } from "@mittwald/flow-react-components";
 import { groupBy } from "remeda";
@@ -5,14 +6,20 @@ import type { ComponentLink } from "@/app/04-components/_components/ComponentsLi
 import { ComponentsList } from "@/app/04-components/_components/ComponentsList";
 import { ComponentGroupingView } from "@/app/_components/ComponentGroupingView/ComponentGroupingView";
 import { extractTextFromPath } from "@/app/_lib/extractTextFromPath";
-import { compareGroupPaths } from "@/app/_lib/compareLabels";
+import { compareGroupPaths, compareLabels } from "@/app/_lib/compareLabels";
+import { compareDeprecatedLast } from "@/lib/componentStatus";
 
 interface Props {
   components: ComponentLink[];
 }
 
+/** Mirrors the navigation's order: deprecated last, then by label. */
+const compareComponents = (a: ComponentLink, b: ComponentLink): number =>
+  compareDeprecatedLast(a.component, b.component) ||
+  compareLabels(a.name, b.name);
+
 export const ComponentsOverview: FC<Props> = (props) => {
-  const { components } = props;
+  const components = [...props.components].sort(compareComponents);
 
   const groups = Object.entries(groupBy(components, (c) => c.group)).sort(
     ([a], [b]) => compareGroupPaths(a, b),

--- a/apps/docs/src/app/04-components/_components/ComponentsOverview.tsx
+++ b/apps/docs/src/app/04-components/_components/ComponentsOverview.tsx
@@ -29,10 +29,15 @@ const toGroups = (components: ComponentLink[]): [string, ComponentLink[]][] =>
     compareEntries(sortableGroup(a), sortableGroup(b)),
   );
 
-const GroupSections: FC<Props> = (props) =>
+interface GroupSectionsProps extends Props {
+  /** `Section` hands every heading level 2, so a nested group states its own. */
+  headingLevel: 2 | 3;
+}
+
+const GroupSections: FC<GroupSectionsProps> = (props) =>
   toGroups(props.components).map(([group, groupComponents]) => (
     <Section key={group}>
-      <Heading>{extractTextFromPath(group)}</Heading>
+      <Heading level={props.headingLevel}>{extractTextFromPath(group)}</Heading>
       <ComponentsList components={groupComponents} />
     </Section>
   ));
@@ -47,7 +52,7 @@ export const ComponentsOverview: FC<Props> = (props) => {
   return (
     <>
       <ComponentGroupingView view="grouped">
-        <GroupSections components={components} />
+        <GroupSections components={components} headingLevel={2} />
       </ComponentGroupingView>
       <ComponentGroupingView view="alphabetical">
         <ComponentsList components={components} aria-label="Components" />
@@ -55,7 +60,7 @@ export const ComponentsOverview: FC<Props> = (props) => {
       {integrations.length > 0 && (
         <Section>
           <Heading>Integrations</Heading>
-          <GroupSections components={integrations} />
+          <GroupSections components={integrations} headingLevel={3} />
         </Section>
       )}
     </>

--- a/apps/docs/src/app/04-components/page.tsx
+++ b/apps/docs/src/app/04-components/page.tsx
@@ -21,6 +21,7 @@ export default async function Page() {
       group: mdxFile.slugs[0] ?? "",
       slug: mdxFile.slugs[1] ?? "",
       name: mdxFile.getNavTitle(),
+      component: mdxFile.mdxSource.frontmatter.component,
       description: mdxFile.mdxSource.frontmatter.description,
       href: `/04-components${mdxFile.pathname}/overview`,
     }))

--- a/apps/docs/src/app/04-components/page.tsx
+++ b/apps/docs/src/app/04-components/page.tsx
@@ -3,7 +3,6 @@ import type { Metadata } from "next";
 import { MdxFileFactory } from "@/lib/mdx/MdxFileFactory";
 import styles from "@/app/layout.module.scss";
 import { ComponentsOverview } from "@/app/04-components/_components/ComponentsOverview";
-import { compareLabels } from "@/app/_lib/compareLabels";
 
 const contentFolder = "src/content/04-components";
 
@@ -15,17 +14,15 @@ export const metadata: Metadata = {
 export default async function Page() {
   const mdxFiles = await MdxFileFactory.fromDir(contentFolder);
 
-  const components = mdxFiles
-    .map((mdxFile) => ({
-      id: mdxFile.pathname,
-      group: mdxFile.slugs[0] ?? "",
-      slug: mdxFile.slugs[1] ?? "",
-      name: mdxFile.getNavTitle(),
-      component: mdxFile.mdxSource.frontmatter.component,
-      description: mdxFile.mdxSource.frontmatter.description,
-      href: `/04-components${mdxFile.pathname}/overview`,
-    }))
-    .sort((a, b) => compareLabels(a.name, b.name));
+  const components = mdxFiles.map((mdxFile) => ({
+    id: mdxFile.pathname,
+    group: mdxFile.slugs[0] ?? "",
+    slug: mdxFile.slugs[1] ?? "",
+    name: mdxFile.getNavTitle(),
+    component: mdxFile.mdxSource.frontmatter.component,
+    description: mdxFile.mdxSource.frontmatter.description,
+    href: `/04-components${mdxFile.pathname}/overview`,
+  }));
 
   return (
     <LayoutCard className={styles.mainContent}>

--- a/apps/docs/src/app/_components/layout/MainNavigation/MainNavigation.tsx
+++ b/apps/docs/src/app/_components/layout/MainNavigation/MainNavigation.tsx
@@ -16,10 +16,7 @@ import {
 } from "@mittwald/flow-react-components";
 import type { SerializedMdxFile } from "@/lib/mdx/MdxFile";
 import { MdxFile } from "@/lib/mdx/MdxFile";
-import {
-  ComponentStatusBadge,
-  compareDeprecatedLast,
-} from "@/lib/componentStatus";
+import { ComponentStatusBadge } from "@/lib/componentStatus";
 import { GroupText } from "@/app/_components/layout/MainNavigation/components/GroupText";
 import type { MdxDirectoryTree } from "@/lib/mdx/components/buildDirectoryTree";
 import { buildDirectoryTree } from "@/lib/mdx/components/buildDirectoryTree";
@@ -28,11 +25,11 @@ import styles from "@/app/layout.module.scss";
 import { extractTextFromPath } from "@/app/_lib/extractTextFromPath";
 import { ComponentGroupingMenu } from "@/app/_components/layout/MainNavigation/components/ComponentGroupingMenu";
 import { ComponentGroupingView } from "@/app/_components/ComponentGroupingView/ComponentGroupingView";
-import { compareLabels } from "@/app/_lib/compareLabels";
+import type { SortableEntry } from "@/app/_lib/compareEntries";
+import { compareEntries } from "@/app/_lib/compareEntries";
+import { isIntegrationGroup } from "@/app/_lib/integrationGroups";
 
 const componentsPathSegment = "04-components";
-
-const integrationGroups = ["react-hook-form"];
 
 interface Props {
   docs: SerializedMdxFile[];
@@ -75,45 +72,25 @@ const NavigationLink: FC<NavigationLinkProps> = (props) => {
   );
 };
 
-const componentName = (
-  treeItem: MdxDirectoryTree | MdxFile,
-): string | undefined =>
+const sortableEntry = ([group, treeItem]: TreeEntry): SortableEntry =>
   treeItem instanceof MdxFile
-    ? treeItem.mdxSource.frontmatter.component
-    : undefined;
+    ? {
+        label: treeItem.getNavTitle(),
+        pathSegment: group,
+        component: treeItem.mdxSource.frontmatter.component,
+      }
+    : { label: extractTextFromPath(group), pathSegment: group };
 
-const entryLabel = ([group, treeItem]: TreeEntry): string =>
-  treeItem instanceof MdxFile
-    ? treeItem.getNavTitle()
-    : extractTextFromPath(group);
-
-/** A numeric path prefix ("01-design") is the author's intended order. */
-const pathPrefix = ([group]: TreeEntry): number | undefined => {
-  const prefix = /^(\d+)-/.exec(group)?.[1];
-  return prefix === undefined ? undefined : Number(prefix);
-};
-
-const comparePosition = (a: TreeEntry, b: TreeEntry): number => {
-  const prefixA = pathPrefix(a);
-  const prefixB = pathPrefix(b);
-
-  return prefixA !== undefined && prefixB !== undefined
-    ? prefixA - prefixB
-    : compareLabels(entryLabel(a), entryLabel(b));
-};
+const sortableFile = (treeItem: MdxFile): SortableEntry => ({
+  label: treeItem.getNavTitle(),
+  pathSegment: treeItem.slugs.at(-1) ?? "",
+  component: treeItem.mdxSource.frontmatter.component,
+});
 
 const sortEntries = (entries: TreeEntry[]): TreeEntry[] =>
-  [...entries].sort(
-    (a, b) =>
-      compareDeprecatedLast(componentName(a[1]), componentName(b[1])) ||
-      comparePosition(a, b),
+  [...entries].sort((a, b) =>
+    compareEntries(sortableEntry(a), sortableEntry(b)),
   );
-
-const compareFiles = (a: MdxFile, b: MdxFile): number =>
-  compareDeprecatedLast(
-    a.mdxSource.frontmatter.component,
-    b.mdxSource.frontmatter.component,
-  ) || compareLabels(a.getNavTitle(), b.getNavTitle());
 
 const collectMdxFiles = (entries: TreeEntry[]): MdxFile[] =>
   entries.flatMap(([, treeItem]) =>
@@ -147,10 +124,10 @@ const NavigationSection: FC<NavigationSectionProps> = (props) => {
 const ComponentsNavigation: FC<{ tree: MdxDirectoryTree }> = (props) => {
   const entries = Object.entries(props.tree);
   const componentEntries = entries.filter(
-    ([group]) => !integrationGroups.includes(group),
+    ([group]) => !isIntegrationGroup(group),
   );
   const integrationEntries = entries.filter(([group]) =>
-    integrationGroups.includes(group),
+    isIntegrationGroup(group),
   );
 
   return (
@@ -168,7 +145,7 @@ const ComponentsNavigation: FC<{ tree: MdxDirectoryTree }> = (props) => {
         <ComponentGroupingView view="alphabetical">
           <Navigation aria-label="Components">
             {collectMdxFiles(componentEntries)
-              .sort(compareFiles)
+              .sort((a, b) => compareEntries(sortableFile(a), sortableFile(b)))
               .map((treeItem) => (
                 <NavigationLink key={treeItem.pathname} treeItem={treeItem} />
               ))}

--- a/apps/docs/src/app/_components/layout/MainNavigation/MainNavigation.tsx
+++ b/apps/docs/src/app/_components/layout/MainNavigation/MainNavigation.tsx
@@ -18,7 +18,7 @@ import type { SerializedMdxFile } from "@/lib/mdx/MdxFile";
 import { MdxFile } from "@/lib/mdx/MdxFile";
 import {
   ComponentStatusBadge,
-  getComponentStatusInfo,
+  compareDeprecatedLast,
 } from "@/lib/componentStatus";
 import { GroupText } from "@/app/_components/layout/MainNavigation/components/GroupText";
 import type { MdxDirectoryTree } from "@/lib/mdx/components/buildDirectoryTree";
@@ -75,14 +75,12 @@ const NavigationLink: FC<NavigationLinkProps> = (props) => {
   );
 };
 
-const deprecatedRank = (treeItem: MdxDirectoryTree | MdxFile): number => {
-  if (!(treeItem instanceof MdxFile)) {
-    return 0;
-  }
-  const component = treeItem.mdxSource.frontmatter.component;
-  const status = component ? getComponentStatusInfo(component) : undefined;
-  return status?.level === "deprecated" ? 1 : 0;
-};
+const componentName = (
+  treeItem: MdxDirectoryTree | MdxFile,
+): string | undefined =>
+  treeItem instanceof MdxFile
+    ? treeItem.mdxSource.frontmatter.component
+    : undefined;
 
 const entryLabel = ([group, treeItem]: TreeEntry): string =>
   treeItem instanceof MdxFile
@@ -107,8 +105,15 @@ const comparePosition = (a: TreeEntry, b: TreeEntry): number => {
 const sortEntries = (entries: TreeEntry[]): TreeEntry[] =>
   [...entries].sort(
     (a, b) =>
-      deprecatedRank(a[1]) - deprecatedRank(b[1]) || comparePosition(a, b),
+      compareDeprecatedLast(componentName(a[1]), componentName(b[1])) ||
+      comparePosition(a, b),
   );
+
+const compareFiles = (a: MdxFile, b: MdxFile): number =>
+  compareDeprecatedLast(
+    a.mdxSource.frontmatter.component,
+    b.mdxSource.frontmatter.component,
+  ) || compareLabels(a.getNavTitle(), b.getNavTitle());
 
 const collectMdxFiles = (entries: TreeEntry[]): MdxFile[] =>
   entries.flatMap(([, treeItem]) =>
@@ -163,7 +168,7 @@ const ComponentsNavigation: FC<{ tree: MdxDirectoryTree }> = (props) => {
         <ComponentGroupingView view="alphabetical">
           <Navigation aria-label="Components">
             {collectMdxFiles(componentEntries)
-              .sort((a, b) => compareLabels(a.getNavTitle(), b.getNavTitle()))
+              .sort(compareFiles)
               .map((treeItem) => (
                 <NavigationLink key={treeItem.pathname} treeItem={treeItem} />
               ))}

--- a/apps/docs/src/app/_lib/compareEntries.ts
+++ b/apps/docs/src/app/_lib/compareEntries.ts
@@ -1,0 +1,39 @@
+import { compareLabels } from "@/app/_lib/compareLabels";
+import { compareDeprecatedLast } from "@/lib/componentStatus";
+
+/**
+ * What ordering needs to know about a navigation entry or an overview tile.
+ * Both sort different shapes, so both map onto this one — the order itself is
+ * defined once, in `compareEntries`.
+ */
+export interface SortableEntry {
+  /** The rendered label. */
+  label: string;
+  /** The path segment; a numeric prefix ("01-design") is the author's order. */
+  pathSegment: string;
+  /** Component display name, for the deprecated demotion. Absent for groups. */
+  component?: string;
+}
+
+/** A numeric path prefix ("01-design") is the author's intended order. */
+const pathPrefix = (entry: SortableEntry): number | undefined => {
+  const prefix = /^(\d+)-/.exec(entry.pathSegment)?.[1];
+  return prefix === undefined ? undefined : Number(prefix);
+};
+
+const comparePosition = (a: SortableEntry, b: SortableEntry): number => {
+  const prefixA = pathPrefix(a);
+  const prefixB = pathPrefix(b);
+
+  return prefixA !== undefined && prefixB !== undefined
+    ? prefixA - prefixB
+    : compareLabels(a.label, b.label);
+};
+
+/**
+ * The order of the component documentation: deprecated components last, then
+ * the author's numeric prefix, then the rendered label. Navigation and the
+ * component overview must agree, so both go through here.
+ */
+export const compareEntries = (a: SortableEntry, b: SortableEntry): number =>
+  compareDeprecatedLast(a.component, b.component) || comparePosition(a, b);

--- a/apps/docs/src/app/_lib/compareLabels.ts
+++ b/apps/docs/src/app/_lib/compareLabels.ts
@@ -1,11 +1,6 @@
-import { extractTextFromPath } from "@/app/_lib/extractTextFromPath";
-
 /**
- * Navigation and lists must agree on order, so both sort by the rendered label.
- * Path order is not the same: "action-group" sorts before "action".
+ * Order by the rendered label, not by path: "action-group" would sort before
+ * "action". Composed into `compareEntries`, which is what callers use.
  */
 export const compareLabels = (a: string, b: string): number =>
   a.localeCompare(b);
-
-export const compareGroupPaths = (a: string, b: string): number =>
-  compareLabels(extractTextFromPath(a), extractTextFromPath(b));

--- a/apps/docs/src/app/_lib/integrationGroups.ts
+++ b/apps/docs/src/app/_lib/integrationGroups.ts
@@ -1,0 +1,9 @@
+/**
+ * Content groups under `04-components` that document an integration rather than
+ * a component. Navigation and the component overview both list them apart from
+ * the components, so the set lives in one place.
+ */
+const integrationGroups = ["react-hook-form"];
+
+export const isIntegrationGroup = (group: string): boolean =>
+  integrationGroups.includes(group);

--- a/apps/docs/src/lib/componentStatus/ComponentStatusBadge.tsx
+++ b/apps/docs/src/lib/componentStatus/ComponentStatusBadge.tsx
@@ -6,6 +6,7 @@ import { getComponentStatusInfo } from "@/lib/componentStatus/componentStatus";
 interface Props {
   /** Component display name (registry lookup key on the main "." surface). */
   name: string;
+  className?: string;
 }
 
 /**
@@ -14,16 +15,29 @@ interface Props {
  * only for stable components. Renders nothing when there is no status.
  */
 export const ComponentStatusBadge: FC<Props> = (props) => {
-  const status = getComponentStatusInfo(props.name);
+  const { name, className } = props;
+  const status = getComponentStatusInfo(name);
 
   if (status?.level === "beta") {
-    return <AlertBadge status="info">Beta</AlertBadge>;
+    return (
+      <AlertBadge status="info" className={className}>
+        Beta
+      </AlertBadge>
+    );
   }
   if (status?.level === "deprecated") {
-    return <AlertBadge status="warning">Deprecated</AlertBadge>;
+    return (
+      <AlertBadge status="warning" className={className}>
+        Deprecated
+      </AlertBadge>
+    );
   }
   if (status?.isNew) {
-    return <Badge color="violet">Neu</Badge>;
+    return (
+      <Badge color="violet" className={className}>
+        Neu
+      </Badge>
+    );
   }
 
   return null;

--- a/apps/docs/src/lib/componentStatus/componentStatus.ts
+++ b/apps/docs/src/lib/componentStatus/componentStatus.ts
@@ -13,3 +13,17 @@ export type { FlowComponentStatus };
 export const getComponentStatusInfo = (
   name: string,
 ): FlowComponentStatus | undefined => getFlowComponentStatus(name);
+
+const isDeprecated = (name: string | undefined): boolean =>
+  (name === undefined ? undefined : getComponentStatusInfo(name)?.level) ===
+  "deprecated";
+
+/**
+ * Deprecated components sort after everything else (ADR 0003 §5: "Deprecated
+ * moved to the end"). The single comparator for it, because navigation and the
+ * component overview must agree on order.
+ */
+export const compareDeprecatedLast = (
+  a: string | undefined,
+  b: string | undefined,
+): number => Number(isDeprecated(a)) - Number(isDeprecated(b));

--- a/apps/docs/src/lib/componentStatus/index.ts
+++ b/apps/docs/src/lib/componentStatus/index.ts
@@ -2,5 +2,6 @@ export { ComponentStatusBadge } from "./ComponentStatusBadge";
 export { ComponentStatusCallout } from "./ComponentStatusCallout";
 export {
   getComponentStatusInfo,
+  compareDeprecatedLast,
   type FlowComponentStatus,
 } from "./componentStatus";


### PR DESCRIPTION
## Badges on the tiles

The component overview tiles now carry the same Beta/Deprecated/Neu badge as the navigation, in the tile's top right corner.

The tile gets `isolation: isolate`, so the badge's `z-index` stays inside the tile instead of competing in the page's root stacking context — the list item does not create one, so the badge otherwise painted over the sticky page header while scrolling.

`ComponentStatusBadge` gained an optional `className` so the tile can position the badge directly. Without it a wrapper element would be needed, and every tile of a component that has no status would render an empty absolutely positioned div.

## One order, one comparator

The overview and the navigation each had their own comparator, and had drifted twice:

- A deprecated component sat in its alphabetical position in the overview, while the navigation moved it to the end. ADR 0003 §5 asks for "Deprecated moved to the end" in the overview.
- The overview mixed the react-hook-form components into the component list and the alphabetical view, while the navigation keeps them in a separate Integrations section.

`compareEntries` now defines the order once — deprecated last, then the author's numeric prefix, then the label — and each side maps its own shape onto `SortableEntry`. The integration split runs off a shared `isIntegrationGroup`.

Two things fall out of the consolidation: the navigation's alphabetical view gains the deprecated demotion it was missing (without it, "the overview is ordered like the navigation" cannot hold in both grouping views at once), and the overview's group sections now honour a numeric path prefix like the navigation's do. `compareGroupPaths` is gone.

`ComponentsOverview` owns the order; the sort runs there rather than in the page, because the status registry reaches the docs app through a client-only export.

## Verified against the running docs app

- All 10 component categories identical between navigation and overview, in content and in order.
- Alphabetical view identical, 84 entries both sides, ending `Truncate, Align, SegmentedControl`.
- Integrations identical: `Field, Form, FormRootError, SubmitButton`.
- With a badged tile scrolled under the sticky header, hit-testing the badge's center returns the header, for all 9 badged tiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)