### PR TITLE
fix(ci): version-contract guard no longer reads a first publish as a tightening

### DIFF
--- a/.github/scripts/version-contract-lib.mjs
+++ b/.github/scripts/version-contract-lib.mjs
@@ -178,6 +178,12 @@ export function collectFindings(packages) {
   for (const { name, base, head } of packages) {
     if (!isPublishable(head)) continue; // not a consumer-facing Flow package
     if (!base) continue; // new package: no prior contract to break
+    // Private at the base means it has never been published, so there is no
+    // consumer and no prior contract either. Its first publish *establishes*
+    // the floor and the peer ranges; it cannot tighten them. Without this,
+    // going `private: true` -> public reads as `(none) -> >=24.0.0` and the
+    // guard demands a breaking marker for a package nobody could install.
+    if (!isPublishable(base)) continue;
 
     const oldNode = base.engines?.node ?? null;
     const newNode = head.engines?.node ?? null;

--- a/.github/scripts/version-contract-lib.test.mjs
+++ b/.github/scripts/version-contract-lib.test.mjs
@@ -206,3 +206,32 @@ test("collectFindings: unparseable peer change → fail-closed finding", () => {
   assert.equal(findings.length, 1);
   assert.equal(findings[0].kind, "unparseable");
 });
+
+test("collectFindings: private at the base → first publish is not a tightening", () => {
+  const packages = [
+    {
+      name: "@mittwald/flow-codemods",
+      base: { name: "@mittwald/flow-codemods", private: true }, // never published
+      head: {
+        name: "@mittwald/flow-codemods",
+        engines: { node: ">=24.0.0" }, // establishes a floor, cannot raise one
+        peerDependencies: { jscodeshift: "^17.0.0" },
+      },
+    },
+  ];
+  assert.deepEqual(collectFindings(packages), []);
+});
+
+test("collectFindings: a published package gaining engines.node still flags", () => {
+  const packages = [
+    {
+      name: "@mittwald/flow-icons",
+      base: { name: "@mittwald/flow-icons" }, // public at the base
+      head: { name: "@mittwald/flow-icons", engines: { node: ">=24.0.0" } },
+    },
+  ];
+  const findings = collectFindings(packages);
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].surface, "engines.node");
+  assert.equal(findings[0].kind, "raised");
+});


### PR DESCRIPTION
## What & why

A package that is `private: true` at the base has never been published. It has no consumer and no prior contract, so its first publish **establishes** the `engines.node` floor and the peer ranges — it cannot tighten them.

Without this, going `private: true` → public while adding `engines.node` reported:

```
::error::@mittwald/flow-codemods: engines.node raised ((none) -> >=24.0.0)
::error::Version contract: a breaking engines.node/peer change is not marked breaking.
```

Neither remedy the guard offered was available. A breaking marker is rejected on `next` by the `routing` job in the same workflow, so the two guards contradicted each other. And reverting the "tightening" means publishing a CLI with no Node floor while all twelve already-published packages declare one.

`collectFindings` already skipped a package with no base file at all, for exactly this reason. The gap was the case in between: the package existed at the base but was not publishable.

The fix is one guard clause plus its rationale, right after the existing `if (!base) continue`:

```js
if (!isPublishable(base)) continue;
```

Closes #2980. Unblocks #2978, whose version-contract check fails until this lands — the fix was on that branch and was reverted out of it, since CI infrastructure does not belong in a codemods feature PR and this repo squash-merges.

## Notes for the reviewer

- **Two tests, and the second is the important one.** `collectFindings: a published package gaining engines.node still flags` pins that the rule is *not* being switched off — an already-published package adding a floor still produces one `engines.node` / `raised` finding. Written test-first and confirmed red before the fix.
- **`fix(ci):` → base `main`.** #2978 sits on `next`; `forward-merge.yml` merges `main` into `next` on push, so it picks the fixed guard up from there.
- **Scope.** CI-only, so per `release-relevance-lib.mjs` this publishes nothing.
- Per #2752 the guard stayed dormant until `next` existed, so this is plausibly its first encounter with a first publish.

## Verification

```
node --test .github/scripts/version-contract-lib.test.mjs   # 14 pass (was 12)
node --test .github/scripts/*.test.mjs                      # 40 pass
npx prettier --check                                        # clean
```

## Checklist

- [x] PR title is a Conventional Commit and matches the base branch above
- [x] `pnpm lint` is clean and `pnpm affected:test` passes (browser tests if behavior changed) — the changed files are outside the pnpm workspace; the guard's own suite is what covers them, and it runs in `test.yml` and in `commit-guard.yml`'s self-test step
- [x] **Generated code is committed** — no generators touched
- [ ] User-facing strings added to both `de-DE` and `en-US` locale files — n/a, no UI
- [ ] Docs updated if a public API changed; intentional visual changes get updated snapshots — n/a, no public API and no visual change

🤖 Generated with [Claude Code](https://claude.com/claude-code)