### PR TITLE
fix(Form): stop a Modal's form submit from reaching the surrounding Form

### DIFF
--- a/packages/remote-react-components/src/tests/NestedFormSubmit.browser.test.tsx
+++ b/packages/remote-react-components/src/tests/NestedFormSubmit.browser.test.tsx
@@ -1,0 +1,176 @@
+import * as RemoteComponents from "@/index";
+import * as RemoteReactHookForm from "@/integrations/react-hook-form";
+import { renderLocal, renderRemote } from "@/tests/lib/environments";
+import { sleep } from "@/tests/lib/sleep";
+import * as LocalComponents from "@mittwald/flow-react-components";
+import * as LocalReactHookForm from "@mittwald/flow-react-components/react-hook-form";
+import { useForm } from "react-hook-form";
+import { expect, test, vi } from "vitest";
+import { page } from "vitest/browser";
+
+/*
+ * A Modal renders through a portal, and React propagates synthetic events
+ * through portals along the React tree. So the submit of a Form inside a Modal
+ * reaches the Form the Modal is nested in, and the surrounding form submits as
+ * well (#2975).
+ *
+ * The Form of `@mittwald/flow-react-components` stops that propagation itself,
+ * which is why this only ever showed remotely: the remote Form receives a
+ * remote event without a `nativeEvent`, so its guard never runs. The host-side
+ * <form> of the renderer is what has to stop it, hence the assertions here are
+ * on the callbacks reaching the remote side, not on the rendered output.
+ */
+
+/** The renderer sends its submit over the connection — give it a roundtrip. */
+const waitForALateSubmit = () => sleep(300);
+
+const environments = [
+  {
+    toString: () => "Local",
+    render: renderLocal,
+    components: { ...LocalComponents, ...LocalReactHookForm },
+  },
+  {
+    toString: () => "Remote",
+    render: renderRemote,
+    components: { ...RemoteComponents, ...RemoteReactHookForm },
+  },
+] as const;
+
+type Components = (typeof environments)[number]["components"];
+
+interface NestedFormProps {
+  components: Components;
+  onOuterSubmit: () => void;
+  onInnerSubmit: () => void;
+}
+
+const NestedForm = (props: NestedFormProps) => {
+  const { onOuterSubmit, onInnerSubmit } = props;
+  const {
+    ActionGroup,
+    Button,
+    Content,
+    Field,
+    Form,
+    Label,
+    Modal,
+    ModalTrigger,
+    TextField,
+  } = props.components;
+
+  const outerForm = useForm({ defaultValues: { user: "" } });
+  const innerForm = useForm({ defaultValues: { username: "" } });
+
+  return (
+    <Form form={outerForm} onSubmit={onOuterSubmit}>
+      <Field name="user">
+        <TextField>
+          <Label>User</Label>
+        </TextField>
+      </Field>
+
+      <ModalTrigger>
+        <Button data-testid="open">Create user</Button>
+        <Modal>
+          <Content>
+            <Form form={innerForm} onSubmit={onInnerSubmit}>
+              <Field name="username" rules={{ required: true }}>
+                <TextField>
+                  <Label>Username</Label>
+                </TextField>
+              </Field>
+              <ActionGroup>
+                <Button type="submit" data-testid="save">
+                  Save
+                </Button>
+              </ActionGroup>
+            </Form>
+          </Content>
+        </Modal>
+      </ModalTrigger>
+    </Form>
+  );
+};
+
+test.each(environments)(
+  "a Form submitted inside a Modal does not submit the Form around it (%s)",
+  async ({ render, components }) => {
+    const onOuterSubmit = vi.fn();
+    const onInnerSubmit = vi.fn();
+
+    await render(
+      <NestedForm
+        components={components}
+        onOuterSubmit={onOuterSubmit}
+        onInnerSubmit={onInnerSubmit}
+      />,
+    );
+
+    await page.getByTestId("open").click();
+    await page.getByLabelText("Username").fill("someone");
+    await page.getByTestId("save").click();
+
+    await expect.poll(() => onInnerSubmit).toHaveBeenCalledTimes(1);
+    await waitForALateSubmit();
+    expect(onOuterSubmit).not.toHaveBeenCalled();
+  },
+);
+
+/*
+ * The plain Form is remote-only. It reaches the same host-side <form> through
+ * the second renderer component, and its `action` runs without an onSubmit
+ * handler at all — the case that decides whether the guard can be attached
+ * next to `preventDefault()`.
+ */
+test("a plain Form action inside a Modal does not submit the Form around it", async () => {
+  const {
+    Button,
+    Content,
+    Form: PlainForm,
+    Label,
+    Modal,
+    ModalTrigger,
+    TextField,
+  } = RemoteComponents;
+  const { Field, Form } = RemoteReactHookForm;
+
+  const onOuterSubmit = vi.fn();
+  const onInnerAction = vi.fn();
+
+  const Scenario = () => {
+    const outerForm = useForm({ defaultValues: { user: "" } });
+
+    return (
+      <Form form={outerForm} onSubmit={onOuterSubmit}>
+        <Field name="user">
+          <TextField>
+            <Label>User</Label>
+          </TextField>
+        </Field>
+
+        <ModalTrigger>
+          <Button data-testid="open">Create user</Button>
+          <Modal>
+            <Content>
+              <PlainForm action={onInnerAction}>
+                <Button type="submit" data-testid="save">
+                  Save
+                </Button>
+              </PlainForm>
+            </Content>
+          </Modal>
+        </ModalTrigger>
+      </Form>
+    );
+  };
+
+  await renderRemote(<Scenario />);
+
+  await page.getByTestId("open").click();
+  await page.getByTestId("save").click();
+
+  await expect.poll(() => onInnerAction).toHaveBeenCalledTimes(1);
+  await waitForALateSubmit();
+  expect(onOuterSubmit).not.toHaveBeenCalled();
+});

