### PR TITLE
docs: fix references to non-existent design tokens

### DIFF
--- a/apps/docs/src/content/02-foundations/01-design/01-design-tokens/index.mdx
+++ b/apps/docs/src/content/02-foundations/01-design/01-design-tokens/index.mdx
@@ -68,15 +68,15 @@ abgrenzt.
 
 ## Beispiele
 
-**hosting-blue-800**
+**color--hosting-blue--800**
 
-Der Token `hosting-blue-800` definiert eine spezifische
-[Color](/02-foundations/01-design/02-colors). Der Name der Farbe `hosting-blue`
-gibt den **Context** an. Die Zahl `800` ist die **Clarification**, die die
-Abstufung der Farbe definiert und auf den genauen Farbwert `#0054F5` im
-Designsystem verweist.
+Der Token `color--hosting-blue--800` definiert eine spezifische
+[Color](/02-foundations/01-design/02-colors). `color` gibt den **Context** an.
+Der Name der Farbe `hosting-blue` ist die **Common Unit**. Die Zahl `800` ist
+die **Clarification**, die die Abstufung der Farbe definiert und auf den genauen
+Farbwert `#0054F5` im Designsystem verweist.
 
-**primary-solid-background-color-default**
+**primary-solid-background-color--default**
 
 Dieser Token definiert die primäre Hintergrundfarbe einer „Solid“-Variante.
 `primary` gibt als Context an, dass es sich um eine primäre Farbe handelt. Die
@@ -84,15 +84,15 @@ Common Unit `solid-background-color` verdeutlicht, dass die Farbe als
 Hintergrundfarbe in der „Solid“-Variante verwendet wird. Die **Clarification**
 `default` gibt an, dass der Token für den Default-State verwendet wird.
 
-**alert-info-outline-border-color-default**
+**alert--info-border-color**
 
 Dieser Token definiert eine Designentscheidung für eine spezifische Component,
 in diesem Fall einen [Alert](/04-components/status/alert). `alert` liefert den
 **Context** und stellt klar, dass der Token nur für diese Component verwendet
-wird. `info-outline-border-color` als **Common Unit** kategorisiert den Token
-weiter ein: Er wird für die Border-Color eines Alerts in der „Info“- und
-„Outline“-Variante verwendet. `default` gibt als **Clarification** an, dass der
-Token für den Default-State genutzt wird.
+wird. `info-border-color` als **Common Unit** kategorisiert den Token weiter
+ein: Er wird für die Border-Color eines Alerts in der „Info“-Variante verwendet.
+Eine **Clarification** braucht dieser Token nicht, weil die Border-Color eines
+Alerts in allen States gleich bleibt.
 
 ---
 
@@ -112,10 +112,10 @@ dafür sind Farben, die einen rein dekorativen Zweck erfüllen. Diese müssen ni
 weiter definiert oder in eine Kategorie eingeordnet werden, da sie einen rein
 optischen Nutzen erfüllen und keiner tieferen Idee folgen.
 
-| Token-Name        | Wert    |
-| ----------------- | ------- |
-| hosting-blue--800 | #0054F5 |
-| size--s           | 8px     |
+| Token-Name               | Wert    |
+| ------------------------ | ------- |
+| color--hosting-blue--800 | #0054F5 |
+| size-px--s               | 8px     |
 
 ## Alias Token
 
@@ -130,10 +130,10 @@ Wir nutzen diese Ebene vor allem für die Definition von Tokens, die sich keiner
 bestimmten Variante (Solid, Soft, Outlined, Plain) zuordnen lassen, aber in eine
 gemeinsame Kategorie zusammengefasst werden können.
 
-| Token-Name              | Wert              |
-| ----------------------- | ----------------- |
-| primary--color--default | hosting-blue--800 |
-| border-width--400       | size--s           |
+| Token-Name          | Wert                     |
+| ------------------- | ------------------------ |
+| primary--color--800 | color--hosting-blue--800 |
+| border-width--400   | size-px--s               |
 
 ## Alias Token 2
 
@@ -147,10 +147,10 @@ zur Hintergrundfarbe passt und barrierefrei lesbar ist.
 Ein Alias Token 2 darf keine hard coded Werte besitzen, sich aber sowohl auf
 Alias als auch Global Token beziehen.
 
-| Token-Name                              | Wert                    |
-| --------------------------------------- | ----------------------- |
-| primary-solid-background-color--default | primary--color--default |
-| info-outline-border-color--default      | info-color--default     |
+| Token-Name                              | Wert                |
+| --------------------------------------- | ------------------- |
+| primary-solid-background-color--default | primary--color--800 |
+| info-outline-border-color               | info--color--800    |
 
 ## Component Specific Token
 
@@ -162,4 +162,4 @@ Token-Struktur und sind somit das Gegenteil eines Global Tokens.
 | Token-Name                                      | Wert                                    |
 | ----------------------------------------------- | --------------------------------------- |
 | button--primary-solid-background-color--default | primary-solid-background-color--default |
-| alert--info-outline-border-color--default       | info-outline-border-color--default      |
+| alert--info-border-color                        | info-outline-border-color               |

