### PR TITLE
docs(AlertIcon): add the missing Component page

### DIFF
--- a/apps/docs/src/content/04-components/navigation/tab-navigation/index.mdx
+++ b/apps/docs/src/content/04-components/navigation/tab-navigation/index.mdx
@@ -49,8 +49,9 @@ dargestellt.
 
 # Mit Status-Icons
 
-Innerhalb der Links kann ein `AlertIcon` verwendet werden, um auf Zustände
-innerhalb eines Navigationsbereichs hinzuweisen.
+Innerhalb der Links kann ein [AlertIcon](/04-components/status/alert-icon)
+verwendet werden, um auf Zustände innerhalb eines Navigationsbereichs
+hinzuweisen.
 
 <LiveCodeEditor example="status" editorCollapsed stretch />
 

--- a/apps/docs/src/content/04-components/status/alert-icon/examples/default.tsx
+++ b/apps/docs/src/content/04-components/status/alert-icon/examples/default.tsx
@@ -1,0 +1,3 @@
+import { AlertIcon } from "@mittwald/flow-react-components";
+
+<AlertIcon status="warning" />;

--- a/apps/docs/src/content/04-components/status/alert-icon/examples/sizes.tsx
+++ b/apps/docs/src/content/04-components/status/alert-icon/examples/sizes.tsx
@@ -1,0 +1,7 @@
+import { AlertIcon } from "@mittwald/flow-react-components";
+
+<>
+  <AlertIcon status="warning" size="s" />
+  <AlertIcon status="warning" size="m" />
+  <AlertIcon status="warning" size="l" />
+</>;

--- a/apps/docs/src/content/04-components/status/alert-icon/examples/status.tsx
+++ b/apps/docs/src/content/04-components/status/alert-icon/examples/status.tsx
@@ -1,0 +1,9 @@
+import { AlertIcon } from "@mittwald/flow-react-components";
+
+<>
+  <AlertIcon status="info" />
+  <AlertIcon status="warning" />
+  <AlertIcon status="danger" />
+  <AlertIcon status="success" />
+  <AlertIcon status="unavailable" />
+</>;

--- a/apps/docs/src/content/04-components/status/alert-icon/examples/tab-navigation.tsx
+++ b/apps/docs/src/content/04-components/status/alert-icon/examples/tab-navigation.tsx
@@ -1,0 +1,16 @@
+import {
+  AlertIcon,
+  Link,
+  TabNavigation,
+} from "@mittwald/flow-react-components";
+
+<TabNavigation aria-label="Projekt-Navigation">
+  <Link href="#" aria-current="page">
+    Dashboard
+  </Link>
+  <Link href="#">
+    Speicherplatz
+    <AlertIcon status="danger" />
+  </Link>
+  <Link href="#">Backups</Link>
+</TabNavigation>;

