### PR TITLE
ci: escalate on the blockage, not on "an issue is open"

### DIFF
--- a/.github/workflows/forward-merge.yml
+++ b/.github/workflows/forward-merge.yml
@@ -170,27 +170,64 @@ jobs:
           # git, and the pull request that eventually appears is a clean,
           # reviewable merge.
           open_sync_issue() {
-            local conflicted body title existing open_pr
+            local conflicted body title existing open_pr fingerprint marker refresh
             title="Forward-merge blocked: main into next needs a manual resolution"
 
-            # An open sync PR means someone has already resolved this and is
-            # waiting for review. The cascade is still blocked, but not on
-            # anyone's attention — no second alert.
+            conflicted="$(git ls-files --unmerged | cut -f2 | sort -u | sed 's/^/- `/; s/$/`/')"
+
+            # What identifies THIS blockage: the `main` tip that failed to merge,
+            # plus the conflicting paths. The escalation is idempotent on the
+            # FINGERPRINT, not on "an issue is open" (ADR 0004 §4).
+            #
+            # The difference is the whole point of #2963. A human resolved the
+            # first conflict; by the time the sync PR merged, `main` had moved on
+            # and the cascade hit a DIFFERENT conflict. Keyed on "an issue is
+            # open", every run after that went silent against an issue whose body
+            # described the problem that was already fixed. Keyed on the
+            # fingerprint, the new blockage gets a comment.
+            fingerprint="$(printf '%s\n%s\n' "$MAIN_SHA" "$conflicted" | sha1sum | cut -c1-12)"
+            marker="<!-- forward-merge-state: ${fingerprint} -->"
+
+            refresh="$(printf '%s\n' \
+              'The cascade is **still blocked** — and on a different blockage than the one reported above.' \
+              '' \
+              "\`main\` is now at \`${SHORT_SHA}\`. Conflicting files:" \
+              '' \
+              "${conflicted}" \
+              '' \
+              'The procedure is unchanged: `pnpm sync:resolve`, resolve, `pnpm sync:resolve --continue`.' \
+              '' \
+              "${marker}")"
+
+            # An open sync PR means someone has already resolved a blockage and is
+            # waiting for review. Whether it resolves THIS one is the question the
+            # fingerprint answers: if `main` has moved past what the PR merges, the
+            # PR is stale and merging it will leave the cascade blocked.
             open_pr="$(gh pr list --repo "$REPO" --head "sync/main-to-next" \
               --base next --state open --json number --jq '.[].number')"
             if [ -n "$open_pr" ]; then
-              echo "::notice::Sync PR #${open_pr} is open — a resolution is already in review. Not opening an issue."
+              if gh pr view "$open_pr" --repo "$REPO" --json body,comments \
+                   --jq '.body, (.comments[].body)' | grep -qF "$marker"; then
+                echo "::notice::Sync PR #${open_pr} already reports this exact blockage — staying quiet."
+                return 0
+              fi
+              gh pr comment "$open_pr" --repo "$REPO" --body "$refresh"
+              echo "::warning::Sync PR #${open_pr} does not cover the current blockage — commented."
               return 0
             fi
 
             existing="$(gh issue list --repo "$REPO" --state open --label sync \
               --search "in:title \"${title}\"" --json number --jq '.[].number')"
             if [ -n "$existing" ]; then
-              echo "::notice::Sync issue #${existing} is already open — not opening another."
+              if gh issue view "$existing" --repo "$REPO" --json body,comments \
+                   --jq '.body, (.comments[].body)' | grep -qF "$marker"; then
+                echo "::notice::Sync issue #${existing} already reports this exact blockage — not commenting again."
+                return 0
+              fi
+              gh issue comment "$existing" --repo "$REPO" --body "$refresh"
+              echo "::warning::Sync issue #${existing} refreshed — the blockage changed."
               return 0
             fi
-
-            conflicted="$(git ls-files --unmerged | cut -f2 | sort -u | sed 's/^/- `/; s/$/`/')"
 
             gh label create sync --repo "$REPO" --color BFD4F2 \
               --description "Forward-merge / promotion sync" 2>/dev/null || true
@@ -216,7 +253,7 @@ jobs:
               '' \
               '`--continue` refuses to commit while conflict markers are left, and keeps the merge a TRUE merge commit so the superset invariant (ADR 0004 §1) holds.' \
               '' \
-              '/cc @mfal @Lisa18289 @ins0 @maaaathis @Jan-Eimertenbrink')"
+              "${marker}")"
 
             gh issue create --repo "$REPO" --label sync --label automated \
               --title "$title" --body "$body"


### PR DESCRIPTION
The cascade sat blocked for 18 hours without a single alert (#2963), because escalation was idempotent on **"an issue is open"**.

A human resolved the first conflict, but by the time the sync PR merged, `main` had moved on and the cascade hit a **different** conflict. From then on every run took the `Sync issue #2963 is already open — not opening another` path and went silent — against an issue whose body described the problem that was already fixed.

## Change

Escalation is now idempotent on a **fingerprint**: the `main` tip that failed to merge plus the conflicting paths, carried in an HTML marker in the issue body and in every refresh comment.

- Same blockage → still quiet, exactly as before.
- Changed blockage → a comment on the open escalation naming the current `main` tip and the current conflicting files.
- An open sync PR that no longer covers what is actually blocking → the comment goes on **the PR**. That is #2969: it was already stale when it merged, and merging it left the cascade blocked.

The escalation issue also loses its `/cc` roll-call. [ADR 0004 §4](../blob/main/docs/adr/0004-forward-merge-main-into-next.md) routes CODEOWNERS at the **sync PR**, not at the issue, so the five-name ping was never required there. The §10 failure issue keeps its ping — there the ADR does mandate it.

## Verification

- YAML parses; `bash -n` over all `run` blocks; Prettier clean.
- `open_sync_issue` driven through five scenarios with `gh`/`git` stubbed: open an issue when nothing is open, stay quiet on an identical blockage, comment on a changed blockage, and both directions of the open-sync-PR case. The generated refresh comment names all three real conflicting files from the #2963 incident plus the `main` tip — the comment that was missing on 2026-08-27 at 12:48.

## Scope: the close-path hole moved to #2994

This PR originally also fixed the second hole the incident exposed — `close_sync_issue` unreachable on the guard's `ahead_by == 0` path. That overlapped with #2994, which does it more completely: the close moves out of the merge step into a step of its own covering **all three** healthy outcomes (merge pushed, churn-only merge dropped per §6/§7, nothing to merge at all), instead of only the third.

Both fixes in the tree at once produced two `gh issue close` loops firing on the same condition, so the duplicate is gone from here. Test-merged against #2994: clean, exactly one close step, fingerprint logic untouched. **Merge #2994 first.**

## Follow-up, deliberately not in this PR

[ADR 0004 §4](../blob/main/docs/adr/0004-forward-merge-main-into-next.md) still states the escalation is idempotent while "a sync issue or a sync PR is open". That sentence now describes the old behaviour and needs to say *fingerprint*. Kept out of this diff because `docs/adr/0004-…md` is one of the files the sync resolutions keep colliding on — a separate docs PR avoids feeding that conflict.
