### PR TITLE
docs: document the publish window on the versioning page (fixes #2974)

### DIFF
--- a/apps/docs/src/content/01-get-started/versioning/index.mdx
+++ b/apps/docs/src/content/01-get-started/versioning/index.mdx
@@ -188,6 +188,42 @@ einem `DeprecationWarningProvider` und gib ihm einen `onWarning`-Handler:
 
 ---
 
+# Direkt nach einem Release
+
+Ein Release veröffentlicht die Packages **nacheinander**, nicht gleichzeitig.
+Für einige Minuten liegt in der npm-Registry deshalb für die schon
+veröffentlichten Packages die neue Version, für die restlichen noch die alte.
+Beim Release `1.0.6` lagen zwischen dem ersten und dem letzten Package rund 25
+Minuten.
+
+Du triffst dieses Fenster leicht, denn ein Update betrifft immer mehrere
+Packages: alle `@mittwald/flow-*`-Packages teilen sich eine gemeinsame Version,
+und `@mittwald/flow-react-components` fordert `@mittwald/flow-icons-pro` als
+Peer-Dependency in exakt derselben Version. Ziehst du in diesem Fenster alle
+Flow-Abhängigkeiten auf die neue Version, schlägt die Installation für das
+Package fehl, das noch nicht dran war:
+
+```
+npm error code ETARGET
+npm error notarget No matching version found for @mittwald/flow-react-components@1.0.6
+```
+
+pnpm meldet dasselbe als `ERR_PNPM_NO_MATCHING_VERSION`.
+
+Das ist keine Lücke im Release: sobald der Release-Lauf durch ist, haben alle
+Packages dieselbe Version. Direkt nach einem Release ist dieser Fehler fast
+immer das Veröffentlichungsfenster und nichts anderes.
+
+<Alert>
+  <Heading>Warte ein paar Minuten und installiere erneut</Heading>
+  <Content>
+    Das Fenster schließt sich von selbst. Du brauchst keinen Workaround – pinne
+    nichts fest und mische keine Flow-Versionen, um den Fehler zu umgehen.
+  </Content>
+</Alert>
+
+---
+
 # Component Lifecycle
 
 Der Vertrag gilt nicht für jede Component gleich. Jede Component hat einen


### PR DESCRIPTION
Flow's packages are not published at the same moment — Lerna publishes them one
after another, so during a release run the registry holds the new version for
some `@mittwald/flow-*` packages and not yet for others. During the `1.0.6`
release that window was ~25 minutes. A consumer who moves all their Flow
dependencies to one version in it gets `ETARGET` with nothing to indicate that
waiting fixes it.

This is not a publish hole (#2887, closed as accepted) — it is only about
telling users. The new **„Direkt nach einem Release"** section on the
versioning page does that:

- a release publishes the packages one after another, so the versions can
  differ for a few minutes;
- why hitting the window is likely rather than exotic — all packages share one
  version, and `@mittwald/flow-react-components` declares
  `@mittwald/flow-icons-pro` as a peer at an **exact** version, so an update
  always spans several packages;
- the error as it actually appears (`ETARGET` / `ERR_PNPM_NO_MATCHING_VERSION`);
- it resolves itself: wait a few minutes, install again, no pinning workaround
  is needed and none is wanted.

## Left out on purpose

The issue also asks for a sentence in `flow-codemods`' README. Neither the
README nor the `upgrade` CLI exists on `main` — both live on #2978. The
sentence has to ride along there, or it collides on merge.

## Verification

- Rendered in the dev server: heading id `direkt-nach-einem-release`, the code
  block and the `Alert` render, and the following *Component Lifecycle* section
  is intact.
- `pnpm format:check` and `pnpm nx test:links docs` green.
- The release-relevance classifier reads the change as docs-only → no publish.

fixes #2974

🤖 Generated with [Claude Code](https://claude.com/claude-code)