--- a/apps/docs/src/content/04-components/status/alert-icon/index.mdx
+++ b/apps/docs/src/content/04-components/status/alert-icon/index.mdx
@@ -1,0 +1,97 @@
+---
+component: AlertIcon
+description:
+  Ein AlertIcon weist als reines Status-Icon auf einen Zustand hin, ohne ihn zu
+  benennen.
+---
+
+<LiveCodeEditor />
+
+---
+
+# Best Practices
+
+- Wähle den Status passend zur Bedeutung des Zustands. Welcher Status wofür
+  steht, beschreibt das
+  [Informationskonzept](/02-foundations/03-content-guidelines/02-informationskonzept).
+- Setze ein AlertIcon dort ein, wo ein Status sonst verborgen bliebe, zum
+  Beispiel in einem Tab einer TabNavigation.
+- Erläutere den Zustand an der Stelle, auf die das AlertIcon verweist, etwa mit
+  einem [Alert](/04-components/status/alert). Das Icon allein benennt weder
+  Ursache noch Handlungsmöglichkeit.
+- Zeige bei konkurrierenden Status nur den handlungsentscheidenden an. Ein
+  Danger überschreibt Warning und Info.
+- Verzichte innerhalb von [Alert](/04-components/status/alert),
+  [AlertBadge](/04-components/status/alert-badge),
+  [AlertText](/04-components/status/alert-text) und
+  [Notification](/04-components/status/notification) auf ein zusätzliches
+  AlertIcon. Diese Components zeigen das Status-Icon bereits selbst an.
+
+## AlertIcon vs. AlertBadge
+
+Beide machen den Status eines Elements sichtbar. Der Unterschied liegt darin, ob
+der Status benannt wird: Das AlertIcon deutet ihn an, das
+[AlertBadge](/04-components/status/alert-badge) beschriftet ihn.
+
+<DoAndDont>
+  <Plain heading="Verwende ein AlertIcon, wenn z. B. ...">
+    - der Status nur angedeutet werden soll, um auf einen Bereich zu verweisen.
+    - der Platz für eine Beschriftung nicht ausreicht.
+
+  </Plain>
+
+  <Plain heading="Verwende ein AlertBadge, wenn z. B. ...">
+    - der Status ohne weiteren Kontext verständlich sein soll.
+    - er in einem Heading oder einem List-Eintrag benannt wird.
+
+  </Plain>
+</DoAndDont>
+
+---
+
+# Status
+
+Je nach Anwendungsfall stehen verschiedene Status-Farben zur Auswahl:
+
+- **Info** – Allgemeine Systemzustände oder laufende Prozesse, die keine Aktion
+  erfordern.
+- **Warning** – Hinweise auf mögliche Risiken mit einer klaren
+  Handlungsempfehlung.
+- **Danger** – Akute Fehlerzustände oder kritische Probleme, die sofortige
+  Aufmerksamkeit erfordern.
+- **Success** – Abgeschlossene, erfolgreiche oder positiv bewertete Zustände.
+- **Unavailable** – Zustände aufgrund von nicht verfügbaren oder gelöschten
+  Inhalten.
+
+<LiveCodeEditor example="status" editorCollapsed row />
+
+Zu jedem Status wird automatisch ein lokalisiertes `aria-label` gesetzt, das den
+Status benennt. Ein eigenes `aria-label` ersetzt diesen Text.
+
+---
+
+# Sizes
+
+- **s** für kleine Hinweise oder Components mit wenig Platz.
+- **m** als Standardgröße.
+- **l** vor allem für dekorative Zwecke.
+
+<LiveCodeEditor example="sizes" editorCollapsed row />
+
+---
+
+# Kombiniere mit ...
+
+## TabNavigation
+
+Platziere ein AlertIcon in einem Link der
+[TabNavigation](/04-components/navigation/tab-navigation), um auf einen Zustand
+innerhalb eines Navigationsbereichs hinzuweisen.
+
+<LiveCodeEditor example="tab-navigation" editorCollapsed stretch />
+
+---
+
+# Properties
+
+<PropertiesTables />


### PR DESCRIPTION
AlertIcon had no Styleguide page, while its siblings [Alert](https://flow.mittwald.de/04-components/status/alert), [AlertBadge](https://flow.mittwald.de/04-components/status/alert-badge) and [AlertText](https://flow.mittwald.de/04-components/status/alert-text) all have one. The gap cost a cross-reference: the AlertIcon link on the TabNavigation page pointed nowhere and was de-linked to inline code in #2957, when the docs link check surfaced it.

## What changed

- **New page** `apps/docs/src/content/04-components/status/alert-icon/index.mdx`, following the fixed spine — default example, `# Best Practices`, the shared visual axes (`# Status`, `# Sizes`), `# Kombiniere mit ...`, `# Properties`.
- **Four examples** (`default`, `status`, `sizes`, `tab-navigation`) with mittwald-domain content.
- **Link restored** in `tab-navigation/index.mdx:52` — an exact revert of the de-link from #2957.

## Content decisions

- **Best Practices** name the rules that exist only for this Component: the icon alone states neither cause nor remedy, so the state is explained where the icon points to; only the decision-relevant status is shown when several compete; and Alert, AlertBadge, AlertText and Notification already render their own status icon, so a second one is wrong inside them (verified in the component sources).
- **`## AlertIcon vs. AlertBadge`** is the one legitimate `<DoAndDont>` case per the content guidelines: the pair differs in whether the status is *named* — a real choice, not a visual one.
- **The automatic, localized `aria-label`** is documented as automatic behaviour in the `# Status` section, next to what it describes, rather than in a separate accessibility block.

## Verification

- Rendered against `pnpm nx dev docs`: the page returns 200, all four live examples render (the icons carry their automatic `aria-label`s), the properties table resolves `status`/`size`/`color`, and AlertIcon now appears in the sidebar navigation and on the component overview. The TabNavigation page emits `href="/04-components/status/alert-icon"`.
- Prettier clean (80-char prose, 60-char examples).

## Note for the reviewer

`pnpm nx test:links docs` does not exist on `main` yet — the link check is still unmerged work on another branch. I ran it here by copying `src/lib/links/` and `src/lib/mdx/anchors.ts` in temporarily and executing the test with `tsx`, then removed the copies (nothing of it is in this diff). Result: the AlertIcon link resolves. The only remaining break is the pre-existing missing leading slash on `04-components/status/notification-provider` in `02-informationskonzept/index.mdx:78` — already fixed on that same unmerged branch, so I left it alone here rather than duplicating the fix.

Optional follow-up, not done here: the Informationskonzept's „Status-Icon" section still links to the icon library rather than to the new AlertIcon page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)