### PR TITLE
fix(FileField): open the file dialog inside a link row

### DIFF
--- a/packages/components/src/components/FileField/FileField.browser.test.tsx
+++ b/packages/components/src/components/FileField/FileField.browser.test.tsx
@@ -1,0 +1,37 @@
+import { render } from "vitest-browser-react";
+import { page } from "vitest/browser";
+import * as Aria from "react-aria-components";
+import { Button } from "@/components/Button";
+import { FileField } from "@/components/FileField";
+
+/*
+ * A list row with an href is a react-aria GridListItem link, and react-aria
+ * suppresses the default action of every click inside such a row. Opening the
+ * file dialog *is* the default action of FileInput's click on its hidden input,
+ * so unless that click stops propagating, the dialog never opens — silently.
+ */
+test("Hidden input's click keeps its default action inside a link row", async () => {
+  render(
+    <Aria.GridList aria-label="Files">
+      <Aria.GridListItem href="#" textValue="Certificate">
+        <FileField>
+          <Button>Select file</Button>
+        </FileField>
+      </Aria.GridListItem>
+    </Aria.GridList>,
+  );
+
+  const trigger = page.getByRole("button", { name: "Select file" });
+  await expect.element(trigger).toBeInTheDocument();
+
+  const input = document.querySelector<HTMLInputElement>('input[type="file"]');
+  let inputClick: MouseEvent | undefined;
+  input?.addEventListener("click", (event) => {
+    inputClick = event;
+  });
+
+  await trigger.click();
+
+  expect(inputClick).toBeDefined();
+  expect(inputClick?.defaultPrevented).toBe(false);
+});

--- a/packages/components/src/components/FileField/components/FileInput.tsx
+++ b/packages/components/src/components/FileField/components/FileInput.tsx
@@ -55,6 +55,7 @@ export const FileInput: FC<FileInputProps> = (props) => {
         type="file"
         ref={inputRef}
         onChange={handleChange}
+        onClick={(event) => event.stopPropagation()}
       />
     </PropsContextProvider>
   );


### PR DESCRIPTION
## Problem

A `FileField` (and `FileDropZone`, which renders one) opens no file dialog when it sits in a `List` row that has an `href` — including in a `Modal` rendered from that row. The button reacts, nothing happens, no error.

Reported from mStudio (`coab-0x7e7/frontend/apps/mstudio#3835`) for a certificate upload and two avatar uploads.

## Cause

A row with `href` is a react-aria `GridListItem` link. react-aria attaches an `onClick` to such rows that kills the click's default action (`useSelectableItem`, `linkBehavior` defaults to `"action"` in `useGridList`) — and unlike its `onPointerDown`/`onMouseDown` siblings, it has no target or portal check.

`FileInput` opens the dialog with `inputRef.current?.click()` on its hidden `<input type="file">`. Opening the dialog **is** that click's default action, so the row handler cancels it.

Portalling does not help: `Overlay` moves the DOM node, but the content stays a React descendant of the row, and React dispatches along the React tree.

## Fix

`onClick={(event) => event.stopPropagation()}` on the hidden input. That click is addressed to this input alone — everything outside can only misread it. Fixes every occurrence at once, however deep the field sits in rows and modals.

## Test

`FileField.browser.test.tsx` renders the field in a `GridListItem` with `href`, clicks the trigger and asserts the input's click is not `defaultPrevented`. Red before the fix in both Firefox and WebKit, green after.

Closes #2964

## Checklist

- [x] PR title is a Conventional Commit (`fix:` → base `main`)
- [x] `pnpm lint` clean (0 errors, prettier clean), `pnpm affected:test` green, full `pnpm nx test:browser components` green (72 files / 500 tests, Firefox + WebKit)
- [x] No generated code affected — `FileInput` is not `@flr-generate`, no prop, JSDoc or SCSS class change; `git diff` empty after `build:remote-components` and `build:scss-types`
- [x] No user-facing strings
- [x] No public API change, no visual change
