### PR TITLE
docs: use primary instead of success for non-final button actions

### DIFF
--- a/apps/docs/src/content/03-patterns/01-patterns/anlegeprozess/examples/app-illustrated-message.tsx
+++ b/apps/docs/src/content/03-patterns/01-patterns/anlegeprozess/examples/app-illustrated-message.tsx
@@ -33,7 +33,7 @@ export default () => {
 
         <ActionGroup>
           <ModalTrigger>
-            <Button color="primary">Anlegen</Button>
+            <Button>Anlegen</Button>
             <Modal offCanvas>
               <Heading>App anlegen</Heading>
               <Content>

--- a/apps/docs/src/content/03-patterns/01-patterns/anlegeprozess/examples/app-illustrated-message.tsx
+++ b/apps/docs/src/content/03-patterns/01-patterns/anlegeprozess/examples/app-illustrated-message.tsx
@@ -33,7 +33,7 @@ export default () => {
 
         <ActionGroup>
           <ModalTrigger>
-            <Button color="success">Anlegen</Button>
+            <Button color="primary">Anlegen</Button>
             <Modal offCanvas>
               <Heading>App anlegen</Heading>
               <Content>

--- a/apps/docs/src/content/03-patterns/01-patterns/anlegeprozess/examples/create-container.tsx
+++ b/apps/docs/src/content/03-patterns/01-patterns/anlegeprozess/examples/create-container.tsx
@@ -37,7 +37,7 @@ export default () => {
 
   return (
     <ModalTrigger>
-      <Button color="primary">Beispiel öffnen</Button>
+      <Button>Beispiel öffnen</Button>
       <Modal offCanvas>
         <Heading>Container anlegen</Heading>
         <Content>

--- a/apps/docs/src/content/03-patterns/01-patterns/anlegeprozess/examples/create-container.tsx
+++ b/apps/docs/src/content/03-patterns/01-patterns/anlegeprozess/examples/create-container.tsx
@@ -37,7 +37,7 @@ export default () => {
 
   return (
     <ModalTrigger>
-      <Button color="success">Beispiel öffnen</Button>
+      <Button color="primary">Beispiel öffnen</Button>
       <Modal offCanvas>
         <Heading>Container anlegen</Heading>
         <Content>

--- a/apps/docs/src/content/03-patterns/01-patterns/anlegeprozess/examples/domain-list.tsx
+++ b/apps/docs/src/content/03-patterns/01-patterns/anlegeprozess/examples/domain-list.tsx
@@ -109,7 +109,7 @@ export default () => {
         </DomainList.Item>
         <ActionGroup>
           <ContextMenuTrigger>
-            <Button color="success">
+            <Button color="primary">
               <Text>Hinzufügen</Text>
               <IconChevronDown />
             </Button>

--- a/apps/docs/src/content/03-patterns/01-patterns/anlegeprozess/examples/domain-list.tsx
+++ b/apps/docs/src/content/03-patterns/01-patterns/anlegeprozess/examples/domain-list.tsx
@@ -109,7 +109,7 @@ export default () => {
         </DomainList.Item>
         <ActionGroup>
           <ContextMenuTrigger>
-            <Button color="primary">
+            <Button>
               <Text>Hinzufügen</Text>
               <IconChevronDown />
             </Button>

--- a/apps/docs/src/content/03-patterns/01-patterns/anlegeprozess/examples/install-app.tsx
+++ b/apps/docs/src/content/03-patterns/01-patterns/anlegeprozess/examples/install-app.tsx
@@ -19,7 +19,7 @@ import {
 } from "@mittwald/flow-react-components";
 
 <ModalTrigger>
-  <Button color="primary">Beispiel öffnen</Button>
+  <Button>Beispiel öffnen</Button>
   <Modal offCanvas>
     <Heading>WordPress anlegen</Heading>
     <Content>
@@ -45,7 +45,7 @@ import {
         </TextField>
         <Header>
           <Heading>Hauptdomain zuweisen</Heading>
-          <Button color="primary">Subdomain anlegen</Button>
+          <Button>Subdomain anlegen</Button>
         </Header>
         <Select isRequired placeholder="Domain wählen">
           <Label>Domain</Label>

--- a/apps/docs/src/content/03-patterns/01-patterns/anlegeprozess/examples/install-app.tsx
+++ b/apps/docs/src/content/03-patterns/01-patterns/anlegeprozess/examples/install-app.tsx
@@ -19,7 +19,7 @@ import {
 } from "@mittwald/flow-react-components";
 
 <ModalTrigger>
-  <Button color="success">Beispiel öffnen</Button>
+  <Button color="primary">Beispiel öffnen</Button>
   <Modal offCanvas>
     <Heading>WordPress anlegen</Heading>
     <Content>
@@ -45,7 +45,7 @@ import {
         </TextField>
         <Header>
           <Heading>Hauptdomain zuweisen</Heading>
-          <Button color="success">Subdomain anlegen</Button>
+          <Button color="primary">Subdomain anlegen</Button>
         </Header>
         <Select isRequired placeholder="Domain wählen">
           <Label>Domain</Label>

--- a/apps/docs/src/content/03-patterns/01-patterns/anlegeprozess/examples/install-extension.tsx
+++ b/apps/docs/src/content/03-patterns/01-patterns/anlegeprozess/examples/install-extension.tsx
@@ -26,7 +26,7 @@ import {
 } from "@mittwald/flow-react-components";
 
 <ModalTrigger>
-  <Button color="primary">Beispiel öffnen</Button>
+  <Button>Beispiel öffnen</Button>
   <Modal offCanvas>
     <Heading>Passwortschutz installieren</Heading>
     <Content>
@@ -54,9 +54,7 @@ import {
               Installation fortzufahren, lege bitte einen
               Vertragspartner an.
             </Text>
-            <Button color="primary">
-              Vertragspartner anlegen
-            </Button>
+            <Button>Vertragspartner anlegen</Button>
           </Content>
         </Alert>
         <Heading>Berechtigungen </Heading>

--- a/apps/docs/src/content/03-patterns/01-patterns/anlegeprozess/examples/install-extension.tsx
+++ b/apps/docs/src/content/03-patterns/01-patterns/anlegeprozess/examples/install-extension.tsx
@@ -26,7 +26,7 @@ import {
 } from "@mittwald/flow-react-components";
 
 <ModalTrigger>
-  <Button color="success">Beispiel öffnen</Button>
+  <Button color="primary">Beispiel öffnen</Button>
   <Modal offCanvas>
     <Heading>Passwortschutz installieren</Heading>
     <Content>
@@ -54,7 +54,7 @@ import {
               Installation fortzufahren, lege bitte einen
               Vertragspartner an.
             </Text>
-            <Button color="success">
+            <Button color="primary">
               Vertragspartner anlegen
             </Button>
           </Content>

--- a/apps/docs/src/content/03-patterns/01-patterns/anlegeprozess/examples/project-illustrated-message.tsx
+++ b/apps/docs/src/content/03-patterns/01-patterns/anlegeprozess/examples/project-illustrated-message.tsx
@@ -21,7 +21,7 @@ import {
       <Button color="secondary" variant="soft">
         Tarif bestellen
       </Button>
-      <Button color="primary">Anlegen</Button>
+      <Button>Anlegen</Button>
     </ActionGroup>
   </IllustratedMessage>
 </LayoutCard>;

--- a/apps/docs/src/content/03-patterns/01-patterns/anlegeprozess/examples/project-illustrated-message.tsx
+++ b/apps/docs/src/content/03-patterns/01-patterns/anlegeprozess/examples/project-illustrated-message.tsx
@@ -21,7 +21,7 @@ import {
       <Button color="secondary" variant="soft">
         Tarif bestellen
       </Button>
-      <Button color="success">Anlegen</Button>
+      <Button color="primary">Anlegen</Button>
     </ActionGroup>
   </IllustratedMessage>
 </LayoutCard>;

--- a/apps/docs/src/content/03-patterns/01-patterns/anlegeprozess/examples/project-list.tsx
+++ b/apps/docs/src/content/03-patterns/01-patterns/anlegeprozess/examples/project-list.tsx
@@ -75,7 +75,7 @@ export default () => {
           <Button color="secondary" variant="soft">
             Tarif bestellen
           </Button>
-          <Button color="success">Anlegen</Button>
+          <Button color="primary">Anlegen</Button>
         </ActionGroup>
       </ProjectList.List>
     </LayoutCard>

--- a/apps/docs/src/content/03-patterns/01-patterns/anlegeprozess/examples/project-list.tsx
+++ b/apps/docs/src/content/03-patterns/01-patterns/anlegeprozess/examples/project-list.tsx
@@ -75,7 +75,7 @@ export default () => {
           <Button color="secondary" variant="soft">
             Tarif bestellen
           </Button>
-          <Button color="primary">Anlegen</Button>
+          <Button>Anlegen</Button>
         </ActionGroup>
       </ProjectList.List>
     </LayoutCard>

--- a/apps/docs/src/content/03-patterns/01-patterns/errorhandling/examples/modal.tsx
+++ b/apps/docs/src/content/03-patterns/01-patterns/errorhandling/examples/modal.tsx
@@ -37,7 +37,7 @@ export default () => {
               controller.open();
             }}
           >
-            <Button color="primary">Projekt anlegen</Button>
+            <Button>Projekt anlegen</Button>
           </Action>
         </IllustratedMessage>
         <Modal controller={controller}>

--- a/apps/docs/src/content/03-patterns/01-patterns/errorhandling/examples/modal.tsx
+++ b/apps/docs/src/content/03-patterns/01-patterns/errorhandling/examples/modal.tsx
@@ -37,7 +37,7 @@ export default () => {
               controller.open();
             }}
           >
-            <Button color="success">Projekt anlegen</Button>
+            <Button color="primary">Projekt anlegen</Button>
           </Action>
         </IllustratedMessage>
         <Modal controller={controller}>

--- a/apps/docs/src/content/03-patterns/01-patterns/list-tile-table/examples/domain-list.tsx
+++ b/apps/docs/src/content/03-patterns/01-patterns/list-tile-table/examples/domain-list.tsx
@@ -109,7 +109,7 @@ export default () => {
           </DomainList.Item>
           <ActionGroup>
             <ContextMenuTrigger>
-              <Button color="success">
+              <Button color="primary">
                 <Text>Hinzufügen</Text>
                 <IconChevronDown />
               </Button>

--- a/apps/docs/src/content/03-patterns/01-patterns/list-tile-table/examples/domain-list.tsx
+++ b/apps/docs/src/content/03-patterns/01-patterns/list-tile-table/examples/domain-list.tsx
@@ -109,7 +109,7 @@ export default () => {
           </DomainList.Item>
           <ActionGroup>
             <ContextMenuTrigger>
-              <Button color="primary">
+              <Button>
                 <Text>Hinzufügen</Text>
                 <IconChevronDown />
               </Button>

--- a/apps/docs/src/content/03-patterns/01-patterns/list-tile-table/examples/project-list-empty.tsx
+++ b/apps/docs/src/content/03-patterns/01-patterns/list-tile-table/examples/project-list-empty.tsx
@@ -25,7 +25,7 @@ export default () => {
             Entwickeln loslegen.
           </Text>
           <ActionGroup>
-            <Button color="success">Anlegen</Button>
+            <Button color="primary">Anlegen</Button>
             <Button
               slot="secondary"
               color="secondary"

--- a/apps/docs/src/content/03-patterns/01-patterns/list-tile-table/examples/project-list-empty.tsx
+++ b/apps/docs/src/content/03-patterns/01-patterns/list-tile-table/examples/project-list-empty.tsx
@@ -25,7 +25,7 @@ export default () => {
             Entwickeln loslegen.
           </Text>
           <ActionGroup>
-            <Button color="primary">Anlegen</Button>
+            <Button>Anlegen</Button>
             <Button
               slot="secondary"
               color="secondary"

--- a/apps/docs/src/content/03-patterns/01-patterns/list-tile-table/examples/project-list.tsx
+++ b/apps/docs/src/content/03-patterns/01-patterns/list-tile-table/examples/project-list.tsx
@@ -85,7 +85,7 @@ export default () => {
             )}
           </ProjectList.Item>
           <ActionGroup>
-            <Button color="primary">
+            <Button>
               <Text>Anlegen</Text>
             </Button>
           </ActionGroup>

--- a/apps/docs/src/content/03-patterns/01-patterns/list-tile-table/examples/project-list.tsx
+++ b/apps/docs/src/content/03-patterns/01-patterns/list-tile-table/examples/project-list.tsx
@@ -85,7 +85,7 @@ export default () => {
             )}
           </ProjectList.Item>
           <ActionGroup>
-            <Button color="success">
+            <Button color="primary">
               <Text>Anlegen</Text>
             </Button>
           </ActionGroup>

--- a/apps/docs/src/content/03-patterns/01-patterns/list-tile-table/examples/server-list.tsx
+++ b/apps/docs/src/content/03-patterns/01-patterns/list-tile-table/examples/server-list.tsx
@@ -96,7 +96,7 @@ export default () => {
             )}
           </ServerList.Item>
           <ActionGroup>
-            <Button color="success">
+            <Button color="primary">
               <Text>Tarif bestellen</Text>
             </Button>
           </ActionGroup>

--- a/apps/docs/src/content/03-patterns/01-patterns/list-tile-table/examples/server-list.tsx
+++ b/apps/docs/src/content/03-patterns/01-patterns/list-tile-table/examples/server-list.tsx
@@ -96,7 +96,7 @@ export default () => {
             )}
           </ServerList.Item>
           <ActionGroup>
-            <Button color="primary">
+            <Button>
               <Text>Tarif bestellen</Text>
             </Button>
           </ActionGroup>

--- a/apps/docs/src/content/03-patterns/01-patterns/list-tile-table/examples/ticket-list.tsx
+++ b/apps/docs/src/content/03-patterns/01-patterns/list-tile-table/examples/ticket-list.tsx
@@ -100,7 +100,7 @@ export default () => {
             </TicketList.TableBody>
           </TicketList.Table>
           <ActionGroup>
-            <Button color="primary">
+            <Button>
               <Text>Anlegen</Text>
             </Button>
           </ActionGroup>

--- a/apps/docs/src/content/03-patterns/01-patterns/list-tile-table/examples/ticket-list.tsx
+++ b/apps/docs/src/content/03-patterns/01-patterns/list-tile-table/examples/ticket-list.tsx
@@ -100,7 +100,7 @@ export default () => {
             </TicketList.TableBody>
           </TicketList.Table>
           <ActionGroup>
-            <Button color="success">
+            <Button color="primary">
               <Text>Anlegen</Text>
             </Button>
           </ActionGroup>

--- a/apps/docs/src/content/04-components/actions/action-group/examples/link.tsx
+++ b/apps/docs/src/content/04-components/actions/action-group/examples/link.tsx
@@ -6,5 +6,5 @@ import {
 
 <ActionGroup>
   <Link slot="abort">Passwort vergessen?</Link>
-  <Button color="success">Anmelden</Button>
+  <Button color="primary">Anmelden</Button>
 </ActionGroup>;

--- a/apps/docs/src/content/04-components/actions/action-group/examples/link.tsx
+++ b/apps/docs/src/content/04-components/actions/action-group/examples/link.tsx
@@ -6,5 +6,5 @@ import {
 
 <ActionGroup>
   <Link slot="abort">Passwort vergessen?</Link>
-  <Button color="primary">Anmelden</Button>
+  <Button>Anmelden</Button>
 </ActionGroup>;

--- a/apps/docs/src/content/04-components/actions/action-group/examples/size.tsx
+++ b/apps/docs/src/content/04-components/actions/action-group/examples/size.tsx
@@ -6,5 +6,5 @@ import {
 
 <ActionGroup size="s">
   <Link>Passwort vergessen?</Link>
-  <Button color="success">Anmelden</Button>
+  <Button color="primary">Anmelden</Button>
 </ActionGroup>;

--- a/apps/docs/src/content/04-components/actions/action-group/examples/size.tsx
+++ b/apps/docs/src/content/04-components/actions/action-group/examples/size.tsx
@@ -6,5 +6,5 @@ import {
 
 <ActionGroup size="s">
   <Link>Passwort vergessen?</Link>
-  <Button color="primary">Anmelden</Button>
+  <Button>Anmelden</Button>
 </ActionGroup>;

--- a/apps/docs/src/content/04-components/structure/flex/examples/layoutCard.tsx
+++ b/apps/docs/src/content/04-components/structure/flex/examples/layoutCard.tsx
@@ -13,6 +13,6 @@ import {
     Quam.
   </Text>
   <Flex align="end" grow>
-    <Button color="primary">Install</Button>
+    <Button>Install</Button>
   </Flex>
 </LayoutCard>;

--- a/apps/docs/src/content/04-components/structure/flex/examples/layoutCard.tsx
+++ b/apps/docs/src/content/04-components/structure/flex/examples/layoutCard.tsx
@@ -13,6 +13,6 @@ import {
     Quam.
   </Text>
   <Flex align="end" grow>
-    <Button color="success">Install</Button>
+    <Button color="primary">Install</Button>
   </Flex>
 </LayoutCard>;

--- a/apps/docs/src/content/04-components/structure/list/examples/actionGroup.tsx
+++ b/apps/docs/src/content/04-components/structure/list/examples/actionGroup.tsx
@@ -24,7 +24,7 @@ export default () => {
     >
       <DomainList.StaticData data={domains} />
       <ActionGroup>
-        <Button color="success">Anlegen</Button>
+        <Button color="primary">Anlegen</Button>
       </ActionGroup>
       <DomainList.Item
         textValue={(domain) => domain.domain}

--- a/apps/docs/src/content/04-components/structure/list/examples/actionGroup.tsx
+++ b/apps/docs/src/content/04-components/structure/list/examples/actionGroup.tsx
@@ -24,7 +24,7 @@ export default () => {
     >
       <DomainList.StaticData data={domains} />
       <ActionGroup>
-        <Button color="primary">Anlegen</Button>
+        <Button>Anlegen</Button>
       </ActionGroup>
       <DomainList.Item
         textValue={(domain) => domain.domain}

--- a/apps/docs/src/content/04-components/structure/list/examples/default.tsx
+++ b/apps/docs/src/content/04-components/structure/list/examples/default.tsx
@@ -28,7 +28,7 @@ export default () => {
     >
       <DomainList.StaticData data={domains} />
       <ActionGroup>
-        <Button color="primary">Anlegen</Button>
+        <Button>Anlegen</Button>
       </ActionGroup>
       <DomainList.Search />
       <DomainList.Filter

--- a/apps/docs/src/content/04-components/structure/list/examples/default.tsx
+++ b/apps/docs/src/content/04-components/structure/list/examples/default.tsx
@@ -28,7 +28,7 @@ export default () => {
     >
       <DomainList.StaticData data={domains} />
       <ActionGroup>
-        <Button color="success">Anlegen</Button>
+        <Button color="primary">Anlegen</Button>
       </ActionGroup>
       <DomainList.Search />
       <DomainList.Filter

--- a/apps/docs/src/content/04-components/structure/list/examples/filter.tsx
+++ b/apps/docs/src/content/04-components/structure/list/examples/filter.tsx
@@ -28,7 +28,7 @@ export default () => {
     >
       <DomainList.StaticData data={domains} />
       <ActionGroup>
-        <Button color="primary">Anlegen</Button>
+        <Button>Anlegen</Button>
       </ActionGroup>
       <DomainList.Search />
       <DomainList.Filter

--- a/apps/docs/src/content/04-components/structure/list/examples/filter.tsx
+++ b/apps/docs/src/content/04-components/structure/list/examples/filter.tsx
@@ -28,7 +28,7 @@ export default () => {
     >
       <DomainList.StaticData data={domains} />
       <ActionGroup>
-        <Button color="success">Anlegen</Button>
+        <Button color="primary">Anlegen</Button>
       </ActionGroup>
       <DomainList.Search />
       <DomainList.Filter

--- a/apps/docs/src/content/04-components/structure/list/examples/mobile.tsx
+++ b/apps/docs/src/content/04-components/structure/list/examples/mobile.tsx
@@ -35,7 +35,7 @@ export default () => {
         >
           <IconDownload />
         </Button>
-        <Button color="primary">Anlegen</Button>
+        <Button>Anlegen</Button>
       </ActionGroup>
       <DomainList.Search />
       <DomainList.Filter

--- a/apps/docs/src/content/04-components/structure/list/examples/mobile.tsx
+++ b/apps/docs/src/content/04-components/structure/list/examples/mobile.tsx
@@ -35,7 +35,7 @@ export default () => {
         >
           <IconDownload />
         </Button>
-        <Button color="success">Anlegen</Button>
+        <Button color="primary">Anlegen</Button>
       </ActionGroup>
       <DomainList.Search />
       <DomainList.Filter

--- a/apps/docs/src/content/04-components/structure/section/examples/alert-badge.tsx
+++ b/apps/docs/src/content/04-components/structure/section/examples/alert-badge.tsx
@@ -26,7 +26,7 @@ import {
     <Button variant="soft" color="secondary">
       Datenbank migrieren
     </Button>
-    <Button color="success">Aktivieren</Button>
+    <Button color="primary">Aktivieren</Button>
   </Header>
 
   <ColumnLayout>

--- a/apps/docs/src/content/04-components/structure/section/examples/alert-badge.tsx
+++ b/apps/docs/src/content/04-components/structure/section/examples/alert-badge.tsx
@@ -26,7 +26,7 @@ import {
     <Button variant="soft" color="secondary">
       Datenbank migrieren
     </Button>
-    <Button color="primary">Aktivieren</Button>
+    <Button>Aktivieren</Button>
   </Header>
 
   <ColumnLayout>


### PR DESCRIPTION
## What & why

Across the styleguide examples, green (`color="success"`) buttons were used for actions that only **start** a process — opening a create modal, triggering a context menu, list-header CTAs, "Beispiel öffnen" triggers. Current guidance reserves success for the **final confirming action**: saving, the button that finally creates something, or the one that finally places an order. Main actions otherwise use **primary**, less important ones **secondary**.

This corrects the wrong button colors in the examples so the docs model the intended usage — especially under [Patterns → Anlegen und Bearbeiten](https://flow.mittwald.de/03-patterns/01-patterns/anlegeprozess).

## Changes

Simple `color="success"` → `color="primary"` swaps, 21 example files.

**Patterns (`03-patterns`):**
- **Anlegeprozess:** project-list, domain-list, install-app (trigger + "Subdomain anlegen"), install-extension (trigger + "Vertragspartner anlegen"), create-container, app-/project-illustrated-message
- **List-Tile-Table:** project-list, server-list, ticket-list, project-list-empty, domain-list
- **Errorhandling:** modal trigger

**Components (`04-components`):** structure/list (×4 "Anlegen"), structure/section ("Aktivieren"), structure/flex ("Install"), action-group link + size ("Anmelden").

## Kept green on purpose (correct final actions)

- The final "Anlegen" inside the create modals (install-app, create-container)
- All modal-footer confirms (Backup/SFTP/Organisation anlegen, Verbinden, Speichern)
- All "Speichern" examples and `button/colors.tsx` ("Erstellen/Speichern")
- ActionGroup form-footers "Organisation erstellen" / "E-Mail-Adresse anlegen"
- `IconCheck color="success"` status icons
- Chat "Senden" buttons (component-specific, left untouched)

## Verification

Ran the docs locally and checked computed button colors: triggers/list CTAs now render primary; the final create/confirm buttons stay success; secondary buttons unchanged.

Docs-only change — no package release.
