### PR TITLE
docs: add the missing separators before top-level sections

### DIFF
--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -441,8 +441,9 @@ Markdown headings are therefore shifted down one level when rendered:
 - Use `#` for the top-level sections of a page — for example `# Best Practices`,
   `# Kombiniere mit ...`, `# Properties`. A page usually has several `#`
   sections.
-- Separate `#` sections from each other with a horizontal rule (`---`). Do not
-  put a rule between a `#` and its own `##`.
+- Put a horizontal rule (`---`) before **every** `#` section — the first one
+  included, so it is set off from the page header above it. Do not put a rule
+  between a `#` and its own `##`.
 - `#` and `##` headings appear in the anchor navigation ("Auf dieser Seite").
   Keep them concise so the navigation remains readable.
 

--- a/apps/docs/src/content/01-get-started/installation/index.mdx
+++ b/apps/docs/src/content/01-get-started/installation/index.mdx
@@ -2,6 +2,8 @@
 description: Willkommen in der Flow Dokumentation!
 ---
 
+---
+
 # Installation der Flow React Component Library
 
 Die Flow React Component Library kann mit einem Package Manager wie `npm` oder

--- a/apps/docs/src/content/01-get-started/versioning/index.mdx
+++ b/apps/docs/src/content/01-get-started/versioning/index.mdx
@@ -7,6 +7,8 @@ description:
   Änderungen absicherst.
 ---
 
+---
+
 # Semantic Versioning
 
 Alle `@mittwald/flow-*`-Packages teilen sich eine gemeinsame Version. Dieselbe

--- a/apps/docs/src/content/02-foundations/01-design/03-themes/index.mdx
+++ b/apps/docs/src/content/02-foundations/01-design/03-themes/index.mdx
@@ -14,6 +14,8 @@ Beide basieren auf denselben Design Tokens und Components. Ein Theme ist damit
 kein separater Modus mit eigener Logik, sondern eine alternative Darstellung
 derselben UI.
 
+---
+
 # Umgang mit Themes
 
 Flow stellt die Grundlage für Themes bereit, übernimmt jedoch nicht automatisch
@@ -30,6 +32,8 @@ Die Anwendung ist verantwortlich für:
 - Umschalten zwischen Themes
 - Berücksichtigung der Browsereinstellung
 - Speicherung der Nutzerpräferenz
+
+---
 
 # Individuelle Inhalte
 
@@ -70,6 +74,8 @@ Richtlinien wie für
 />
 
 </DoAndDont>
+
+---
 
 # Technische Implementierung
 

--- a/apps/docs/src/content/02-foundations/04-internal/01-boundaries/index.mdx
+++ b/apps/docs/src/content/02-foundations/04-internal/01-boundaries/index.mdx
@@ -23,6 +23,8 @@ practices sollen bei der Orientierung und Entscheidungsfindung helfen.
   </Content>
 </Alert>
 
+---
+
 # Technische Umsetzung
 
 Bei der Platzierung der Boundaries empfiehlt es sich, vom Groben ins Detail

--- a/apps/docs/src/content/03-patterns/02-codesnippets/zeitintervalle/index.mdx
+++ b/apps/docs/src/content/03-patterns/02-codesnippets/zeitintervalle/index.mdx
@@ -25,6 +25,8 @@ die Auswahl zu verfeinern. Die Option "Benutzerdefiniert" ermöglicht über ein
 können die nächsten drei Ausführungen beispielhaft in einem `LabeledValue`
 dargestellt werden.
 
+---
+
 # Best Practices
 
 - Reduziere die Auswahl auf für den Nutzungskontext relevante Zeitintervalle, um


### PR DESCRIPTION
Six `#` sections started without the `---` rule that sets a section off from the one above it:

- **Installation** and **Versionierung** — the first section, where the rule separates it from the generated page header (H1 + description)
- **Themes** — `# Umgang mit Themes`, `# Individuelle Inhalte`, `# Technische Implementierung`
- **Boundaries** — `# Technische Umsetzung`
- **Zeitintervalle** — `# Best Practices`

The README rule said "separate `#` sections from each other", which left the first section open — it now names it explicitly.

`releases/index.mdx` keeps its bare heading: the `/releases` route builds its content from the GitHub releases, so that file only feeds `llms.txt` and the search index.

Verified on the dev server — every section now renders a `<Separator />` above it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)