### PR TITLE
ci: commit only baselines that reproduce, and only baselines

### DIFF
--- a/.github/workflows/test-visual-label.yml
+++ b/.github/workflows/test-visual-label.yml
@@ -96,6 +96,12 @@ jobs:
         with:
           name: visual-diffs
           path: packages/**/.vitest-attachments/**
+          # `.vitest-attachments` is a dot directory, and upload-artifact skips
+          # hidden paths by default — so this artifact never existed, on any run.
+          # The failure comment points reviewers at it regardless, and vitest
+          # truncates the step log before its own failure summary, which left a
+          # red check with no reference, actual or diff image anywhere (#2985).
+          include-hidden-files: true
           if-no-files-found: ignore
           retention-days: 7
 

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -92,7 +92,18 @@ jobs:
 
       - run: pnpm test:browser:prepare --only-shell
 
+      # continue-on-error, because a snapshot-update run is allowed to be red.
+      # `--update` writes every baseline it can and *then* the suite still fails
+      # on anything a rewritten snapshot cannot fix — a scenario that never
+      # captures a stable frame, say. The job used to stop there, so one unstable
+      # scenario anywhere threw away the baselines it had already written for
+      # every other one, and the label appeared to do nothing at all (#2985).
+      #
+      # Nothing is trusted because this step is green; the verification below is
+      # the gate.
       - name: Update Visual Regression Screenshots
+        id: update
+        continue-on-error: true
         run: pnpm test:visual --update --browser.fileParallelism=false
 
       # `--update` rewrites whatever renders now, across the whole suite — it
@@ -195,6 +206,7 @@ jobs:
           CHANGED_COUNT: ${{ steps.check_changes.outputs.changed_count }}
           CHANGED_FILES: ${{ steps.check_changes.outputs.changed_files }}
           VERIFY_OUTCOME: ${{ steps.verify.outcome }}
+          UPDATE_OUTCOME: ${{ steps.update.outcome }}
           HEAD_REF: ${{ github.head_ref }}
         run: |
           if [[ "$VERIFY_OUTCOME" == "failure" ]]; then
@@ -222,7 +234,20 @@ jobs:
           else
             echo "### ℹ️ No Screenshot Updates Required" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "The visual regression test command ran successfully but no screenshots needed updating." >> "$GITHUB_STEP_SUMMARY"
+            echo "No baseline needed updating." >> "$GITHUB_STEP_SUMMARY"
+
+            if [[ "$UPDATE_OUTCOME" == "failure" ]]; then
+              # The update run is allowed to be red, but "red and wrote nothing"
+              # is not the same as "everything was already correct" — say which.
+              echo "" >> "$GITHUB_STEP_SUMMARY"
+              echo "⚠️ The update run itself failed without writing any baseline, so this is not a clean bill of health: something failed for a reason a rewritten snapshot cannot fix. Check the run log." >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "" >> "$GITHUB_STEP_SUMMARY"
+              echo "All screenshots are already up to date! 🎉" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          fi
+
+          if [[ "$UPDATE_OUTCOME" == "failure" && "$CHANGES" == "true" ]]; then
             echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "All screenshots are already up to date! 🎉" >> "$GITHUB_STEP_SUMMARY"
+            echo "_Note: the update run reported failures of its own. Baselines above were still written and verified; scenarios that fail for reasons a snapshot cannot fix are listed in the run log._" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -94,30 +94,91 @@ jobs:
 
       - name: Update Visual Regression Screenshots
         run: pnpm test:visual --update --browser.fileParallelism=false
-      # check what changed
-      - name: Check for changes
-        id: check_changes
-        run: |
-          CHANGED_FILES=$(git status --porcelain | awk '{print $2}')
-          if [ "${CHANGED_FILES:+x}" ]; then
-            echo "changes=true" >> $GITHUB_OUTPUT
-            echo "Changes detected"
 
-            # save the list for the summary
-            echo "changed_files<<EOF" >> $GITHUB_OUTPUT
-            echo "$CHANGED_FILES" >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
-            echo "changed_count=$(echo "$CHANGED_FILES" | wc -l)" >> $GITHUB_OUTPUT
-          else
-            echo "changes=false" >> $GITHUB_OUTPUT
-            echo "No changes detected"
+      # `--update` rewrites whatever renders now, across the whole suite — it
+      # cannot tell a baseline this PR meant to move from one belonging to a
+      # scenario that merely happens to be failing or flaky. #2945 (a CodeBlock
+      # change) picked up a tooltip-less frame of the racy `Tooltip` scenario
+      # that way and committed it as a baseline, contradicting the three beside
+      # it and keeping the scheduled run red in both environments for days.
+      #
+      # So stage baselines only, and verify below that they reproduce.
+      - name: Collect updated baselines
+        id: check_changes
+        env:
+          # The only directory `test:visual` can write: remote-react-components
+          # is the sole project with that target. `git add -A` used to sweep in
+          # anything else the job left behind — a lockfile, .vitest-attachments,
+          # a regenerated artifact — none of which belongs in a screenshot
+          # commit, and none of which a reviewer expects to find in one.
+          BASELINE_DIR: packages/remote-react-components/src/tests/visual/__screenshots__
+        run: |
+          git add -- "$BASELINE_DIR"
+
+          # --name-only over `git status | awk '{print $2}'`, which mis-parses a
+          # rename ("R old -> new") and any path containing a space.
+          CHANGED_FILES="$(git diff --cached --name-only)"
+
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "changes=false" >> "$GITHUB_OUTPUT"
+            echo "No baseline changes detected"
+            exit 0
           fi
+
+          echo "changes=true" >> "$GITHUB_OUTPUT"
+          echo "Baseline changes detected"
+
+          # A baseline lives at <dir>/__screenshots__/<test file>/<snapshot>.png,
+          # so the owning test file is that path with the __screenshots__ segment
+          # and the file name dropped. Relative to the package, for vitest.
+          TEST_FILES="$(printf '%s\n' "$CHANGED_FILES" \
+            | sed -e 's#^packages/remote-react-components/##' \
+                  -e 's#__screenshots__/\([^/]*\)/[^/]*$#\1#' \
+            | sort -u)"
+
+          {
+            echo "changed_files<<EOF"
+            echo "$CHANGED_FILES"
+            echo "EOF"
+            echo "test_files<<EOF"
+            echo "$TEST_FILES"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "changed_count=$(echo "$CHANGED_FILES" | wc -l)" >> "$GITHUB_OUTPUT"
+
+      # A baseline is only worth committing if it renders the same way twice.
+      # Re-run the affected scenarios against what was just written: a frame the
+      # suite cannot reproduce is a race, not a new truth, and committing it
+      # hands the next reader a baseline that contradicts the component.
+      #
+      # Scoped to the affected files, so this costs seconds rather than a second
+      # full suite. Runs the package script directly on purpose — the nx target
+      # above already built every dependency, and re-entering the graph here
+      # would rebuild them for nothing.
+      - name: Verify the updated baselines reproduce
+        if: steps.check_changes.outputs.changes == 'true'
+        id: verify
+        env:
+          TEST_FILES: ${{ steps.check_changes.outputs.test_files }}
+        run: |
+          # Built as an array rather than left to word splitting: an empty
+          # element would reach vitest as an empty filter, which matches every
+          # file — turning a scoped check back into a full-suite run without
+          # saying so.
+          files=()
+          while IFS= read -r file; do
+            [ -n "$file" ] && files+=("$file")
+          done <<< "$TEST_FILES"
+
+          printf 'Verifying %s scenario file(s):\n' "${#files[@]}"
+          printf '  %s\n' "${files[@]}"
+
+          pnpm --filter @mittwald/flow-remote-react-components test:visual \
+            --browser.fileParallelism=false "${files[@]}"
 
       - name: Commit changes
         if: steps.check_changes.outputs.changes == 'true'
-        run: |
-          git add -A
-          git commit -m "${{ env.COMMIT_MESSAGE }}"
+        run: git commit -m "${{ env.COMMIT_MESSAGE }}"
 
       - name: Push changes
         if: steps.check_changes.outputs.changes == 'true'
@@ -125,14 +186,29 @@ jobs:
           HEAD_REF: ${{ github.head_ref }}
         run: git push origin "$HEAD_REF"
 
+      # always(), so a failed verification explains itself instead of leaving a
+      # red step with no context.
       - name: Summary
+        if: always()
         env:
           CHANGES: ${{ steps.check_changes.outputs.changes }}
           CHANGED_COUNT: ${{ steps.check_changes.outputs.changed_count }}
           CHANGED_FILES: ${{ steps.check_changes.outputs.changed_files }}
+          VERIFY_OUTCOME: ${{ steps.verify.outcome }}
           HEAD_REF: ${{ github.head_ref }}
         run: |
-          if [[ "$CHANGES" == "true" ]]; then
+          if [[ "$VERIFY_OUTCOME" == "failure" ]]; then
+            echo "### ⚠️ Screenshots Updated But Not Committed" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "The updated baselines did not reproduce: re-running the affected scenarios against the frames just written failed, so **nothing was committed**." >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "That means at least one of these scenarios is racy — the frame it renders depends on timing, and whichever one \`--update\` happened to catch would have become the baseline. Fix the scenario, then re-apply the label." >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "#### Baselines that would have changed:" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            echo "$CHANGED_FILES" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          elif [[ "$CHANGES" == "true" ]]; then
             echo "### 📸 Visual Regression Screenshots Updated" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "Successfully updated **$CHANGED_COUNT** screenshot(s) on \`$HEAD_REF\`" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## What & why

`update-screenshots` ran `pnpm test:visual --update` over the whole suite and
then `git add -A`. Neither half was scoped, and both cost us.

**`--update` rewrites whatever renders now.** It cannot tell a baseline the PR
meant to move from one belonging to a scenario that merely happens to be failing
or flaky. 6bf57c7c5 (`fix(CodeBlock): …`, #2945) hit exactly that: it picked up a
tooltip-less frame of the racy `Tooltip` scenario and committed it as the
`firefox-linux` baseline for `Tooltip - visible`, contradicting the three
baselines beside it. The scheduled visual run stayed red in both environments for
days, over a file nobody reviewing a CodeBlock PR would think to open. (Fixed in
#2985; this is the mechanism that let it happen.)

**`git add -A` widened the blast radius past screenshots entirely.** A lockfile, a
`.vitest-attachments` leftover, a regenerated artifact — anything the job left
behind would ride along in a commit titled "update visual regression
screenshots".

## What changes

- **Stage only baselines.** `git add -- <baseline dir>` instead of `git add -A`,
  scoped to `packages/remote-react-components/src/tests/visual/__screenshots__` —
  the one directory `test:visual` can write, since that package is the only
  project with the target.

- **Verify that the new baselines reproduce.** The changed baseline paths name
  their own test files (`…/__screenshots__/<test file>/<snapshot>.png`), so those
  scenarios are re-run against the frames just written. A baseline the suite
  cannot reproduce is a race, not a new truth: nothing is committed, the job goes
  red, and the summary names the scenarios to fix. Scoped to the affected files,
  so it costs seconds — not a second full suite.

  This is the part that would have stopped #2945: the tooltip-less frame does not
  reproduce, because the tooltip is normally still painted.

- **Report the failure case** (`if: always()` on the summary), so a blocked
  update explains itself instead of leaving a red step with no context.

- **Drop the `git status --porcelain | awk '{print $2}'` parse**, which mis-reads
  a rename (`R old -> new`) and any path containing a space, for
  `git diff --cached --name-only`.

## Third commit: the update run no longer discards its own work

`--update` writes every baseline it can and *then* vitest can still exit 1 —
**not because a test failed, but because the run had unhandled errors.** Vitest
treats those as a failed run regardless of test results. Reproduced locally:

```
Test Files  1 passed (1)
      Tests  18 passed (18)
EXIT=1

⎯⎯⎯⎯⎯⎯ Unhandled Errors ⎯⎯⎯⎯⎯⎯
TypeError: listener is not a function
```

The job stopped at that step, so `Commit changes` never ran and **nothing was
committed** — while the finished baselines sat on the runner's disk. That is why
the `update-screenshots` label looked like a no-op on #2985: its sweep log shows
no `FAIL` and no failing file at all, only repeated
`[Error: ResizeObserver loop completed with undelivered notifications.]`.

So the update run is allowed to be red, and the verification from the first
commit becomes the actual gate: a baseline is committed if re-running its
scenario reproduces it, whatever else the run reported. The summary distinguishes
"red and wrote nothing" from "everything was already correct".

This treats the symptom. The unhandled errors are real bugs of their own —
`TypeError: listener is not a function` comes from the remote-dom fork, where
`usePropsForRemoteElement` wraps every `eventListeners` entry without the
`if (listener)` guard its `eventProps` branch has, so a removed listener (key
retained, value `undefined`) becomes a callable that throws when invoked. Fixing
that belongs in `mfal/remote-dom` or `patches/`, not here.

## Second commit: the diff artifact never existed

Separate one-line bug, found while diagnosing #2985 and included because it is
what made that diagnosis so expensive.

`visual-diffs` has **never** been uploaded, on any run. `.vitest-attachments` is
a dot directory and `actions/upload-artifact` skips hidden paths by default, so
every run logged `No files were found with the provided path` — including runs
whose failure was a plain pixel mismatch with reference, actual and diff images
sitting right there on disk. The failure comment points reviewers at that
artifact regardless, and vitest truncates the step log before its own failure
summary, so a red visual check offered no image and no list of failing
scenarios.

`include-hidden-files: true` is the whole fix.

Worth knowing: the **scheduled** visual workflow uploads nothing at all, so its
failures stay just as opaque. Left alone here — it needs an upload step added,
not a flag. Say the word and I'll do it.

## Notes for the reviewer

- **The verification is deliberately strict.** A legitimate update to a scenario
  that is *genuinely* flaky will now be blocked rather than committed. That is
  the intended direction — the alternative is what this PR is cleaning up — and
  the summary says what to do. No retry loop, because a retry is how flakiness
  gets hidden.

- **The file list is built as an array, not left to word splitting.** An empty
  element would reach vitest as an empty filter, which matches every file and
  would quietly turn the scoped check back into a full-suite run.

- **Merge order:** landing this before #2985 gets the label is the nicer
  sequence, since `pull_request`-triggered workflows run the definition from the
  base branch — #2985's sweep would then already be covered by the verification.
  Either order works, though; #2985 makes the suite green on its own.

## Verification

Run in `bash` (as the runner does), not zsh — where the array construction matters:

| Check | Result |
| --- | --- |
| Baseline path → test file derivation | 4 baselines across 3 files → 3 correct test paths |
| Verification command, 2 derived files | 4 test files (2 × 2 browser projects), 12 tests, passes |
| `yaml.safe_load` on the workflow | parses; 14 steps in the expected order |
| `prettier --check` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
