### PR TITLE
fix(docs): hide deprecated values from the properties table

### DIFF
--- a/apps/docs/src/lib/PropertiesTables/lib/loadProperties.ts
+++ b/apps/docs/src/lib/PropertiesTables/lib/loadProperties.ts
@@ -1,23 +1,34 @@
 import docGenFile from "@mittwald/flow-react-components/doc-properties";
 import type { ComponentDoc } from "react-docgen-typescript";
 import type { Properties, Property } from "../types";
-import { splitUnion } from "./unionType";
+import { splitUnion, unquote } from "./unionType";
 
 const eventRegex = /^on[A-Z]+.*/;
 const a11yRegex = /^aria-.+/;
 const nullishMembers = ["undefined", "null"];
+/** `@deprecatedValues accent, plain` — but not the prop-level `@deprecated`. */
+const deprecatedRegex = /@deprecated(?!\w)/;
+const deprecatedValuesRegex = /^[ \t]*@deprecatedValues[ \t]+(.*)$/m;
 
 /*
- * `undefined` and `null` as top-level union members only restate the "Required"
- * badge. Nested ones are part of the type and have to survive: ColumnLayout's
- * `(number | null)[]` documents that `null` hides a column.
+ * Drops union members the table must not offer: `undefined`/`null`, which only
+ * restate the "Required" badge, and the values a prop marks `@deprecatedValues`
+ * — those still work at runtime, but nothing should send a reader towards them.
+ * Only top-level members go; nested ones are part of the type and have to
+ * survive, e.g. ColumnLayout's `(number | null)[]`, where `null` hides a column.
  */
-const stripTopLevelNullish = (type: string): string => {
+const hideMembers = (type: string, hidden: string[]): string => {
   const members = splitUnion(type).filter(
-    (member) => !nullishMembers.includes(member),
+    (member) => !hidden.includes(unquote(member)),
   );
   return members.length > 0 ? members.join(" | ") : type;
 };
+
+const parseDeprecatedValues = (description: string): string[] =>
+  (deprecatedValuesRegex.exec(description)?.[1] ?? "")
+    .split(",")
+    .map((value) => unquote(value.trim()))
+    .filter(Boolean);
 
 /** An `@default: x` JSDoc tag keeps its colon in the generated metadata. */
 const normalizeDefaultValue = (value: unknown): string | null => {
@@ -42,17 +53,21 @@ export default function loadProperties(name: string): Properties | null {
     .filter(([name, prop]) => name && prop)
     .filter(([, prop]) => !prop.description.includes("@internal"))
     .map(([, prop]) => {
+      const hidden = [
+        ...nullishMembers,
+        ...parseDeprecatedValues(prop.description),
+      ];
       const type =
         prop.name === "children"
           ? "ReactNode"
-          : stripTopLevelNullish(prop.type.name);
+          : hideMembers(prop.type.name, hidden);
 
       return {
         name: prop.name,
         default: normalizeDefaultValue(prop.defaultValue?.value),
-        description: prop.description,
+        description: prop.description.replace(deprecatedValuesRegex, "").trim(),
         required: prop.required,
-        deprecated: prop.description.includes("@deprecated"),
+        deprecated: deprecatedRegex.test(prop.description),
         type,
       };
     });

--- a/apps/docs/src/lib/PropertiesTables/lib/unionType.ts
+++ b/apps/docs/src/lib/PropertiesTables/lib/unionType.ts
@@ -30,7 +30,7 @@ export const splitUnion = (type: string): string[] => {
 
 const stringLiteralPattern = /^["'](.*)["']$/;
 
-const unquote = (member: string): string =>
+export const unquote = (member: string): string =>
   member.replace(stringLiteralPattern, "$1");
 
 export interface FormattedType {

--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -282,7 +282,11 @@ to zero components.
 
 Prop JSDoc feeds the generated `doc-properties.json` and the docs site: write
 doc comments on public props, use `@default` for defaults and `@internal` for
-props to hide.
+props to hide. A deprecated **value** of a still-current prop — `Button`'s
+`color="accent"` — is listed with `@deprecatedValues accent` (comma-separated
+for several) and drops out of the properties table, so the table only offers
+values that should still be used. The value stays in the prop's type and keeps
+working; the runtime warns via `useWarnDeprecation` as usual.
 
 ## Misc
 

--- a/packages/components/src/components/Button/Button.tsx
+++ b/packages/components/src/components/Button/Button.tsx
@@ -22,7 +22,12 @@ export interface ButtonProps
     FlowComponentProps<HTMLButtonElement> {
   /** Slot for button placement in action groups. */
   slot?: string;
-  /** The color of the button. @default "primary" */
+  /**
+   * The color of the button.
+   *
+   * @default "primary"
+   * @deprecatedValues accent
+   */
   color?:
     "primary" | "success" | "secondary" | "danger" | AlphaColor | "accent";
   /** The visual variant of the button. @default "solid" */


### PR DESCRIPTION
A prop can keep a value working while no longer wanting anyone to use it — `Button`'s `color="accent"`, renamed to `success` long ago, was still listed in the properties table as a normal choice.

`@deprecatedValues accent` on the prop's JSDoc drops it from the table. The mechanism is generic: `react-docgen-typescript` already carries the tag through to `doc-properties.json`, so any prop can list one or more deprecated values, and the same top-level union filter that removes `undefined`/`null` (from #2961) removes them.

```
color   … | success | danger | primary (default) | secondary | accent
    →   … | success | danger | primary (default) | secondary
```

Nothing about the prop itself changes: `accent` stays in `ButtonProps["color"]`, still renders as `success`, and still warns via `useWarnDeprecation`. The deprecation window stays open — the table just stops advertising it.

Based on #2961, whose union splitter this reuses.

<sub>This PR previously removed `accent` from the type instead; that version is dropped, see the discussion below.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)