### PR TITLE
fix(docs): stop the footer from overflowing on narrow screens

### DIFF
--- a/apps/docs/src/app/_components/layout/Footer/Footer.module.scss
+++ b/apps/docs/src/app/_components/layout/Footer/Footer.module.scss
@@ -14,7 +14,7 @@
 
   .legal,
   .resources {
-    flex: 1;
+    flex: 1 1 auto;
   }
 
   .mittwaldLogo {

--- a/apps/docs/src/app/_components/layout/Footer/Footer.tsx
+++ b/apps/docs/src/app/_components/layout/Footer/Footer.tsx
@@ -17,7 +17,7 @@ const Footer: FC = () => {
         className={styles.footerContent}
       >
         <Flex direction="column" grow gap="xl">
-          <Flex gap="xl">
+          <Flex gap="xl" wrap="wrap">
             <Flex
               elementType="section"
               direction="column"
@@ -69,7 +69,7 @@ const Footer: FC = () => {
           </Flex>
           <Flex direction="column" gap="xs">
             <MittwaldLogo />
-            <Text whiteSpace="nowrap">
+            <Text>
               <small>© {year} Mittwald CM Service GmbH & Co. KG</small>
             </Text>
           </Flex>


### PR DESCRIPTION
At a 320px viewport every page of the docs scrolled sideways by 18px. The cause is the footer, in two places where content could not give way:

- **"Ressourcen" and "Rechtliches"** sit in a `Flex` without `wrap`, and `flex: 1` gives them a zero basis — so they never reach the wrapping condition and shrink to the width their `whiteSpace="nowrap"` links enforce. They need `wrap` *and* an `auto` basis: with the content as their base size, they stack once they no longer fit side by side.
- **The copyright line** was `whiteSpace="nowrap"` at 300px wide, which set the minimum width of the entire column and kept the page 12px too wide even after the sections stacked.

Measured on the Button page, which has no other narrow-screen issues:

| Viewport | before | after |
| --- | --- | --- |
| 320px | 18px sideways scroll | none, sections stacked |
| 375px | 18px | none, sections side by side |
| 1440px | none | unchanged, copyright on one line |

Found while working on #2954; unrelated to it, so it is here on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)