### PR TITLE
fix(ci): docs- and CI-only merges no longer publish through package.json or the lockfile

### DIFF
--- a/.github/scripts/release-relevance-guard.mjs
+++ b/.github/scripts/release-relevance-guard.mjs
@@ -6,12 +6,20 @@
  * Reads the changed-file list on stdin (one repository-relative path per line)
  * and writes `publish=true|false` to $GITHUB_OUTPUT.
  *
+ * `ROOT_MANIFEST_BEFORE_FILE` / `ROOT_MANIFEST_AFTER_FILE` optionally point at
+ * the two versions of the root `package.json`. They let the classifier judge
+ * that manifest by its key diff instead of its path (#2970); without them the
+ * root manifest stays relevant, as before.
+ *
  * It never fails the run. The decision is a routing choice, not a policy
  * violation: an empty or unreadable input yields `publish=true`, which is the
  * behaviour before #2931.
  */
 import { appendFileSync, readFileSync } from "node:fs";
-import { classifyChangedFiles } from "./release-relevance-lib.mjs";
+import {
+  classifyChangedFiles,
+  classifyRootManifestChange,
+} from "./release-relevance-lib.mjs";
 
 /** Read all of stdin; an unreadable stdin is an empty list (fail-safe). */
 function readStdin() {
@@ -27,7 +35,41 @@ const files = readStdin()
   .map((line) => line.trim())
   .filter((line) => line !== "");
 
-const { publish, reason, relevant, total } = classifyChangedFiles(files);
+/**
+ * The root manifest's two versions, if the workflow fetched them.
+ *
+ * A missing or unreadable file is `undefined`, which
+ * `classifyRootManifestChange` reports as relevant — the behaviour before this
+ * refinement.
+ *
+ * @param {string} variable
+ */
+function readManifest(variable) {
+  const path = process.env[variable];
+  if (!path) return undefined;
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    console.log(`::warning::Could not read ${variable} (${path}).`);
+    return undefined;
+  }
+}
+
+/** @type {{ rootManifestRelevant?: boolean }} */
+const options = {};
+if (files.includes("package.json")) {
+  const manifest = classifyRootManifestChange(
+    readManifest("ROOT_MANIFEST_BEFORE_FILE"),
+    readManifest("ROOT_MANIFEST_AFTER_FILE"),
+  );
+  options.rootManifestRelevant = manifest.relevant;
+  console.log(`Root manifest: ${manifest.reason}.`);
+}
+
+const { publish, reason, relevant, total } = classifyChangedFiles(
+  files,
+  options,
+);
 
 // Cap the log: a large merge lists hundreds of files and the first few already
 // explain the decision.

--- a/.github/scripts/release-relevance-lib.mjs
+++ b/.github/scripts/release-relevance-lib.mjs
@@ -8,13 +8,13 @@
  * Release (#2931).
  *
  * The rule is a DENYLIST, and that direction is deliberate. Every published
- * package ships `dist` (plus `*.md` for flow-react-components), so "what ends
- * up in a tarball" spans nearly all of `packages/**` — source, locales, SCSS,
- * tsconfigs, vite configs, generated code. An ALLOWLIST that forgets one of
- * those paths silently swallows a real release. A DENYLIST that forgets a new
- * docs directory merely publishes one needless version — exactly what happens
- * today. So unknown paths are RELEVANT, and only paths that provably cannot
- * reach a tarball are listed below.
+ * package ships `dist` (plus three `.md` for flow-react-components), so "what
+ * ends up in a tarball" spans nearly all of `packages/**` — source, locales,
+ * SCSS, tsconfigs, vite configs, generated code. An ALLOWLIST that forgets one
+ * of those paths silently swallows a real release. A DENYLIST that forgets a
+ * new docs directory merely publishes one needless version — exactly what
+ * happens today. So unknown paths are RELEVANT, and only paths that provably
+ * cannot reach a tarball are listed below.
  */
 
 /**
@@ -44,6 +44,12 @@ const IRRELEVANT_PREFIXES = [
  * `pnpm-workspace.yaml`, `nx.json`, `lerna.json`, `eslint.config.js`,
  * `stylelint.config.mjs` and `patches/**` — a dependency, resolution or build
  * wiring change can move the built output, so those stay relevant.
+ *
+ * `package.json` and `pnpm-lock.yaml` are relevant only CONDITIONALLY, because
+ * for those two the path alone says nothing (#2970, #2959). `isPublishRelevant`
+ * still reports both as relevant — the refinement lives in
+ * `classifyChangedFiles`, which sees the whole changed set and the root
+ * manifest's key diff.
  */
 const IRRELEVANT_ROOT_FILES = new Set([
   "LICENSE",
@@ -59,10 +65,10 @@ const IRRELEVANT_ROOT_FILES = new Set([
  * Can a change to `path` reach a published package's tarball?
  *
  * Note that `packages/**` is relevant WHOLESALE, Markdown included:
- * `@mittwald/flow-react-components` ships `["*.md", "dist"]`, so a
- * package-local `.md` really is part of the published artifact. Only Markdown
- * OUTSIDE `packages/` (root `README.md`, `AGENTS.md`, `CHANGELOG.md`, …) is
- * irrelevant.
+ * `@mittwald/flow-react-components` ships `AGENTS.md`, `MIGRATION.md` and
+ * `USAGE.md` next to `dist`, so a package-local `.md` really can be part of the
+ * published artifact. Only Markdown OUTSIDE `packages/` (root `README.md`,
+ * `AGENTS.md`, `CHANGELOG.md`, …) is irrelevant.
  *
  * @param {string} path Repository-relative, forward-slash separated.
  * @returns {boolean}
@@ -99,13 +105,106 @@ function looksLikePath(line) {
 }
 
 /**
+ * Root-`package.json` keys whose change cannot reach any tarball.
+ *
+ * Both are provably local: `scripts` is task wiring run by CI and by
+ * developers, `simple-git-hooks` configures the local git hooks. Every other
+ * key — the dependency blocks, `resolutions`, `packageManager`, `workspaces`,
+ * `type`, `engines`, `version` — can move a built artifact or the toolchain
+ * that produces it, and an UNKNOWN key is relevant like an unknown path is.
+ */
+const IRRELEVANT_ROOT_MANIFEST_KEYS = new Set(["scripts", "simple-git-hooks"]);
+
+/**
+ * Can a change to the root `package.json` reach a published tarball?
+ *
+ * The root manifest is private and never published, so nothing in it ships
+ * directly — but its dependency and wiring keys shape what every package
+ * builds. Only the key DIFF can tell the two apart, which is why the path-level
+ * `isPublishRelevant` cannot: `scripts` churn (#2970 added `test:links` to two
+ * scripts and cut 1.0.9) looks exactly like a `devDependencies` bump.
+ *
+ * Fails SAFE in both directions: unreadable or unparsable content is relevant,
+ * and so is any key not on the denylist above.
+ *
+ * @param {string | null | undefined} beforeText
+ * @param {string | null | undefined} afterText
+ * @returns {{ relevant: boolean; reason: string }}
+ */
+export function classifyRootManifestChange(beforeText, afterText) {
+  /** @param {string | null | undefined} text */
+  const parse = (text) => {
+    if (typeof text !== "string") return undefined;
+    try {
+      const value = JSON.parse(text);
+      return value !== null && typeof value === "object" ? value : undefined;
+    } catch {
+      return undefined;
+    }
+  };
+
+  const before = parse(beforeText);
+  const after = parse(afterText);
+
+  if (!before || !after) {
+    return {
+      relevant: true,
+      reason: "the root package.json could not be read (fail-safe default)",
+    };
+  }
+
+  const keys = new Set([...Object.keys(before), ...Object.keys(after)]);
+  const changed = [...keys].filter(
+    (key) => JSON.stringify(before[key]) !== JSON.stringify(after[key]),
+  );
+
+  if (changed.length === 0) {
+    return { relevant: false, reason: "the root package.json did not change" };
+  }
+
+  const relevantKeys = changed.filter(
+    (key) => !IRRELEVANT_ROOT_MANIFEST_KEYS.has(key),
+  );
+
+  if (relevantKeys.length === 0) {
+    return {
+      relevant: false,
+      reason: `the root package.json only changed ${changed.join(", ")}`,
+    };
+  }
+
+  return {
+    relevant: true,
+    reason: `the root package.json changed ${relevantKeys.join(", ")}`,
+  };
+}
+
+/** Does `path` name a package manifest? */
+function isManifest(path) {
+  return path === "package.json" || path.endsWith("/package.json");
+}
+
+/**
  * Decide whether a push publishes.
  *
  * Fails SAFE: an empty file list means we could not determine what changed
  * (unreachable `before` sha, a force push, a compare response we could not
  * read), and the answer is then "publish" — the behaviour before #2931.
  *
+ * Two paths are refined beyond `isPublishRelevant`, because for them the path
+ * alone carries no information (#2970, #2959):
+ *
+ * - **`package.json`** (root) — relevant only per `options.rootManifestRelevant`,
+ *   which the caller derives from the key diff via
+ *   `classifyRootManifestChange`. Unknown (`undefined`) stays relevant.
+ * - **`pnpm-lock.yaml`** — a DERIVED file: it is relevant when the manifest that
+ *   moved it is. So it follows the manifests in the same push, and drops out
+ *   only when at least one manifest changed and none of them is relevant. A
+ *   lockfile that changed with NO manifest (a dedupe, a resolution refresh)
+ *   stays relevant — nothing in the path list explains it.
+ *
  * @param {string[]} paths Changed files, repository-relative.
+ * @param {{ rootManifestRelevant?: boolean }} [options]
  * @returns {{
  *   publish: boolean;
  *   reason: string;
@@ -113,7 +212,7 @@ function looksLikePath(line) {
  *   total: number;
  * }}
  */
-export function classifyChangedFiles(paths) {
+export function classifyChangedFiles(paths, options = {}) {
   const files = paths.map((p) => p.trim()).filter((p) => p !== "");
 
   if (!files.every(looksLikePath)) {
@@ -135,7 +234,19 @@ export function classifyChangedFiles(paths) {
     };
   }
 
-  const relevant = files.filter(isPublishRelevant);
+  let relevant = files.filter(isPublishRelevant);
+
+  // The root manifest first: the lockfile rule below reads the REFINED
+  // relevance of the manifests, not the path-level one.
+  if (options.rootManifestRelevant === false) {
+    relevant = relevant.filter((path) => path !== "package.json");
+  }
+
+  const manifests = files.filter(isManifest);
+  const relevantManifests = manifests.filter((path) => relevant.includes(path));
+  if (manifests.length > 0 && relevantManifests.length === 0) {
+    relevant = relevant.filter((path) => path !== "pnpm-lock.yaml");
+  }
 
   if (relevant.length === 0) {
     return {

--- a/.github/scripts/release-relevance-lib.test.mjs
+++ b/.github/scripts/release-relevance-lib.test.mjs
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import {
   isPublishRelevant,
   classifyChangedFiles,
+  classifyRootManifestChange,
 } from "./release-relevance-lib.mjs";
 
 test("isPublishRelevant: docs, CI and tooling paths are irrelevant", () => {
@@ -52,8 +53,9 @@ test("isPublishRelevant: anything reaching a tarball is relevant", () => {
 });
 
 test("isPublishRelevant: Markdown INSIDE packages is relevant", () => {
-  // @mittwald/flow-react-components ships `["*.md", "dist"]` — a package-local
-  // Markdown file really is part of the published artifact.
+  // @mittwald/flow-react-components ships AGENTS.md, MIGRATION.md and USAGE.md
+  // next to `dist` — a package-local Markdown file really can be part of the
+  // published artifact.
   assert.equal(isPublishRelevant("packages/components/README.md"), true);
   assert.equal(isPublishRelevant("packages/components/AGENTS.md"), true);
   assert.equal(isPublishRelevant("packages/components/MIGRATION.md"), true);
@@ -162,5 +164,117 @@ test("classifyChangedFiles: square brackets are legitimate path characters", () 
       "apps/docs/src/app/01-get-started/[...slug]/page.tsx",
     ]).publish,
     false,
+  );
+});
+
+test("classifyRootManifestChange: a scripts-only change is irrelevant", () => {
+  // #2970 "test(docs): check the documentation's internal links in CI" → 1.0.9
+  const before = JSON.stringify({
+    name: "root",
+    scripts: { test: "nx run-many --targets=test:unit,test:compile" },
+    devDependencies: { vite: "7.0.0" },
+  });
+  const after = JSON.stringify({
+    name: "root",
+    scripts: {
+      test: "nx run-many --targets=test:unit,test:compile,test:links",
+    },
+    devDependencies: { vite: "7.0.0" },
+  });
+  assert.equal(classifyRootManifestChange(before, after).relevant, false);
+});
+
+test("classifyRootManifestChange: dependency and wiring keys stay relevant", () => {
+  const base = { scripts: { test: "a" }, devDependencies: { vite: "7.0.0" } };
+  for (const [key, value] of [
+    ["devDependencies", { vite: "7.1.0" }],
+    ["dependencies", { react: "19.2.0" }],
+    ["resolutions", { react: "19.2.0" }],
+    ["packageManager", "pnpm@10.28.3"],
+    ["workspaces", ["packages/*"]],
+    ["type", "commonjs"],
+    ["engines", { node: ">=26" }],
+    ["version", "1.0.9"],
+    ["brandNewKey", { a: 1 }],
+  ]) {
+    const after = JSON.stringify({ ...base, [key]: value });
+    assert.equal(
+      classifyRootManifestChange(JSON.stringify(base), after).relevant,
+      true,
+      key,
+    );
+  }
+});
+
+test("classifyRootManifestChange: unparsable or unknown content is relevant", () => {
+  assert.equal(classifyRootManifestChange("{ not json", "{}").relevant, true);
+  assert.equal(classifyRootManifestChange(null, "{}").relevant, true);
+  assert.equal(classifyRootManifestChange("{}", undefined).relevant, true);
+});
+
+test("classifyChangedFiles: a scripts-only root manifest does not publish", () => {
+  // #2970: apps/docs/**, a workflow, and two npm scripts.
+  const result = classifyChangedFiles(
+    [
+      "apps/docs/src/lib/links/checkLinks.ts",
+      "apps/docs/package.json",
+      ".github/workflows/test.yml",
+      "package.json",
+    ],
+    { rootManifestRelevant: false },
+  );
+  assert.equal(result.publish, false);
+  assert.deepEqual(result.relevant, []);
+});
+
+test("classifyChangedFiles: an unclassified root manifest still publishes", () => {
+  for (const options of [undefined, {}, { rootManifestRelevant: true }]) {
+    assert.equal(
+      classifyChangedFiles(["apps/docs/a.mdx", "package.json"], options)
+        .publish,
+      true,
+    );
+  }
+});
+
+test("classifyChangedFiles: a lockfile follows the manifests that moved it", () => {
+  // #2959 "docs: upgrade fumadocs-mdx" → 1.0.4. The lock churn belongs to an
+  // importer that is never published.
+  assert.equal(
+    classifyChangedFiles(["apps/docs/package.json", "pnpm-lock.yaml"]).publish,
+    false,
+  );
+  // A published package's own dependency bump keeps the lockfile relevant.
+  assert.equal(
+    classifyChangedFiles(["packages/components/package.json", "pnpm-lock.yaml"])
+      .publish,
+    true,
+  );
+  // The root manifest counts as a manifest — and only when it is relevant.
+  assert.equal(
+    classifyChangedFiles(["package.json", "pnpm-lock.yaml"], {
+      rootManifestRelevant: false,
+    }).publish,
+    false,
+  );
+  assert.equal(
+    classifyChangedFiles(["package.json", "pnpm-lock.yaml"], {
+      rootManifestRelevant: true,
+    }).publish,
+    true,
+  );
+});
+
+test("classifyChangedFiles: unexplained lock churn publishes (fail-safe)", () => {
+  // No manifest changed at all — a dedupe or resolution refresh can move what a
+  // published package bundles, and nothing in the path list says otherwise.
+  assert.equal(classifyChangedFiles(["pnpm-lock.yaml"]).publish, true);
+  assert.equal(
+    classifyChangedFiles(["pnpm-workspace.yaml", "pnpm-lock.yaml"]).publish,
+    true,
+  );
+  assert.equal(
+    classifyChangedFiles(["patches/foo@1.0.0.patch", "pnpm-lock.yaml"]).publish,
+    true,
   );
 });

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -133,6 +133,26 @@ jobs:
             files=""
           fi
 
+          # The root `package.json` is judged by its KEY DIFF, not its path: a
+          # `scripts` edit cannot reach a tarball, a `devDependencies` bump can,
+          # and the path cannot tell them apart (#2970). Fetch both versions so
+          # the classifier can compare them. A failed fetch leaves the file
+          # missing, which the guard reads as "relevant" — the behaviour before.
+          if printf '%s\n' "$files" | grep -qx 'package.json'; then
+            for side in BEFORE AFTER; do
+              if [ "$side" = AFTER ]; then ref="${AFTER}"; else ref="${BEFORE}"; fi
+              target="${RUNNER_TEMP}/root-package.${side}.json"
+              if gh api "repos/${REPO}/contents/package.json?ref=${ref}" \
+                --header 'Accept: application/vnd.github.raw+json' \
+                > "$target"; then
+                export "ROOT_MANIFEST_${side}_FILE=${target}"
+              else
+                echo "::warning::Could not fetch the root package.json at ${ref}."
+                rm -f "$target"
+              fi
+            done
+          fi
+
           printf '%s\n' "$files" \
             | node .github/scripts/release-relevance-guard.mjs
 

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -79,7 +79,19 @@ flowchart LR
     publishable. Forgetting a docs path costs one needless version; forgetting a
     source path would silently swallow a real release. So `packages/**` is
     relevant wholesale, Markdown included: `@mittwald/flow-react-components`
-    ships `["*.md", "dist"]`.
+    ships `AGENTS.md`, `MIGRATION.md` and `USAGE.md` next to `dist`.
+  - **Two files are judged by content, not by path**, because for them the path
+    carries no information:
+    - Root **`package.json`** — a `scripts` or `simple-git-hooks` edit cannot
+      reach a tarball, a `devDependencies` bump can. The `decide` job fetches
+      both versions and compares the top-level keys; an unknown key is relevant
+      like an unknown path is. #2970 added `test:links` to two scripts and cut
+      1.0.9.
+    - **`pnpm-lock.yaml`** — a derived file, relevant when the manifest that
+      moved it is. It follows the manifests in the same push and drops out only
+      when at least one changed and none of them is publish-relevant. Lock churn
+      with NO manifest change (a dedupe, a resolution refresh) stays relevant.
+      #2959 bumped an `apps/docs` dependency and cut 1.0.4.
   - A **`workflow_dispatch` run always publishes.** That is the escape hatch
     when a docs-only change has to go out as a release anyway.
 - **The build runs after the version bump.** Both publish workflows version


### PR DESCRIPTION
Docs- and CI-only merges must not produce a release (#2931). Two of them did anyway, because the release-relevance guard classifies by **path** — and two paths carry no information in their name.

| File | before | actually | cost |
| --- | --- | --- | --- |
| root `package.json` | always relevant | a `scripts` edit reaches no tarball, a `devDependencies` bump does | #2970 → 1.0.9 |
| `pnpm-lock.yaml` | always relevant | a **derived** file — relevant when the manifest that moved it is | #2959 → 1.0.4 |

#2970 appended `test:links` to `test` and `affected:test`; the rest of the merge was `apps/docs/**` and a workflow. #2959 bumped a dependency of `apps/docs`, an importer that is never published.

## What changed

Both files are now judged by content instead of by path.

- **Root manifest** — by its top-level key **diff**. `scripts` and `simple-git-hooks` are provably local; every other key, known or unknown, stays relevant. `classifyRootManifestChange` is pure; the `decide` job fetches both versions via the contents API and passes them in through two env vars. A failed fetch leaves the manifest relevant, so the fallback is the previous behaviour.
- **Lockfile** — follows the manifests in the same push, and drops out only when at least one manifest changed and none of them is publish-relevant. Lock churn with **no** manifest change (a dedupe, a resolution refresh) stays relevant, because nothing in the path list explains it.

The denylist direction is unchanged: unknown means relevant, and the guard still never fails a run.

## Verification

19/19 unit tests green (7 new), eslint and prettier clean. Every push since the guard landed with 1.0.0, replayed through the actual guard binary:

```
#2970 (1.0.9)  → publish=false   fixed
#2959 (1.0.4)  → publish=false   fixed
1.0.1 / 1.0.2 / 1.0.3 / 1.0.8 / #2976    → publish=true    unchanged
1.0.5 / 1.0.6                            → publish=true    unchanged
#2958 / #2968 / #2983 / #2956 / #2937    → publish=false   unchanged
#2970 without the manifest fetch         → publish=true    fail-safe holds
```

## For the reviewer

**1.0.5 and 1.0.6 were correct releases**, despite their `fix(docs):` titles. #2961 changed `packages/components/dev/createDocPropertiesJson.ts`, which writes `dist/assets/doc-properties.json` — a published export (`"./doc-properties"`). #2960 changed `packages/components/AGENTS.md` (listed in `files`) and `Button`'s JSDoc, which lands in the emitted `.d.ts`. Neither is touched by this PR.

**The residual risk** is in the lockfile rule: an `apps/**` dependency bump that also re-resolves a version a published package depends on would now skip a release it should have cut. pnpm's lockfile is per-importer, so this needs a shared range to move — unlikely, and recoverable with a `workflow_dispatch` run, which always publishes.

Also corrects a stale claim in the classifier and in `docs/release-workflow.md`: flow-react-components ships `AGENTS.md`, `MIGRATION.md` and `USAGE.md` next to `dist`, not `*.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)