### PR TITLE
docs: make layout example diagrams theme-aware

### DIFF
--- a/apps/docs/src/content/02-foundations/02-structure/01-layout/examples/general-layout.tsx
+++ b/apps/docs/src/content/02-foundations/02-structure/01-layout/examples/general-layout.tsx
@@ -1,74 +1,47 @@
 export default () => {
-  const styles: Record<string, React.CSSProperties> = {
-    layoutContainer: {
-      display: "grid",
-      gridTemplateAreas: `
-        'header header'
-        'nav content'
-      `,
-      gridTemplateColumns: "90px 1fr",
-      gridTemplateRows: "auto 1fr",
-      gap: "10px",
-      border: "1px solid rgba(206, 75, 255, 1)",
-      borderRadius: "4px",
-      padding: "10px",
-    },
-    header: {
-      gridArea: "header",
-      backgroundColor: "rgba(0, 84, 245, 0.02)",
-      padding: "10px",
-      textAlign: "center",
-      border: "1px dashed rgba(0, 84, 245, 1)",
-      borderRadius: "4px",
-    },
-    sideNavigation: {
-      gridArea: "nav",
-      backgroundColor: "rgba(0, 84, 245, 0.02)",
-      display: "flex",
-      justifyContent: "center",
-      padding: "55px 10px",
-      border: "1px dashed rgba(0, 84, 245, 1)",
-      borderRadius: "4px",
-      width: "90px",
-    },
-    verticalText: {
-      writingMode: "vertical-rl",
-      transform: "rotate(180deg)",
-    },
-    content: {
-      gridArea: "content",
-      backgroundColor: "rgba(0, 84, 245, 0.02)",
-      display: "flex",
-      justifyContent: "center",
-      alignItems: "center",
-      padding: "10px",
-      border: "1px dashed rgba(0, 84, 245, 1)",
-      borderRadius: "4px",
-    },
-    textStyle: {
-      color: "rgba(0, 63, 184, 1)",
-      fontWeight: "400",
-      fontSize: "14px",
-    },
+  const area: React.CSSProperties = {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: "var(--size-px--xs)",
+    backgroundColor:
+      "var(--info-soft-background-color--default)",
+    border: "1px dashed var(--info-soft-content-color)",
+    borderRadius: "var(--corner-radius--s)",
+  };
+
+  const vertical: React.CSSProperties = {
+    writingMode: "vertical-rl",
+    transform: "rotate(180deg)",
+  };
+
+  const layout: React.CSSProperties = {
+    alignSelf: "stretch",
+    height: "280px",
+    display: "grid",
+    gridTemplateAreas: `
+      'header header'
+      'nav    content'
+    `,
+    gridTemplateColumns: "1fr 5fr",
+    gridTemplateRows: "1fr 6fr",
+    gap: "var(--size-px--s)",
+    color: "var(--info-soft-content-color)",
+    fontSize: "var(--font-size-text--s)",
   };
 
   return (
-    <div style={styles.layoutContainer}>
-      <header style={styles.header}>
-        <p style={styles.textStyle}>Header</p>
+    <div style={layout}>
+      <header style={{ ...area, gridArea: "header" }}>
+        Header
       </header>
-      <nav style={styles.sideNavigation}>
-        <p
-          style={{
-            ...styles.verticalText,
-            ...styles.textStyle,
-          }}
-        >
-          Side-Navigation
-        </p>
+      <nav
+        style={{ ...area, ...vertical, gridArea: "nav" }}
+      >
+        Side-Navigation
       </nav>
-      <main style={styles.content}>
-        <p style={styles.textStyle}>Content</p>
+      <main style={{ ...area, gridArea: "content" }}>
+        Content
       </main>
     </div>
   );

--- a/apps/docs/src/content/02-foundations/02-structure/01-layout/examples/mStudio-layout.tsx
+++ b/apps/docs/src/content/02-foundations/02-structure/01-layout/examples/mStudio-layout.tsx
@@ -1,145 +1,77 @@
+import { IconMittwald } from "@mittwald/flow-react-components";
+
 export default () => {
-  const styles: Record<string, React.CSSProperties> = {
-    rootContainer: {
-      display: "flex",
-      flexDirection: "column",
-      gap: "10px",
-      border: "1px solid rgba(206, 75, 255, 1)",
-      borderRadius: "4px",
-      padding: "10px",
-    },
-    headerContainer: {
-      display: "grid",
-      gridTemplateAreas: `
-        'logo header header'
-      `,
-      gridTemplateColumns: "60px 1fr 1fr",
-      gap: "10px",
-    },
-    layoutContainer: {
-      display: "grid",
-      gridTemplateAreas: `
-        'primaryNav secondaryNav breadcrumb breadcrumb'
-        'primaryNav secondaryNav pageTitle button'
-        'primaryNav secondaryNav content content'
-      `,
-      gridTemplateColumns: "30px 60px 1fr",
-      gridTemplateRows: "auto auto 1fr",
-      gap: "10px",
-    },
-    logo: {
-      gridArea: "logo",
-      backgroundColor: "rgba(0, 84, 245, 0.02)",
-      padding: "10px",
-      border: "1px dashed rgba(0, 84, 245, 1)",
-      borderRadius: "4px",
-      display: "flex",
-      justifyContent: "center",
-      alignItems: "center",
-    },
-    header: {
-      gridArea: "header",
-      backgroundColor: "rgba(0, 84, 245, 0.02)",
-      padding: "10px",
-      textAlign: "center",
-      border: "1px dashed rgba(0, 84, 245, 1)",
-      borderRadius: "4px",
-    },
-    primaryNav: {
-      gridArea: "primaryNav",
-      backgroundColor: "rgba(0, 84, 245, 0.02)",
-      display: "flex",
-      justifyContent: "center",
-      alignItems: "center",
-      padding: "38px 0px",
-      border: "1px dashed rgba(0, 84, 245, 1)",
-      borderRadius: "4px",
-      writingMode: "vertical-rl",
-      transform: "rotate(180deg)",
-    },
-    secondaryNav: {
-      gridArea: "secondaryNav",
-      backgroundColor: "rgba(0, 84, 245, 0.02)",
-      display: "flex",
-      justifyContent: "center",
-      alignItems: "center",
-      padding: "38px 0px",
-      border: "1px dashed rgba(0, 84, 245, 1)",
-      borderRadius: "4px",
-      writingMode: "vertical-rl",
-      transform: "rotate(180deg)",
-    },
-    breadcrumb: {
-      gridArea: "breadcrumb",
-      backgroundColor: "rgba(0, 84, 245, 0.02)",
-      textAlign: "center",
-      border: "1px dashed rgba(0, 84, 245, 1)",
-      borderRadius: "4px",
-    },
-    pageTitle: {
-      gridArea: "pageTitle",
-      backgroundColor: "rgba(0, 84, 245, 0.02)",
-      textAlign: "center",
-      border: "1px dashed rgba(0, 84, 245, 1)",
-      borderRadius: "4px",
-    },
-    button: {
-      gridArea: "button",
-      backgroundColor: "rgba(0, 84, 245, 0.02)",
-      padding: "0px 5px",
-      textAlign: "center",
-      border: "1px dashed rgba(0, 84, 245, 1)",
-      borderRadius: "4px",
-    },
-    content: {
-      gridArea: "content",
-      backgroundColor: "rgba(0, 84, 245, 0.02)",
-      display: "flex",
-      justifyContent: "center",
-      alignItems: "center",
-      padding: "10px",
-      border: "1px dashed rgba(0, 84, 245, 1)",
-      borderRadius: "4px",
-    },
-    textStyle: {
-      color: "rgba(0, 63, 184, 1)",
-      fontWeight: "400",
-      fontSize: "14px",
-    },
+  const area: React.CSSProperties = {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: "var(--size-px--xs)",
+    backgroundColor:
+      "var(--info-soft-background-color--default)",
+    border: "1px dashed var(--info-soft-content-color)",
+    borderRadius: "var(--corner-radius--s)",
+  };
+
+  const vertical: React.CSSProperties = {
+    writingMode: "vertical-rl",
+    transform: "rotate(180deg)",
+  };
+
+  const layout: React.CSSProperties = {
+    alignSelf: "stretch",
+    height: "280px",
+    display: "grid",
+    gridTemplateAreas: `
+      'logo       header       header     header'
+      'primaryNav secondaryNav breadcrumb breadcrumb'
+      'primaryNav secondaryNav pageTitle  button'
+      'primaryNav secondaryNav content    content'
+    `,
+    gridTemplateColumns: "1fr 2fr 12fr 3fr",
+    gridTemplateRows: "auto auto auto 1fr",
+    gap: "var(--size-px--s)",
+    color: "var(--info-soft-content-color)",
+    fontSize: "var(--font-size-text--s)",
   };
 
   return (
-    <div style={styles.rootContainer}>
-      <div style={styles.headerContainer}>
-        <div style={styles.logo}>
-          <p style={styles.textStyle}>Logo</p>
-        </div>
-        <header style={styles.header}>
-          <p style={styles.textStyle}>Header</p>
-        </header>
+    <div style={layout}>
+      <div style={{ ...area, gridArea: "logo" }}>
+        <IconMittwald size="s" />
       </div>
-      <div style={styles.layoutContainer}>
-        <nav style={styles.primaryNav}>
-          <p style={styles.textStyle}>Primary Navigation</p>
-        </nav>
-        <nav style={styles.secondaryNav}>
-          <p style={styles.textStyle}>
-            Secondary Navigation
-          </p>
-        </nav>
-        <div style={styles.breadcrumb}>
-          <p style={styles.textStyle}>Breadcrumb</p>
-        </div>
-        <div style={styles.pageTitle}>
-          <p style={styles.textStyle}>Page Title</p>
-        </div>
-        <div style={styles.button}>
-          <p style={styles.textStyle}>Button</p>
-        </div>
-        <main style={styles.content}>
-          <p style={styles.textStyle}>Content</p>
-        </main>
+      <header style={{ ...area, gridArea: "header" }}>
+        Header
+      </header>
+      <nav
+        style={{
+          ...area,
+          ...vertical,
+          gridArea: "primaryNav",
+        }}
+      >
+        Primary Navigation
+      </nav>
+      <nav
+        style={{
+          ...area,
+          ...vertical,
+          gridArea: "secondaryNav",
+        }}
+      >
+        Secondary Navigation
+      </nav>
+      <div style={{ ...area, gridArea: "breadcrumb" }}>
+        Breadcrumb
       </div>
+      <div style={{ ...area, gridArea: "pageTitle" }}>
+        Page Title
+      </div>
+      <div style={{ ...area, gridArea: "button" }}>
+        Button
+      </div>
+      <main style={{ ...area, gridArea: "content" }}>
+        Content
+      </main>
     </div>
   );
 };


### PR DESCRIPTION
The two schematic examples on Foundations → Structure → Layout hardcoded light-theme blue literals, so in dark mode the labels had almost no contrast and the section fills were invisible.

Colors, spacing, radii and label size now come from design tokens — `--info-soft-background-color--default` for the area fills, `--info-soft-content-color` for labels and dashed borders, `--size-px--*` / `--corner-radius--s` for spacing and radii.

Both examples are rebuilt around one shared `area` style and a single grid. Every box is the same centered, dashed tile that only names its grid area; the proportions come from `fr` values instead of per-box padding, and the text color and size are inherited from the grid. The mStudio example no longer nests two grids.

The lilac frame is gone and both diagrams stretch across the full width of their example tile at a shared 280px height. The height used to come from oversized padding on the navigation columns, so it depended on how long the rotated labels render — the two diagrams ended up different heights and neither filled its tile.

Net effect: 102 insertions, 201 deletions.

Closes #2892

🤖 Generated with [Claude Code](https://claude.com/claude-code)