### PR TITLE
docs: fix page-action alignment on foundations and patterns pages

### DIFF
--- a/apps/docs/src/app/_components/layout/TopContent/TopContent.tsx
+++ b/apps/docs/src/app/_components/layout/TopContent/TopContent.tsx
@@ -1,7 +1,6 @@
 import type { FC } from "react";
 import {
   ColumnLayout,
-  Flex,
   Header,
   Heading,
   LayoutCard,
@@ -31,11 +30,15 @@ export const TopContent: FC<Props> = (props) => {
   if (!component) {
     return (
       <LayoutCard className={styles.mainContent}>
-        <Flex justify="space-between" align="start">
-          <Heading level={1}>{mdxFile.getTitle()}</Heading>
-          <PageActions title={mdxFile.getTitle()} markdownUrl={markdownUrl} />
-        </Flex>
-        {mdxFile.mdxSource.frontmatter.description}
+        <Section>
+          <Header>
+            <Heading level={1}>{mdxFile.getTitle()}</Heading>
+            <PageActions title={mdxFile.getTitle()} markdownUrl={markdownUrl} />
+          </Header>
+
+          {mdxFile.mdxSource.frontmatter.description}
+        </Section>
+
         <MdxFileView mdxFile={mdxFile.serialize()} />
       </LayoutCard>
     );


### PR DESCRIPTION
The "Seite kopieren" button and its context menu were torn apart on foundations and patterns pages — 229px of forced gap between them.

Both `PageActions` buttons use `color="secondary"`, which an auto-sorting `ActionGroup` maps to the `abort` slot, and that slot carries `margin-inline-end: auto`. Two of them in a `flex-grow: 1` group means each pushes the next away.

Component pages never showed this because they wrap the heading in `Section` + `Header`; the resulting `SectionHeader` sets `preserveOrder: true` on the `ActionGroup` via `PropsContext`. The non-component `TopContent` branch used a bare `Flex` instead, so it now uses the same structure — which also brings the vertical centering and the `--section-header--heading-to-action-spacing` token.

Alternative would have been `preserveOrder` directly on `PageActions`' `ActionGroup`. Matching the components layout seemed better: all three call sites now render identically.

Verified in the dev server on `/02-foundations/01-design/02-colors` and `/03-patterns/01-patterns/forms` against `/04-components/actions/button`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)