--- a/packages/remote-react-renderer/src/components/Form.tsx
+++ b/packages/remote-react-renderer/src/components/Form.tsx
@@ -21,10 +21,9 @@ export const Form: FC<FormProps> = (props) => {
 
   const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
     /*
-     * React propagates synthetic events through portals along the React tree,
-     * so a Modal rendered inside a Form carries this submit up to that Form's
-     * onSubmit — which would submit the surrounding form as well (#2975). This
-     * runs for an action-only form too, hence the handler is always attached.
+     * React events bubble through portals, so a submit inside a Modal would
+     * reach the Form the Modal sits in and submit it too (#2975). An
+     * action-only form needs that guard as well, so the handler always runs.
      */
     event.stopPropagation();
 

--- a/packages/remote-react-renderer/src/components/Form.tsx
+++ b/packages/remote-react-renderer/src/components/Form.tsx
@@ -20,8 +20,19 @@ export const Form: FC<FormProps> = (props) => {
   } = props;
 
   const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    /*
+     * React propagates synthetic events through portals along the React tree,
+     * so a Modal rendered inside a Form carries this submit up to that Form's
+     * onSubmit — which would submit the surrounding form as well (#2975). This
+     * runs for an action-only form too, hence the handler is always attached.
+     */
+    event.stopPropagation();
+
+    if (!onSubmitFromProps) {
+      return;
+    }
     event.preventDefault();
-    await onSubmitFromProps?.(new FormData(event.currentTarget));
+    await onSubmitFromProps(new FormData(event.currentTarget));
   };
 
   const onAction = async (formData: FormData) => {
@@ -33,7 +44,7 @@ export const Form: FC<FormProps> = (props) => {
       {...rest}
       ref={ref}
       action={onActionFromProps ? onAction : undefined}
-      onSubmit={onSubmitFromProps ? onSubmit : undefined}
+      onSubmit={onSubmit}
     />
   );
 };

--- a/packages/remote-react-renderer/src/components/Form.tsx
+++ b/packages/remote-react-renderer/src/components/Form.tsx
@@ -22,8 +22,8 @@ export const Form: FC<FormProps> = (props) => {
   const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
     /*
      * React events bubble through portals, so a submit inside a Modal would
-     * reach the Form the Modal sits in and submit it too (#2975). An
-     * action-only form needs that guard as well, so the handler always runs.
+     * reach the Form the Modal sits in and submit it too. An action-only form
+     * needs that guard as well, so the handler always runs.
      */
     event.stopPropagation();
 

--- a/packages/remote-react-renderer/src/integrations/react-hook-form/Form.tsx
+++ b/packages/remote-react-renderer/src/integrations/react-hook-form/Form.tsx
@@ -21,11 +21,9 @@ export const Form: FC<FormProps> = (props) => {
   const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     /*
-     * React propagates synthetic events through portals along the React tree,
-     * so a Modal rendered inside a Form carries this submit up to that Form's
-     * onSubmit — which would submit the surrounding form as well (#2975). The
-     * remote Form's own guard cannot do this: the submit it receives is a
-     * remote event without a nativeEvent.
+     * React events bubble through portals, so a submit inside a Modal would
+     * reach the Form the Modal sits in and submit it too (#2975). The remote
+     * Form cannot stop that itself — its submit has no nativeEvent.
      */
     event.stopPropagation();
     await onSubmitFromProps?.();

--- a/packages/remote-react-renderer/src/integrations/react-hook-form/Form.tsx
+++ b/packages/remote-react-renderer/src/integrations/react-hook-form/Form.tsx
@@ -22,8 +22,8 @@ export const Form: FC<FormProps> = (props) => {
     event.preventDefault();
     /*
      * React events bubble through portals, so a submit inside a Modal would
-     * reach the Form the Modal sits in and submit it too (#2975). The remote
-     * Form cannot stop that itself — its submit has no nativeEvent.
+     * reach the Form the Modal sits in and submit it too. The remote Form
+     * cannot stop that itself — its submit has no nativeEvent.
      */
     event.stopPropagation();
     await onSubmitFromProps?.();

--- a/packages/remote-react-renderer/src/integrations/react-hook-form/Form.tsx
+++ b/packages/remote-react-renderer/src/integrations/react-hook-form/Form.tsx
@@ -20,6 +20,14 @@ export const Form: FC<FormProps> = (props) => {
 
   const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    /*
+     * React propagates synthetic events through portals along the React tree,
+     * so a Modal rendered inside a Form carries this submit up to that Form's
+     * onSubmit — which would submit the surrounding form as well (#2975). The
+     * remote Form's own guard cannot do this: the submit it receives is a
+     * remote event without a nativeEvent.
+     */
+    event.stopPropagation();
     await onSubmitFromProps?.();
   };
 


### PR DESCRIPTION
Closes #2975

A Modal renders through a portal, and React propagates synthetic events through portals along the React tree. So the submit of a `Form` inside a `Modal` reached the `Form` the `Modal` is nested in, and that form submitted too — running its validation behind the open Modal.

The host-side `<form>` of the renderer only called `preventDefault()`, so it now stops propagation as well. The `Form` of `flow-react-components` already guards this itself, which is why it only showed remotely: the remote `Form` receives a remote event without a `nativeEvent`, so its guard never runs.

For the plain `Form` the guard is attached even without an `onSubmit` handler. Its `action` did not run at all in this constellation: the surrounding form's `preventDefault()` cancelled the submit before React dispatched the action.

`src/tests/NestedFormSubmit.browser.test.tsx` covers both, the react-hook-form case in the `Local` and `Remote` environment. Without the fix both remote tests fail; `Local` passes either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)