### PR TITLE
fix(docs): show full prop types in the properties table

### DIFF
--- a/apps/docs/src/lib/PropertiesTables/lib/loadProperties.ts
+++ b/apps/docs/src/lib/PropertiesTables/lib/loadProperties.ts
@@ -1,10 +1,23 @@
 import docGenFile from "@mittwald/flow-react-components/doc-properties";
 import type { ComponentDoc } from "react-docgen-typescript";
 import type { Properties, Property } from "../types";
+import { splitUnion } from "./unionType";
 
 const eventRegex = /^on[A-Z]+.*/;
 const a11yRegex = /^aria-.+/;
-const optionalRegex = / \| (undefined|null)/g;
+const nullishMembers = ["undefined", "null"];
+
+/*
+ * `undefined` and `null` as top-level union members only restate the "Required"
+ * badge. Nested ones are part of the type and have to survive: ColumnLayout's
+ * `(number | null)[]` documents that `null` hides a column.
+ */
+const stripTopLevelNullish = (type: string): string => {
+  const members = splitUnion(type).filter(
+    (member) => !nullishMembers.includes(member),
+  );
+  return members.length > 0 ? members.join(" | ") : type;
+};
 
 /** An `@default: x` JSDoc tag keeps its colon in the generated metadata. */
 const normalizeDefaultValue = (value: unknown): string | null => {
@@ -29,11 +42,11 @@ export default function loadProperties(name: string): Properties | null {
     .filter(([name, prop]) => name && prop)
     .filter(([, prop]) => !prop.description.includes("@internal"))
     .map(([, prop]) => {
-      let type = prop.type.name.replaceAll(optionalRegex, "");
+      const type =
+        prop.name === "children"
+          ? "ReactNode"
+          : stripTopLevelNullish(prop.type.name);
 
-      if (prop.name === "children") {
-        type = "ReactNode";
-      }
       return {
         name: prop.name,
         default: normalizeDefaultValue(prop.defaultValue?.value),

--- a/apps/docs/src/lib/PropertiesTables/lib/unionType.ts
+++ b/apps/docs/src/lib/PropertiesTables/lib/unionType.ts
@@ -1,5 +1,5 @@
 /** `Iterable<A | B> | null` yields two members, not three. */
-const splitUnion = (type: string): string[] => {
+export const splitUnion = (type: string): string[] => {
   const parts: string[] = [];
   let depth = 0;
   let current = "";

--- a/packages/components/dev/createDocPropertiesJson.ts
+++ b/packages/components/dev/createDocPropertiesJson.ts
@@ -6,10 +6,30 @@ import * as docgen from "react-docgen-typescript";
 
 import type { ComponentDoc } from "react-docgen-typescript";
 
+/*
+ * `shouldExtractLiteralValuesFromEnum` resolves the members behind a literal
+ * union alias (`gap?: GapSize`), which `typeToString` would print as the bare
+ * alias name. It reports them as `{ name: "enum", value: [...] }` — fold them
+ * back into the union string every consumer reads from `type.name`.
+ */
+function expandLiteralUnions(components: ComponentDoc[]): void {
+  for (const component of components) {
+    for (const prop of Object.values(component.props)) {
+      const { name, value } = prop.type;
+      if (name === "enum" && Array.isArray(value) && value.length > 0) {
+        prop.type.name = value
+          .map((member: { value: unknown }) => String(member.value))
+          .join(" | ");
+      }
+    }
+  }
+}
+
 async function parse(): Promise<ComponentDoc[]> {
   const parser = docgen.withCustomConfig(path.resolve("./tsconfig.json"), {
     skipChildrenPropWithoutDoc: false,
     shouldRemoveUndefinedFromOptional: true,
+    shouldExtractLiteralValuesFromEnum: true,
     savePropValueAsString: true,
   });
 
@@ -22,7 +42,9 @@ async function parse(): Promise<ComponentDoc[]> {
     ],
   });
 
-  return parser.parse(files);
+  const components = parser.parse(files);
+  expandLiteralUnions(components);
+  return components;
 }
 
 async function createDocPropertiesJson() {


### PR DESCRIPTION
Two independent causes made the generated properties table understate a prop's type. Both are visible on [ColumnLayout](https://flow.mittwald.de/04-components/structure/column-layout).

**Nullable arrays lost the `null`.** The generator emitted `(number | null)[]` correctly; `loadProperties` then ran `/ \| (undefined|null)/g` over the whole type string, so it matched *inside* the parentheses and rendered `(number)[]` — contradicting the page's own "Ausgeblendete Spalten" section. The strip is now depth-aware and only drops `undefined`/`null` as top-level union members, where they merely restate the Required badge.

**Type aliases were rendered by name.** `checker.typeToString()` prints a prop typed exactly as an alias by that alias' name, so `gap?: GapSize` became `GapSize` and the allowed values were nowhere in the table. `shouldExtractLiteralValuesFromEnum` resolves the members; the generator folds them back into the union string, keeping the shape every consumer of `doc-properties.json` reads from `type.name`. 37 aliases expand — `GapSize`, `Orientation`, `Placement`, `SelectionMode`, `ListViewMode`, `WordBreak` and others.

Before → after on ColumnLayout:

```
s      (number)[]   →  (number | null)[]
gap    GapSize      →  s | m (default) | l | xl
```

Verified in the running docs app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)