### PR TITLE
docs: Remove stability notice from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,6 @@ with those same components from inside an iframe.
 - 🎛️ **Storybook:** <https://storybook.flow-components.de>
 - 🧩 **Extension developer portal:** <https://developer.mittwald.de>
 
-> ⚠️ **Early development — stability notice**
->
-> Flow is in early development and we offer no stability guarantees of any kind.
-> Try it and tell us what you think — but don't rely on any input or output
-> staying stable between releases.
-
 ## Highlights
 
 - **Various components** covering actions, forms, overlays, navigation, data


### PR DESCRIPTION
Removed early development stability notice from README.

<!--
  Thanks for contributing to Flow! Full guide:
  https://github.com/mittwald/flow/blob/main/CONTRIBUTE.md
-->

## What & why

<!-- What does this change do, and why? Link related issues (e.g. Closes #123). -->

## Base branch & title

This repo **squash-merges**, so your **PR title becomes the release commit** —
it must be a valid [Conventional Commit](https://www.conventionalcommits.org/)
(e.g. `fix(Button): correct focus ring`). A CI guard lints the title _and_ that
it matches the base branch. Pick the base by change type
([details](https://github.com/mittwald/flow/blob/main/CONTRIBUTE.md#choosing-the-base-branch)):

- `fix:` / `docs:` / `chore:` / `refactor:` / … → base **`main`**
- `feat:` (new feature) → base **`next`**
- Breaking change (`feat!:` / `BREAKING CHANGE:`) → base **the major line**

> A major line only exists while a breaking change is being collected — ask a
> maintainer before opening one.

## Checklist

- [ ] PR title is a Conventional Commit and matches the base branch above
- [ ] `pnpm lint` is clean and `pnpm affected:test` passes (browser tests if
      behavior changed)
- [ ] **Generated code is committed** (`git diff` is empty after the relevant
      `build:*` targets)
- [ ] User-facing strings added to **both** `de-DE` and `en-US` locale files
- [ ] Docs updated if a public API changed; intentional visual changes get
      updated snapshots / the `update-screenshots` label
