### PR TITLE
fix(ci): exempt a package's first publish from the version contract

### DIFF
--- a/.github/scripts/version-contract-lib.mjs
+++ b/.github/scripts/version-contract-lib.mjs
@@ -178,6 +178,12 @@ export function collectFindings(packages) {
   for (const { name, base, head } of packages) {
     if (!isPublishable(head)) continue; // not a consumer-facing Flow package
     if (!base) continue; // new package: no prior contract to break
+    // Private at the base means it has never been published, so there is no
+    // consumer and no prior contract either. Its first publish *establishes*
+    // the floor and the peer ranges; it cannot tighten them. Without this, going
+    // `private: true` -> public reads as `(none) -> >=24.0.0` and the guard
+    // demands a breaking marker for a package nobody could have installed.
+    if (!isPublishable(base)) continue;
 
     const oldNode = base.engines?.node ?? null;
     const newNode = head.engines?.node ?? null;

--- a/.github/scripts/version-contract-lib.test.mjs
+++ b/.github/scripts/version-contract-lib.test.mjs
@@ -206,3 +206,38 @@ test("collectFindings: unparseable peer change → fail-closed finding", () => {
   assert.equal(findings.length, 1);
   assert.equal(findings[0].kind, "unparseable");
 });
+
+test("collectFindings: a package's first publish establishes the contract, not a tightening", () => {
+  const packages = [
+    {
+      name: "@mittwald/flow-codemods",
+      // Private, so never published: no floor, no peers, no consumers.
+      base: { name: "@mittwald/flow-codemods", private: true },
+      head: {
+        name: "@mittwald/flow-codemods",
+        engines: { node: ">=24.0.0" },
+        peerDependencies: { react: "^19.2.0" },
+      },
+    },
+  ];
+
+  assert.deepEqual(collectFindings(packages), []);
+});
+
+test("collectFindings: an already-published package still cannot gain a floor unmarked", () => {
+  const packages = [
+    {
+      name: "@mittwald/flow-react-components",
+      base: { name: "@mittwald/flow-react-components" },
+      head: {
+        name: "@mittwald/flow-react-components",
+        engines: { node: ">=24.0.0" },
+      },
+    },
+  ];
+
+  assert.deepEqual(
+    collectFindings(packages).map(({ surface, kind }) => ({ surface, kind })),
+    [{ surface: "engines.node", kind: "raised" }],
+  );
+});


### PR DESCRIPTION
Closes #2980.

## The problem

Going `private: true` → public while adding `engines.node` fails the version-contract guard:

```
::error::@mittwald/flow-codemods: engines.node raised ((none) -> >=24.0.0)
::error::Version contract: a breaking engines.node/peer change is not marked breaking.
```

Neither remedy the message offers is available:

- A breaking marker routes to the major line, and the **routing job in the same workflow** rejects a breaking marker on a standing line. The two guards contradict each other for this change.
- Dropping the floor means publishing a CLI without one, while its code uses import attributes, `structuredClone` and `toSorted`. On an older Node that is a bare `SyntaxError` with no hint why, and all twelve already-published packages declare a floor.

## Why the guard is wrong here, and only here

A `private: true` package has never been published. No consumer, no prior contract — its first publish **establishes** the floor and the peer ranges rather than narrowing them.

`collectFindings` already skips a package with no base file at all, for exactly this reason:

```js
if (!isPublishable(head)) continue; // not a consumer-facing Flow package
if (!base) continue; // new package: no prior contract to break
```

The gap was the case in between: the package existed at the base but was not publishable. This adds that line.

## What is deliberately not changed

The rule for anything already on npm. The second of the two added tests is the one that matters — it pins that `@mittwald/flow-react-components` gaining `engines.node` is still reported as `raised`, so this is an exemption for the first publish, not a hole in the guard.

I also checked it by hand: with the fix applied, an artificial "already-published package gains a floor" still produces the finding, and the guard goes green on #2978's branch.

## Route

`fix(ci):` → `main`, from where the forward-merge carries it to `next`. #2978 targets `next` and is blocked on this; the cascade unblocks it without that PR needing to carry CI infrastructure.

14 guard tests pass (12 existing, 2 added).