--- a/apps/docs/src/content/02-foundations/04-internal/01-boundaries/examples/modal-error.tsx
+++ b/apps/docs/src/content/02-foundations/04-internal/01-boundaries/examples/modal-error.tsx
@@ -9,7 +9,7 @@ import {
 
 <div
   style={{
-    background: "var(--overlay--background-color)",
+    background: "var(--overlay--backdrop-color)",
     margin: "calc(var(--size-px--l) * -1)",
     padding: "var(--size-px--l)",
   }}

--- a/apps/docs/src/content/02-foundations/04-internal/01-boundaries/examples/modal-loading.tsx
+++ b/apps/docs/src/content/02-foundations/04-internal/01-boundaries/examples/modal-loading.tsx
@@ -2,7 +2,7 @@ import { LoadingSpinner } from "@mittwald/flow-react-components";
 
 <div
   style={{
-    background: "var(--overlay--background-color)",
+    background: "var(--overlay--backdrop-color)",
     margin: "calc(var(--size-px--l) * -1)",
     padding: "var(--size-px--xxl)",
     display: "flex",

--- a/apps/docs/src/lib/liveCode/components/LiveCodeEditor/lib/flowTheme.ts
+++ b/apps/docs/src/lib/liveCode/components/LiveCodeEditor/lib/flowTheme.ts
@@ -62,12 +62,6 @@ export const flowTheme: PrismTheme = {
       },
     },
     {
-      types: ["punctuation"],
-      style: {
-        color: "var(--color--code-syntax--text)",
-      },
-    },
-    {
       types: ["tag"],
       style: {
         color: "var(--color--code-syntax--keyword)",
@@ -83,18 +77,6 @@ export const flowTheme: PrismTheme = {
       types: ["attr-value"],
       style: {
         color: "var(--color--code-syntax--string)",
-      },
-    },
-    {
-      types: ["inserted"],
-      style: {
-        color: "var(--color--code-syntax--inserted)",
-      },
-    },
-    {
-      types: ["deleted"],
-      style: {
-        color: "var(--color--code-syntax--invalid)",
       },
     },
     {

--- a/packages/components/src/components/MarkdownEditor/stories/Default.stories.tsx
+++ b/packages/components/src/components/MarkdownEditor/stories/Default.stories.tsx
@@ -21,6 +21,7 @@ import { Action } from "@/components/Action";
 import { ActionGroup } from "@/components/ActionGroup";
 import { IconSignature } from "@tabler/icons-react";
 import { Icon } from "@/components/Icon";
+import { Color } from "@/components/Color";
 
 const meta: Meta<typeof MarkdownEditor> = {
   title: "Form Controls/MarkdownEditor",
@@ -113,18 +114,7 @@ const DemoMentionMarkdownPreview = ({
       components={{
         a: ({ children, href }) => {
           if (href?.includes("mention:")) {
-            return (
-              <strong
-                style={{
-                  color: "var(--color--primary)",
-                  background: "var(--color--primary-subtle)",
-                  borderRadius: "var(--border-radius-pill)",
-                  padding: "0 var(--space-1)",
-                }}
-              >
-                @{children}
-              </strong>
-            );
+            return <Color color="teal">@{children}</Color>;
           }
 
           return <a href={href}>{children}</a>;


### PR DESCRIPTION
Audits every `var(--…)` reference in `packages/**` and `apps/docs` against the generated token set, and fixes the dangling names it found.

**Renamed away.** `--overlay--background-color` became `--overlay--backdrop-color` in #2338; the two boundary modal examples kept the old name and had rendered without a backdrop since.

**Never existed.** `--color--code-syntax--text` and `--color--code-syntax--inserted` in the live-code editor theme. The rules referencing them are removed rather than remapped, along with the equally unreachable `deleted` rule — `prism-react-renderer` bundles no `diff` grammar and both call sites render `tsx`, so `inserted` and `deleted` can never be produced, and `punctuation` already fell back to `plain`. `flowTheme` now uses exactly the ten `--color--code-syntax--*` tokens that exist, the same set as CodeEditor's `defaultEditorTheme`. Rendering is unchanged.

**MarkdownEditor mention story.** `--color--primary`, `--color--primary-subtle`, `--border-radius-pill` and `--space-1` are not Flow tokens, so the mention chip rendered unstyled. It now uses the `Color` component rather than a hand-styled `<strong>`. `Badge` would be the closer visual match but does not work inline — it renders a `<div>`, which React rejects inside the `<p>` markdown produces, and its `display: flex` breaks the sentence across three lines.

**Design-token page.** Five of the names in the example tables no longer exist (`size--s`, `primary--color--default`, `info-outline-border-color--default`, `info-color--default`, `alert--info-outline-border-color--default`). The tables now show the real chain, which runs cleanly across all four levels: `color--hosting-blue--800` → `primary--color--800` → `primary-solid-background-color--default` → `button--primary-solid-background-color--default`.

The shipped component CSS was already clean. Fourteen names stay unresolved on purpose: twelve are set at runtime (ours, plus react-aria's `--page-height`, `--trigger-width`, `--visual-viewport-height`), and the docs wireframe's `--wireframe-width` / `--wireframe-height` have inline fallbacks.