### PR TITLE
test(docs): check the documentation's internal links in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Test the CI guard scripts
         run: node --test .github/scripts/*.test.mjs
 
-      - name: Run unit tests
+      - name: Run tests
         run: pnpm affected:test
 
       - name: Cache Playwright browsers

--- a/apps/docs/AGENTS.md
+++ b/apps/docs/AGENTS.md
@@ -19,5 +19,10 @@ Next.js documentation site for the flow Styleguide, deployed to
   members/roles, prices, component props) — see the existing `table/examples`
   for the tone. Star Wars-flavoured fixtures are fine in Storybook stories, but
   never in the docs.
+- **Internal links are checked in CI.** `pnpm nx test:links docs` validates
+  every `/pathname` and `#anchor` in the content and in the app's own sources
+  against the pages that exist — it runs as part of `pnpm affected:test`, so a
+  link to a moved or renamed page fails the PR. Move a page and the failure
+  names the candidates it could mean. External URLs are out of scope.
 - Run `pnpm format` (Prettier, 80-character prose wrap) before committing. The
   local dev server is `pnpm nx dev docs`.

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -9,7 +9,8 @@
     "build:imports": "tsx dev/generateLiveCodeEditorGlobalImports.ts",
     "dev": "next dev",
     "postinstall": "fumadocs-mdx",
-    "start": "pnpx serve@latest out"
+    "start": "pnpx serve@latest out",
+    "test:links": "tsx --test 'src/lib/**/*.test.ts'"
   },
   "dependencies": {
     "@internationalized/date": "^3.12.3",

--- a/apps/docs/project.json
+++ b/apps/docs/project.json
@@ -8,6 +8,10 @@
       "cache": true,
       "inputs": ["default", "{projectRoot}/src/content/**/*.mdx"]
     },
