### PR TITLE
docs(adr): mark the version-contract guard live after the 1.0.0 cut

### DIFF
--- a/docs/adr/0005-semver-contract.md
+++ b/docs/adr/0005-semver-contract.md
@@ -141,8 +141,8 @@ These two statements are a launch requirement for the 1.0.0 docs, not optional.
   `BREAKING CHANGE`). This would have caught the `>=24` floor bump that shipped
   as a `fix` in #2728. Composes with the RFC #2711 routing guard.
   **Implemented** in #2752 (`.github/scripts/version-contract-guard.mjs`, wired
-  into `commit-guard.yml`); currently dormant until the `next` branch exists
-  (pre-1.0.0-cut).
+  into `commit-guard.yml`); live on both standing lines since the 1.0.0 cut —
+  the pre-cut dormancy guard was dropped in #2938.
 - The **one-time API review** of the ~110 `public.ts` exports + `flr-universal`
   props before the cut (RFC #2711, "The 1.0.0 cut") — the last cheap chance to
   fix names/props/types before they go under this contract.


### PR DESCRIPTION
ADR 0005's follow-up list still described the version-contract guard as
"currently dormant until the `next` branch exists (pre-1.0.0-cut)". Both
conditions are gone: `next` was created at the cut (#2816), and #2938 removed
the dormancy checks from `commit-guard.yml`. The guard now runs on every PR
against `main` and `next` — and is a required check on both since the cut.

Docs-only, so the release-relevance classifier skips the publish.

Refs #2816

🤖 Generated with [Claude Code](https://claude.com/claude-code)