### PR TITLE
docs: correct the component page structure in apps/docs/AGENTS.md

### DIFF
--- a/apps/docs/AGENTS.md
+++ b/apps/docs/AGENTS.md
@@ -5,12 +5,14 @@ Next.js documentation site for the flow Styleguide, deployed to
 
 - **Before writing or changing any Styleguide content, read
   [README.md](README.md)** — it is the canonical content guideline and defines
-  the section and tab structures, heading conventions, tone of voice, and
+  the section and page structures, heading conventions, tone of voice, and
   language rules (German content, English Design System terminology).
 - Content lives in `src/content` as MDX, one directory per section
-  (`01-get-started`, `02-foundations`, `03-patterns`, `04-components`).
-  Component pages consist of `index.mdx`, `overview.mdx`, `develop.mdx`, and
-  `guidelines.mdx`.
+  (`01-get-started`, `02-foundations`, `03-patterns`, `04-components`). A
+  component page is a single `index.mdx` — the former `overview`, `develop` and
+  `guidelines` tabs are consolidated onto it. Their routes under
+  `src/app/04-components/[group]/[component]/` are `redirect()`-only, kept so
+  existing links (and their fragments) keep working.
 - Code examples are `.tsx` files in the `examples/` directory next to the MDX
   file, referenced via `example="<name>"` (see "Page Building Blocks" in the
   README).


### PR DESCRIPTION
## What & why

`apps/docs/AGENTS.md` claimed component pages consist of `index.mdx`, `overview.mdx`, `develop.mdx` and `guidelines.mdx`. Stale: the tabs were consolidated onto the base page. A component page is a single `index.mdx`, and the three tab routes under `src/app/04-components/[group]/[component]/` are `redirect()`-only, kept so existing links (and their URL fragments) keep working.

Two edits, both in `apps/docs/AGENTS.md`:

- The four-file bullet now states the single-`index.mdx` structure, names the consolidated tabs, and records why the redirect routes still exist.
- The README pointer loses "tab structures" — the README no longer defines one for component pages.

`apps/docs/README.md` needed no change. It already describes the current state (`README.md:91`: "A page is a **single** `index.mdx` file — one continuous page … Earlier the content was split across three tabs … these are consolidated into `index.mdx`"). Its remaining `tab` matches are unrelated: `PropertiesTables`, the rules for condensing the older three-tab content, and `Tabs → TabNavigation` terminology.

## Base branch & title

`docs:` → base `main`.

## Checklist

- [x] PR title is a Conventional Commit and matches the base branch above
- [x] `pnpm lint` is clean and `pnpm affected:test` passes (browser tests if
      behavior changed) — prose-only change; verified with `pnpm exec prettier --check apps/docs/AGENTS.md`
- [x] **Generated code is committed** — no generators touched
- [x] User-facing strings added to **both** `de-DE` and `en-US` locale files — n/a
- [x] Docs updated if a public API changed; intentional visual changes get
      updated snapshots / the `update-screenshots` label — n/a, no rendered output changes

Verified against the code: all three `page.tsx` files under `src/app/04-components/[group]/[component]/{overview,guidelines,develop}/` are `redirect()` to the component's base page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)