+    "test:links": {
+      "cache": true,
+      "inputs": ["default"]
+    },
     "build": {
       "dependsOn": [
         "build:imports",

--- a/apps/docs/src/content/02-foundations/03-content-guidelines/02-informationskonzept/index.mdx
+++ b/apps/docs/src/content/02-foundations/03-content-guidelines/02-informationskonzept/index.mdx
@@ -75,7 +75,7 @@ sollten bewusst und sparsam eingesetzt werden. Denn zu viele Notifications
 überfluten den User und lenken von wirklich wichtigen Informationen ab.
 
 Notifications werden durch den
-[NotificationsProvider](04-components/status/notification-provider) ausgelöst.
+[NotificationsProvider](/04-components/status/notification-provider) ausgelöst.
 Da Notifications in der Regel nur kurz sichtbar sind, sollten sie an einem
 zentralen Ort gesammelt werden, damit ungelesene Notifications auch zu einem
 späteren Zeitpunkt eingesehen werden können. Kritische Probleme sollten

--- a/apps/docs/src/lib/links/checkLinks.test.ts
+++ b/apps/docs/src/lib/links/checkLinks.test.ts
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { PageInventory } from "@/lib/links/checkLinks";
+import { checkLinks } from "@/lib/links/checkLinks";
+import type { FoundLink } from "@/lib/links/extractLinks";
+
+const inventory: PageInventory = new Map([
+  ["/04-components/form-controls/rating", new Set<string>()],
+  ["/04-components/react-hook-form/form", new Set<string>()],
+  ["/02-foundations/01-design/02-colors", new Set(["farben-light-und-dark"])],
+  ["/", new Set<string>()],
+]);
+
+const link = (href: string, page?: string): FoundLink => ({
+  href,
+  file: "test.mdx",
+  line: 1,
+  page,
+});
+
+const check = (href: string, page?: string) =>
+  checkLinks([link(href, page)], inventory);
+
+describe("checkLinks", () => {
+  it("accepts a link to an existing page", () => {
+    assert.deepEqual(check("/04-components/form-controls/rating"), []);
+  });
+
+  it("accepts a trailing slash and a query string", () => {
+    assert.deepEqual(check("/04-components/form-controls/rating/"), []);
+    assert.deepEqual(check("/04-components/form-controls/rating?tab=x"), []);
+  });
+
+  it("ignores external targets", () => {
+    for (const href of [
+      "https://example.com/nirgendwo",
+      "http://example.com",
+      "mailto:hallo@mittwald.de",
+    ]) {
+      assert.deepEqual(check(href), []);
+    }
+  });
+
+  it("reports an unknown page", () => {
+    const [problem] = check("/04-components/content/nirgendwo");
+
+    assert.equal(problem?.reason, "unknown-page");
+  });
+
+  it("suggests the page that kept its name when a page moved", () => {
+    const [problem] = check("/04-components/content/rating");
+
+    assert.deepEqual(problem?.suggestions, [
+      "/04-components/form-controls/rating",
+    ]);
+  });
+
+  it("suggests a renamed page by token overlap", () => {
+    const [problem] = check(
+      "/04-components/form-controls/form-react-hook-form",
+    );
+
+    assert.equal(
+      problem?.suggestions[0],
+      "/04-components/react-hook-form/form",
+    );
+  });
+
+  it("reports a link without a leading slash", () => {
+    const [problem] = check("04-components/form-controls/rating");
+
+    assert.equal(problem?.reason, "relative-link");
+  });
+
+  it("accepts a known anchor on another page", () => {
+    assert.deepEqual(
+      check("/02-foundations/01-design/02-colors#farben-light-und-dark"),
+      [],
+    );
+  });
+
+  it("reports an unknown anchor and lists what the page offers", () => {
+    const [problem] = check(
+      "/02-foundations/01-design/02-colors#gibt-es-nicht",
+    );
+
+    assert.equal(problem?.reason, "unknown-anchor");
+    assert.deepEqual(problem?.availableAnchors, ["farben-light-und-dark"]);
+  });
+
+  it("resolves a bare fragment against the page it sits on", () => {
+    assert.deepEqual(
+      check("#farben-light-und-dark", "/02-foundations/01-design/02-colors"),
+      [],
+    );
+    assert.equal(
+      check("#gibt-es-nicht", "/02-foundations/01-design/02-colors")[0]?.reason,
+      "unknown-anchor",
+    );
+  });
+
+  it("ignores a placeholder href and a fragment outside a page", () => {
+    assert.deepEqual(check("#"), []);
+    assert.deepEqual(check("#irgendwas"), []);
+  });
+
+  it("collects problems from every link", () => {
+    const problems = checkLinks(
+      [link("/gibt-es-nicht"), link("auch-nicht"), link("/")],
+      inventory,
+    );
+
+    assert.deepEqual(
+      problems.map((problem) => problem.reason),
+      ["unknown-page", "relative-link"],
+    );
+  });
+});

--- a/apps/docs/src/lib/links/checkLinks.ts
+++ b/apps/docs/src/lib/links/checkLinks.ts
@@ -1,0 +1,140 @@
+import type { FoundLink } from "@/lib/links/extractLinks";
+
+/** Every routable pathname of the site, mapped to the fragments it offers. */
+export type PageInventory = Map<string, Set<string>>;
+
+export type LinkProblemReason =
+  "relative-link" | "unknown-page" | "unknown-anchor";
+
+export interface LinkProblem extends FoundLink {
+  reason: LinkProblemReason;
+  /** Pages that plausibly replace an unknown one, best guess first. */
+  suggestions: string[];
+  /** Fragments the target page actually offers, for `unknown-anchor`. */
+  availableAnchors: string[];
+}
+
+/** Links the check has nothing to say about — external targets are class 4. */
+const IGNORED_PROTOCOL = /^(?:https?:|mailto:|tel:)/;
+
+const SUGGESTION_THRESHOLD = 0.5;
+const MAX_SUGGESTIONS = 3;
+
+const lastSegment = (pathname: string): string =>
+  pathname.split("/").filter(Boolean).at(-1) ?? "";
+
+const tokens = (pathname: string): Set<string> =>
+  new Set(pathname.split(/[/-]/).filter(Boolean));
+
+/** Share of tokens two pathnames have in common. */
+const overlap = (a: string, b: string): number => {
+  const [left, right] = [tokens(a), tokens(b)];
+  const shared = [...left].filter((token) => right.has(token)).length;
+  const union = new Set([...left, ...right]).size;
+
+  return union === 0 ? 0 : shared / union;
+};
+
+/**
+ * Ranks existing pages against a target that does not exist.
+ *
+ * A page that kept its last segment wins outright, and suppresses the weaker
+ * candidates: renaming a directory while keeping the page name is the move that
+ * breaks links here, so the last segment is exactly what survived. Only when
+ * nothing matches by name does token overlap guess at a renamed page.
+ */
+const suggestPages = (href: string, inventory: PageInventory): string[] => {
+  const pathnames = [...inventory.keys()];
+
+  const sameName = pathnames.filter(
+    (pathname) => lastSegment(pathname) === lastSegment(href),
+  );
+  if (sameName.length) {
+    return sameName.slice(0, MAX_SUGGESTIONS);
+  }
+
+  return pathnames
+    .map((pathname) => ({ pathname, score: overlap(pathname, href) }))
+    .filter(({ score }) => score >= SUGGESTION_THRESHOLD)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, MAX_SUGGESTIONS)
+    .map(({ pathname }) => pathname);
+};
+
+const normalizePathname = (pathname: string): string =>
+  pathname.length > 1 ? pathname.replace(/\/$/, "") : pathname;
+
+const problem = (
+  link: FoundLink,
+  reason: LinkProblemReason,
+  extra: Partial<Pick<LinkProblem, "suggestions" | "availableAnchors">> = {},
+): LinkProblem => ({
+  ...link,
+  reason,
+  suggestions: extra.suggestions ?? [],
+  availableAnchors: extra.availableAnchors ?? [],
+});
+
+const checkFragment = (
+  link: FoundLink,
+  fragment: string,
+  anchors: Set<string>,
+): LinkProblem[] =>
+  anchors.has(fragment)
+    ? []
+    : [
+        problem(link, "unknown-anchor", {
+          availableAnchors: [...anchors].sort(),
+        }),
+      ];
+
+const checkLink = (
+  link: FoundLink,
+  inventory: PageInventory,
+): LinkProblem[] => {
+  const { href } = link;
+
+  if (IGNORED_PROTOCOL.test(href)) {
+    return [];
+  }
+
+  if (href.startsWith("#")) {
+    const fragment = href.slice(1);
+    const anchors = link.page ? inventory.get(link.page) : undefined;
+
+    // `href="#"` is the standard placeholder in code examples, and a fragment
+    // in a file that renders no page of its own cannot be resolved.
+    if (!fragment || !anchors) {
+      return [];
+    }
+
+    return checkFragment(link, fragment, anchors);
+  }
+
+  if (!href.startsWith("/")) {
+    return [problem(link, "relative-link")];
+  }
+
+  const [target = "", fragment] = href.split("#");
+  const pathname = normalizePathname(target.split("?")[0] ?? "");
+  const anchors = inventory.get(pathname);
+
+  if (!anchors) {
+    return [
+      problem(link, "unknown-page", {
+        suggestions: suggestPages(pathname, inventory),
+      }),
+    ];
+  }
+
+  return fragment ? checkFragment(link, fragment, anchors) : [];
+};
+
+/**
+ * Validates internal links against the pages that exist. Pure: hand it links
+ * and an inventory, it tells you which links are broken.
+ */
+export const checkLinks = (
+  links: FoundLink[],
+  inventory: PageInventory,
+): LinkProblem[] => links.flatMap((link) => checkLink(link, inventory));

--- a/apps/docs/src/lib/links/contentLinks.test.ts
+++ b/apps/docs/src/lib/links/contentLinks.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { checkLinks } from "@/lib/links/checkLinks";
+import { formatProblems } from "@/lib/links/formatProblems";
+import { buildPageInventory, collectDocLinks } from "@/lib/links/scanDocs";
+
+describe("the documentation's internal links", () => {
+  const inventory = buildPageInventory();
+  const links = collectDocLinks();
+
+  it("scans the content and the app sources", () => {
+    assert.ok(inventory.size > 100, `only ${inventory.size} pages found`);
+    assert.ok(links.length > 400, `only ${links.length} links found`);
+  });
+
+  it("all resolve", () => {
+    const problems = checkLinks(links, inventory);
+
+    assert.equal(problems.length, 0, formatProblems(problems));
+  });
+});

--- a/apps/docs/src/lib/links/extractLinks.test.ts
+++ b/apps/docs/src/lib/links/extractLinks.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { extractMdxLinks, extractSourceLinks } from "@/lib/links/extractLinks";
+
+const hrefsOf = (source: string) =>
+  extractMdxLinks(source, "test.mdx").map((link) => link.href);
+
+describe("extractMdxLinks", () => {
+  it("finds a markdown link", () => {
+    assert.deepEqual(
+      hrefsOf("Siehe [Button](/04-components/actions/button)."),
+      ["/04-components/actions/button"],
+    );
+  });
+
+  it("finds a markdown link with a title", () => {
+    assert.deepEqual(hrefsOf('[Button](/actions/button "Der Button")'), [
+      "/actions/button",
+    ]);
+  });
+
+  it("finds several links on one line", () => {
+    assert.deepEqual(hrefsOf("[a](/a) und [b](/b)"), ["/a", "/b"]);
+  });
+
+  it("finds a JSX href", () => {
+    assert.deepEqual(
+      hrefsOf('<Link href="/02-foundations/themes">Themes</Link>'),
+      ["/02-foundations/themes"],
+    );
+  });
+
+  it("reports the line a link was found on", () => {
+    const [link] = extractMdxLinks("erste\n\n[a](/a)", "test.mdx");
+
+    assert.equal(link?.line, 3);
+  });
+
+  it("skips links inside a fenced code block", () => {
+    assert.deepEqual(
+      hrefsOf('Text\n\n```tsx\n<Link href="/nirgendwo" />\n```\n\n[a](/a)'),
+      ["/a"],
+    );
+  });
+
+  it("skips links inside inline code", () => {
+    assert.deepEqual(hrefsOf("`[a](/nirgendwo)` aber [b](/b)"), ["/b"]);
+  });
+
+  it("finds links in frontmatter", () => {
+    assert.deepEqual(
+      hrefsOf("---\ndeprecationNotice: Nutze [Alert](/status/alert).\n---\n"),
+      ["/status/alert"],
+    );
+  });
+
+  it("passes the page through to every link", () => {
+    const [link] = extractMdxLinks("[a](/a)", "test.mdx", "/my/page");
+
+    assert.equal(link?.page, "/my/page");
+  });
+});
+
+describe("extractSourceLinks", () => {
+  const hrefsOf = (source: string) =>
+    extractSourceLinks(source, "test.tsx").map((link) => link.href);
+
+  it("finds a JSX href", () => {
+    assert.deepEqual(hrefsOf('<Link href="/releases">Releases</Link>'), [
+      "/releases",
+    ]);
+  });
+
+  it("ignores markdown link syntax", () => {
+    // A `](…)` in a TS source is regex or string content, not navigation.
+    assert.deepEqual(hrefsOf('code.replace(/\\]\\(([^)]+)\\)/g, "[$1]")'), []);
+  });
+});

--- a/apps/docs/src/lib/links/extractLinks.ts
+++ b/apps/docs/src/lib/links/extractLinks.ts
@@ -1,0 +1,80 @@
+export interface FoundLink {
+  /** The raw link target, exactly as written. */
+  href: string;
+  /** Path of the file the link was found in, for the error message. */
+  file: string;
+  /** 1-based line number, for the error message. */
+  line: number;
+  /**
+   * Pathname of the page this file renders, if it renders one. Only set for
+   * content files — a bare `#fragment` can only be resolved against its own
+   * page.
+   */
+  page?: string;
+}
+
+const MARKDOWN_LINK = /\]\(\s*([^)\s]+)[^)]*\)/g;
+const JSX_HREF = /href=["']([^"']*)["']/g;
+const FENCE = /^\s*```/;
+const INLINE_CODE = /`[^`]*`/g;
+
+const extract = (
+  source: string,
+  file: string,
+  patterns: RegExp[],
+  page?: string,
+): FoundLink[] => {
+  const links: FoundLink[] = [];
+  let insideFence = false;
+
+  source.split("\n").forEach((rawLine, index) => {
+    if (FENCE.test(rawLine)) {
+      insideFence = !insideFence;
+      return;
+    }
+    if (insideFence) {
+      return;
+    }
+
+    const line = rawLine.replaceAll(INLINE_CODE, "");
+
+    for (const pattern of patterns) {
+      for (const match of line.matchAll(pattern)) {
+        links.push({ href: match[1] ?? "", file, line: index + 1, page });
+      }
+    }
+  });
+
+  return links;
+};
+
+/**
+ * Collects the links of an MDX page: markdown `[text](target)` and JSX
+ * `href="target"`.
+ *
+ * Fenced and inline code are stripped first. A link inside a code sample
+ * documents syntax, it does not navigate anywhere — reporting it would be a
+ * false positive, and a check that cries wolf gets switched off. Stripping
+ * happens line by line so the reported line numbers stay correct.
+ *
+ * Frontmatter is deliberately _not_ stripped: markdown links in frontmatter
+ * (such as a `deprecationNotice` pointing at the successor component) render as
+ * real links and are checked like any other.
+ */
+export const extractMdxLinks = (
+  source: string,
+  file: string,
+  page?: string,
+): FoundLink[] => extract(source, file, [MARKDOWN_LINK, JSX_HREF], page);
+
+/**
+ * Collects the hardcoded links of a TypeScript source file — `href="target"`
+ * only.
+ *
+ * Markdown link syntax is deliberately ignored here: in TS sources a `](…)` is
+ * regex or string content (a markdown _generator_, a replacement pattern),
+ * never a link that navigates. Matching it reported `$1` and `.*` as broken
+ * pages.
+ */
+export const extractSourceLinks = (source: string, file: string): FoundLink[] =>
+  extract(source, file, [JSX_HREF]);

--- a/apps/docs/src/lib/links/formatProblems.ts
+++ b/apps/docs/src/lib/links/formatProblems.ts
@@ -1,0 +1,29 @@
+import type { LinkProblem } from "@/lib/links/checkLinks";
+
+const describe = (problem: LinkProblem): string => {
+  switch (problem.reason) {
+    case "relative-link":
+      return 'relative link — internal links must start with "/"';
+    case "unknown-page":
+      return problem.suggestions.length
+        ? `unknown page — did you mean ${problem.suggestions.join(" or ")}?`
+        : "unknown page";
+    case "unknown-anchor":
+      return problem.availableAnchors.length
+        ? `unknown anchor — the page offers ${problem.availableAnchors.join(", ")}`
+        : "unknown anchor — the page has no anchors";
+  }
+};
+
+/**
+ * Renders every problem at once. Moving a page breaks a dozen links in one go,
+ * and those belong in a single CI run rather than one per fix.
+ */
+export const formatProblems = (problems: LinkProblem[]): string =>
+  [
+    `${problems.length} broken ${problems.length === 1 ? "link" : "links"}:`,
+    ...problems.map(
+      (problem) =>
+        `  ${problem.file}:${problem.line}  ${problem.href}\n    ${describe(problem)}`,
+    ),
+  ].join("\n");

--- a/apps/docs/src/lib/links/scanDocs.ts
+++ b/apps/docs/src/lib/links/scanDocs.ts
@@ -1,0 +1,92 @@
+import jetpack from "fs-jetpack";
+import * as path from "path";
+import { extractAnchors } from "@/lib/mdx/anchors";
+import type { PageInventory } from "@/lib/links/checkLinks";
+import type { FoundLink } from "@/lib/links/extractLinks";
+import { extractMdxLinks, extractSourceLinks } from "@/lib/links/extractLinks";
+
+const contentDir = "src/content";
+/** Directories holding the app's own code — scanned for hardcoded links. */
+const sourceDirs = ["src/app", "src/lib"];
+
+const componentsSection = "04-components";
+
+/**
+ * Routes kept as `redirect()` pages so links written before the component tabs
+ * were merged into one page keep working, fragments included.
+ */
+const legacyComponentTabs = ["overview", "guidelines", "develop"];
+
+const pathnameOf = (dir: string): string => (dir === "." ? "/" : `/${dir}`);
+
+const isDynamicRoute = (dir: string): boolean =>
+  dir.split("/").some((segment) => segment.startsWith("["));
+
+/**
+ * Every pathname the site serves, with the fragments each page offers.
+ *
+ * Content directories mirror the route structure one to one, so a single rule
+ * covers all four sections. `src/app` adds the routes that have no MDX behind
+ * them (the start page, the component index) — derived rather than listed by
+ * hand so a new static route does not silently fail the check.
+ */
+export const buildPageInventory = (): PageInventory => {
+  const inventory: PageInventory = new Map();
+
+  for (const file of jetpack.find(contentDir, { matching: "**/index.mdx" })) {
+    const dir = path.dirname(path.relative(contentDir, file));
+    const anchors = new Set(
+      extractAnchors(jetpack.read(file) ?? "").map((anchor) => anchor.slug),
+    );
+
+    inventory.set(pathnameOf(dir), anchors);
+
+    if (dir.startsWith(`${componentsSection}/`)) {
+      for (const tab of legacyComponentTabs) {
+        inventory.set(`${pathnameOf(dir)}/${tab}`, anchors);
+      }
+    }
+  }
+
+  for (const dir of sourceDirs) {
+    for (const file of jetpack.find(dir, { matching: "**/page.tsx" })) {
+      const routeDir = path.dirname(path.relative(dir, file));
+
+      if (isDynamicRoute(routeDir)) {
+        continue;
+      }
+      const pathname = pathnameOf(routeDir);
+
+      if (!inventory.has(pathname)) {
+        inventory.set(pathname, new Set());
+      }
+    }
+  }
+
+  return inventory;
+};
+
+/**
+ * Every link written in the documentation: the MDX content plus the hardcoded
+ * links in the app's own code (navigation, start page). Example files under
+ * `src/content` are code samples, not navigation, and stay out — as do test
+ * files, whose fixtures link to pages that deliberately do not exist.
+ */
+export const collectDocLinks = (): FoundLink[] => [
+  ...jetpack
+    .find(contentDir, { matching: "**/index.mdx" })
+    .flatMap((file) =>
+      extractMdxLinks(
+        jetpack.read(file) ?? "",
+        file,
+        pathnameOf(path.dirname(path.relative(contentDir, file))),
+      ),
+    ),
+  ...sourceDirs.flatMap((dir) =>
+    jetpack
+      .find(dir, {
+        matching: ["**/*.ts", "**/*.tsx", "!**/*.test.ts", "!**/*.test.tsx"],
+      })
+      .flatMap((file) => extractSourceLinks(jetpack.read(file) ?? "", file)),
+  ),
+];

--- a/apps/docs/src/lib/mdx/MdxFileFactory.ts
+++ b/apps/docs/src/lib/mdx/MdxFileFactory.ts
@@ -10,8 +10,8 @@ import type {
 import { MdxFile } from "@/lib/mdx/MdxFile";
 import type { Metadata } from "next";
 import remarkGfm from "remark-gfm";
-import slugify from "slugify";
 import { absoluteUrl, pagePath, rawMarkdownPath } from "@/lib/llms/siteUrls";
+import { extractAnchors } from "@/lib/mdx/anchors";
 
 export class MdxFileFactory {
   public static async fromDir(
@@ -110,34 +110,7 @@ export class MdxFileFactory {
       throw new Error(`Could not read file: ${filename}`);
     }
 
-    let currentH1: string;
-
-    return fileContent
-      .split("\n")
-      .filter((line) => line.startsWith("# ") || line.startsWith("## "))
-      .map((line) => {
-        if (line.startsWith("# ")) {
-          const text = line.substring(2).trim().replaceAll(".", "");
-          currentH1 = text;
-
-          return {
-            slug: slugify(text, { lower: true, strict: true }),
-            text,
-            level: 2,
-          };
-        }
-
-        const h2Text = line.substring(3).trim();
-
-        return {
-          slug: slugify(currentH1 ? `${currentH1}-${h2Text}` : h2Text, {
-            lower: true,
-            strict: true,
-          }),
-          text: h2Text,
-          level: 3,
-        };
-      });
+    return extractAnchors(fileContent);
   }
 
   private static async getMdxSource(

--- a/apps/docs/src/lib/mdx/anchors.test.ts
+++ b/apps/docs/src/lib/mdx/anchors.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { extractAnchors } from "@/lib/mdx/anchors";
+
+describe("extractAnchors", () => {
+  it("slugifies an h1", () => {
+    assert.deepEqual(extractAnchors("# Light und Dark"), [
+      { slug: "light-und-dark", text: "Light und Dark", level: 2 },
+    ]);
+  });
+
+  it("nests an h2 under the preceding h1", () => {
+    const [, h2] = extractAnchors("# Farben\n\n## Light und Dark Color");
+
+    assert.deepEqual(h2, {
+      slug: "farben-light-und-dark-color",
+      text: "Light und Dark Color",
+      level: 3,
+    });
+  });
+
+  it("drops dots from an h1 before slugifying", () => {
+    const [h1] = extractAnchors("# Version 1.0 Notes");
+
+    assert.equal(h1?.slug, "version-10-notes");
+  });
+
+  it("keeps an h2 without a preceding h1 standalone", () => {
+    const [h2] = extractAnchors("## Ohne Überschrift");
+
+    assert.equal(h2?.slug, "ohne-uberschrift");
+  });
+
+  it("ignores deeper headings and prose", () => {
+    assert.deepEqual(
+      extractAnchors("### Zu tief\n\nEin Satz mit # in der Mitte").length,
+      0,
+    );
+  });
+});

--- a/apps/docs/src/lib/mdx/anchors.ts
+++ b/apps/docs/src/lib/mdx/anchors.ts
@@ -1,0 +1,43 @@
+import slugify from "slugify";
+import type { Anchor } from "@/lib/mdx/MdxFile";
+
+/**
+ * Turns heading text into the URL fragment the rendered page uses. Kept in one
+ * place because both the page (via `MdxFileFactory`/`AnchorLinkHeading`) and
+ * the link check derive fragments from it — two implementations would drift and
+ * the check would start validating against anchors that never render.
+ */
+export const anchorSlug = (text: string): string =>
+  slugify(text, { lower: true, strict: true });
+
+/**
+ * Extracts the anchors of an MDX page. An `## h2` is nested under the preceding
+ * `# h1`, so its fragment combines both texts.
+ */
+export const extractAnchors = (fileContent: string): Anchor[] => {
+  let currentH1: string;
+
+  return fileContent
+    .split("\n")
+    .filter((line) => line.startsWith("# ") || line.startsWith("## "))
+    .map((line) => {
+      if (line.startsWith("# ")) {
+        const text = line.substring(2).trim().replaceAll(".", "");
+        currentH1 = text;
+
+        return {
+          slug: anchorSlug(text),
+          text,
+          level: 2,
+        };
+      }
+
+      const h2Text = line.substring(3).trim();
+
+      return {
+        slug: anchorSlug(currentH1 ? `${currentH1}-${h2Text}` : h2Text),
+        text: h2Text,
+        level: 3,
+      };
+    });
+};

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "node": ">=24.0.0"
   },
   "scripts": {
-    "affected:test": "nx affected --targets=test:unit,test:compile",
+    "affected:test": "nx affected --targets=test:unit,test:compile,test:links",
     "affected:test:browser": "nx affected --targets=test:browser,test:e2e,test:visual",
     "build": "nx run-many --targets=build --exclude docs",
     "clean": "nx reset",
@@ -22,7 +22,7 @@
     "lint": "eslint . && stylelint '**/*.{css,scss}' && pnpm format:check",
     "prepare": "node .github/scripts/init-merge-drivers.cjs",
     "sync:resolve": "node .github/scripts/sync-resolve.cjs",
-    "test": "nx run-many --targets=test:unit,test:compile",
+    "test": "nx run-many --targets=test:unit,test:compile,test:links",
     "test:browser": "nx run-many --targets=test:browser,test:e2e,test:visual",
     "test:browser:prepare": "pnpm exec playwright install --with-deps firefox webkit",
     "test:visual": "nx run-many --targets=test:visual",


### PR DESCRIPTION
## What & why

The docs site had **no link checking at all** — no workflow, no remark-lint, no
crawler, and `apps/docs` had no test target. 5 of its ~525 internal links were
already dead, one of them a page that moved from `content/rating` to
`form-controls/rating`. Moves and renames are the failure mode here, not typos.

The one build-time guard that existed, `resolveReplacedBy`, disappears with the
deprecation-notice rework, which is what made this urgent.

`pnpm nx test:links docs` now validates every `/pathname` and `#anchor` in the
MDX content **and** in the app's own sources against the pages that exist. It is
wired into the root `test` / `affected:test` scripts, so it runs in the PR gate
that already exists. No network, no new dependency, ~0.3s.

```
5 broken links:
  src/content/04-components/data-visualisation/big-number/index.mdx:22  /04-components/content/rating
    unknown page — did you mean /04-components/form-controls/rating?
  src/content/02-foundations/.../02-informationskonzept/index.mdx:79  04-components/status/notification-provider
    relative link — internal links must start with "/"
```

### How it works

| File | Role |
| --- | --- |
| `src/lib/mdx/anchors.ts` | `extractAnchors`, pulled out of `MdxFileFactory` so page and check share one slug implementation |
| `src/lib/links/extractLinks.ts` | `extractMdxLinks` (markdown + JSX) and `extractSourceLinks` (JSX only), pure |
| `src/lib/links/checkLinks.ts` | the rules and the "did you mean" ranking, pure |
| `src/lib/links/scanDocs.ts` | the only `fs` access: page inventory and link collection |
| `src/lib/links/formatProblems.ts` | every problem in one message |

- **The page inventory is derived, not listed.** Every `src/content/**/index.mdx`
  directory *is* its pathname — content mirrors routing 1:1 across all four
  sections and `/releases`. `src/app/**/page.tsx` without a dynamic segment adds
  the routes that have no MDX behind them (`/`, `/04-components`), so a new
  static route cannot silently escape the check. Component pages also accept the
  legacy `overview|guidelines|develop` redirect routes.
- **Markdown link syntax is extracted from MDX only.** In a TS source a `](…)` is
  regex or string content — a markdown *generator*, a replacement pattern — and
  matching it reported `$1` and `.*` as broken pages. `.ts`/`.tsx` therefore
  contribute `href="…"` only, and `*.test.ts` is skipped entirely (fixtures link
  to pages that must not exist). This was the difference between 21 findings and
  the 5 real ones.
- Fenced and inline code are stripped before matching, line by line so reported
  line numbers stay correct. **Frontmatter is deliberately kept**: once
  `deprecationNotice` becomes markdown, its inline successor link is checked like
  any other. That is how this replaces what `resolveReplacedBy` guarded — one
  field before, all ~525 links now.
- For an unknown page, a candidate that kept its **last segment** wins outright
  and suppresses the weaker guesses: that is exactly what survives a directory
  rename.

**Out of scope:** the 24 external URLs (network flake does not belong in a PR
gate — a separate scheduled job is the right home), orphan-page detection, and
anchors on React-only routes.

### Two things a reviewer should know

**1. This merge triggers a release, for nothing.** `test:links` had to go into the
root `test` / `affected:test` scripts, and root `package.json` is deliberately
*not* in the denylist of `.github/scripts/release-relevance-lib.mjs` (a
dependency or build-wiring change there can move built output). So this
docs-only change classifies as publish-relevant and will produce one needless
patch version. The alternative was naming the target `test:unit` — which would
have needed no root change, but would promise something the check does not do.
Deliberate trade; say the word if you'd rather have it the other way.

**2. `AlertIcon` is de-linked, not repointed.** The component ships, but it has no
docs page at all. Writing one is its own change; the dead link had to go for the
check to start green.

### Verification

- 30 tests green: the rules, the extractors, the anchor slugs, plus one guard
  test over the real content and app sources.
- The `extractAnchors` move is **byte-identical** to the previous implementation
  across all 113 pages / 806 anchors (checked by diffing both implementations).
- Mutation-checked: a simulated page move and a dead anchor are both reported.
- nx cache hits on a repeat run and is invalidated by a content change.

## Base branch & title

`test(docs): …` on `main` — a test/tooling change, not a feature.

## Checklist

- [x] PR title is a Conventional Commit and matches the base branch above
- [x] `pnpm lint` is clean — enforced by the `pre-push` hook on this push
- [x] `pnpm nx test:links docs` and `nx run-many --targets=test:links` pass.
      The full `pnpm affected:test` was **not** run locally (it would build the
      component library in this worktree); CI covers it. No rendered behavior
      changed, so no browser tests.
- [x] No generators touched — `git diff` is empty
- [ ] n/a — no user-facing strings
- [x] `apps/docs/AGENTS.md` documents the check; no public API changed, no visual
      change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
