### PR TITLE
ci: split the test suite into parallel jobs, shard the visual tests

### DIFF
--- a/.github/actions/prepare-browser-tests/action.yml
+++ b/.github/actions/prepare-browser-tests/action.yml
@@ -1,0 +1,50 @@
+name: Prepare browser tests
+description:
+  Answers whether a browser suite has anything to run in this PR, and installs
+  the browser only when it has.
+
+inputs:
+  target:
+    description: The nx target the calling job runs, e.g. `test:visual`.
+    required: true
+
+outputs:
+  run:
+    description:
+      Whether at least one affected project has the target. Gate the job's
+      remaining steps on it.
+    value: ${{ steps.affected.outputs.run }}
+
+runs:
+  using: composite
+  steps:
+    # Needs the shas nrwl/nx-set-shas exports, so call this after it.
+    - name: Check whether the suite is affected
+      id: affected
+      shell: bash
+      run: |
+        projects="$(pnpm nx show projects --affected --with-target=${{ inputs.target }} --json | tail -n 1)"
+        echo "affected projects with ${{ inputs.target }}: $projects"
+        if [ "$projects" = "[]" ]; then
+          echo "run=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "run=true" >> "$GITHUB_OUTPUT"
+        fi
+
+    # Keyed apart from the visual workflows' cache on purpose. They install
+    # Firefox as well, and under one shared key whichever workflow saved first
+    # would decide what the other one finds.
+    - name: Cache the Playwright browser
+      if: steps.affected.outputs.run == 'true'
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+      with:
+        path: ~/.cache/ms-playwright
+        key:
+          playwright-webkit-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          playwright-webkit-${{ runner.os }}-
+
+    - name: Install the Playwright browser
+      if: steps.affected.outputs.run == 'true'
+      shell: bash
+      run: pnpm exec playwright install --with-deps webkit

--- a/.github/actions/prepare-workspace/action.yml
+++ b/.github/actions/prepare-workspace/action.yml
@@ -1,6 +1,6 @@
 name: Prepare workspace
 description:
-  Node, pnpm and the workspace dependencies, plus the two caches the test jobs
+  Node, pnpm and the workspace dependencies, plus the nx cache the test jobs
   share.
 
 inputs:
@@ -9,11 +9,6 @@ inputs:
       Restore nx's local task cache. Every job that builds workspace packages
       before it can test wants this; a job that only lints does not.
     default: "true"
-  playwright:
-    description:
-      Install the browser the test suites are driven in. WebKit only - Firefox
-      belongs to the visual workflows, which render both themes.
-    default: "false"
 
 runs:
   using: composite
@@ -44,21 +39,3 @@ runs:
         key: nx-${{ runner.os }}-${{ github.sha }}
         restore-keys: |
           nx-${{ runner.os }}-
-
-    # Keyed apart from the visual workflows' cache on purpose. They install
-    # Firefox as well, and under one shared key whichever workflow saved first
-    # would decide what the other one finds.
-    - name: Cache the Playwright browser
-      if: inputs.playwright == 'true'
-      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
-      with:
-        path: ~/.cache/ms-playwright
-        key:
-          playwright-webkit-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-        restore-keys: |
-          playwright-webkit-${{ runner.os }}-
-
-    - name: Install the Playwright browser
-      if: inputs.playwright == 'true'
-      shell: bash
-      run: pnpm exec playwright install --with-deps webkit

--- a/.github/actions/prepare-workspace/action.yml
+++ b/.github/actions/prepare-workspace/action.yml
@@ -1,0 +1,64 @@
+name: Prepare workspace
+description:
+  Node, pnpm and the workspace dependencies, plus the two caches the test jobs
+  share.
+
+inputs:
+  nx-cache:
+    description:
+      Restore nx's local task cache. Every job that builds workspace packages
+      before it can test wants this; a job that only lints does not.
+    default: "true"
+  playwright:
+    description:
+      Install the browser the test suites are driven in. WebKit only - Firefox
+      belongs to the visual workflows, which render both themes.
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Install pnpm
+      uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+    - name: Setup Node.js
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      with:
+        node-version: 24
+        cache: pnpm
+
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile
+
+    # Restore only. Every job below builds the same workspace packages through
+    # `^build` before it can test, and a hit turns those ~40s into unpacking.
+    # Only `main` writes the cache (see test.yml): a cache created on a PR branch
+    # is visible to that branch alone, while the default branch's is visible to
+    # every PR.
+    - name: Restore the nx cache
+      if: inputs.nx-cache == 'true'
+      uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+      with:
+        path: .nx/cache
+        key: nx-${{ runner.os }}-${{ github.sha }}
+        restore-keys: |
+          nx-${{ runner.os }}-
+
+    # Keyed apart from the visual workflows' cache on purpose. They install
+    # Firefox as well, and under one shared key whichever workflow saved first
+    # would decide what the other one finds.
+    - name: Cache the Playwright browser
+      if: inputs.playwright == 'true'
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+      with:
+        path: ~/.cache/ms-playwright
+        key:
+          playwright-webkit-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          playwright-webkit-${{ runner.os }}-
+
+    - name: Install the Playwright browser
+      if: inputs.playwright == 'true'
+      shell: bash
+      run: pnpm exec playwright install --with-deps webkit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,19 @@
+# The PR test suite. It used to be one sequential job — lint, unit, then every
+# browser suite behind each other — which summed to 12-14 minutes, half of it in
+# `test:visual` alone. Nothing here is skipped or weakened: the same targets run,
+# split by target so the wall clock is the slowest job instead of the sum, and
+# the 84-file visual suite is sharded across four runners because it is serial by
+# design (`fileParallelism: false`, see the visual project in
+# packages/remote-react-components/vitest.config.ts).
+#
+# Every suite is driven in WebKit. Should be changed to Chromium when flakiness
+# is resolved, because of Chromium wider usage. BTW: Using Webkit for now,
+# because Firefox has issues with parallel visual tests.
+#
+# `main` at the bottom is the aggregate. Keep that job id: it is the required
+# status check in the branch ruleset, and the check Dependabot waits for before
+# it merges its own PRs (see dependabot-auto-merge.yml). Renaming it, or adding a
+# job below without adding it to `needs`, silently drops that gate.
 name: Run tests
 on:
   push:
@@ -14,31 +30,17 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  main:
+  lint:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-
-      - name: Setup Node.js
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      - uses: ./.github/actions/prepare-workspace
         with:
-          node-version: 24
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
-
-      - name: Prepare NX affected commands
-        if: github.ref != 'refs/heads/main'
-        run: git branch --track main origin/main
+          nx-cache: "false" # nothing here builds a package
 
       - name: Lint & check formatting
         run: pnpm lint
@@ -57,24 +59,168 @@ jobs:
       - name: Check version consistency
         run: node .github/scripts/version-consistency-guard.mjs
 
+  unit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/prepare-workspace
+
+      - uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
+
+      - name: Prepare NX affected commands
+        if: github.ref != 'refs/heads/main'
+        run: git branch --track main origin/main
+
       - name: Run tests
         run: pnpm affected:test
 
-      - name: Cache Playwright browsers
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            playwright-${{ runner.os }}-
-
-      - name: Prepare browser tests
-        run: pnpm test:browser:prepare --only-shell
-
-      # Should be changed to Chromium when flakiness is resolved, because of Chromium wider usage
-      # BTW: Using Webkit for now, because Firefox has issues with parallel visual tests
-      - name: Run browser tests in Webkit
-        run: pnpm affected:test:browser --parallel=1 --browser.name=webkit
-
+      # Stays in this job because its affected set is the widest: every project
+      # with a browser suite also has `test:compile`, and both targets build the
+      # same `^build` chain — so whatever generator the browser jobs would run
+      # has already run here.
       - name: Check all generated code is committed
         run: git diff --exit-code
+
+      # The one writer. Every other job restores this, so a PR starts from the
+      # builds `main` already paid for and only rebuilds what it changed.
+      - name: Save the nx cache
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: .nx/cache
+          key: nx-${{ runner.os }}-${{ github.sha }}
+
+  browser:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/prepare-workspace
+        with:
+          playwright: "true"
+
+      - uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
+
+      - name: Prepare NX affected commands
+        if: github.ref != 'refs/heads/main'
+        run: git branch --track main origin/main
+
+      # `--parallel=1` throughout: the suites are unchanged, one browser at a
+      # time on the runner, exactly as they ran in the single job. What overlaps
+      # now are jobs, not suites inside a job.
+      - name: Run browser tests in Webkit
+        run:
+          pnpm nx affected --targets=test:browser --parallel=1
+          --browser.name=webkit
+
+  # Its own job rather than a second target on `browser`: run behind it, the two
+  # of them together would take longer than the visual shards below and become
+  # the critical path.
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/prepare-workspace
+        with:
+          playwright: "true"
+
+      - uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
+
+      - name: Prepare NX affected commands
+        if: github.ref != 'refs/heads/main'
+        run: git branch --track main origin/main
+
+      - name: Run e2e tests in Webkit
+        run:
+          pnpm nx affected --targets=test:e2e --parallel=1 --browser.name=webkit
+
+  visual:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      # Each shard is a separate signal. A failing one must not cancel the others
+      # — the diffs of the shards still running are what tell you whether the
+      # change is broad or local.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/prepare-workspace
+        with:
+          playwright: "true"
+
+      - uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
+
+      - name: Prepare NX affected commands
+        if: github.ref != 'refs/heads/main'
+        run: git branch --track main origin/main
+
+      # `nx affected` answers this for the other jobs. The shards call vitest
+      # directly (see below), so they have to ask before doing any work — a PR
+      # that touches neither the components nor the remote packages must not
+      # start four browsers.
+      - name: Check whether the visual suite is affected
+        id: affected
+        run: |
+          projects="$(pnpm nx show projects --affected --with-target=test:visual --json | tail -n 1)"
+          echo "affected projects: $projects"
+          if [ "$projects" = "[]" ]; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # `test:visual` only declares `^build`; building the package itself is a
+      # superset of that, and one `nx run` is all the shards need to be ready.
+      - name: Build the packages the visual suite renders
+        if: steps.affected.outputs.run == 'true'
+        run: pnpm nx run remote-react-components:build
+
+      # Deliberately not `nx run …:test:visual`: the target is cached, and nx
+      # hands every shard of it the same task hash — with the cache shared across
+      # jobs, three of the four shards would be served a pass they never ran.
+      #
+      # vitest shards by hashing the file paths, so the split is stable and each
+      # shard still runs its files one at a time, in one browser, against the
+      # committed baselines. Same suite, four runners.
+      - name: Run visual tests in Webkit (shard ${{ matrix.shard }})
+        if: steps.affected.outputs.run == 'true'
+        run:
+          pnpm --filter @mittwald/flow-remote-react-components test:visual
+          --shard=${{ matrix.shard }}/${{ strategy.job-total }}
+          --browser.name=webkit
+
+  # The required check. Green only when every job above is.
+  main:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: always()
+    needs:
+      - lint
+      - unit
+      - browser
+      - e2e
+      - visual
+    steps:
+      - name: Check the test jobs
+        if: >
+          contains(needs.*.result, 'failure') ||
+          contains(needs.*.result, 'cancelled')
+        run: |
+          echo "::error::At least one test job failed. See the jobs of this run."
+          exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,8 +103,6 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/prepare-workspace
-        with:
-          playwright: "true"
 
       - uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
 
@@ -112,9 +110,14 @@ jobs:
         if: github.ref != 'refs/heads/main'
         run: git branch --track main origin/main
 
-      # `--parallel=1` throughout: the suites are unchanged, one browser at a
-      # time on the runner, exactly as they ran in the single job. What overlaps
-      # now are jobs, not suites inside a job.
+      - uses: ./.github/actions/prepare-browser-tests
+        with:
+          target: test:browser
+
+      # `nx affected` is still the authority on what runs — it just no-ops in a
+      # second when nothing is. `--parallel=1` throughout: the suites are
+      # unchanged, one browser at a time on the runner, exactly as they ran in
+      # the single job. What overlaps now are jobs, not suites inside a job.
       - name: Run browser tests in Webkit
         run:
           pnpm nx affected --targets=test:browser --parallel=1
@@ -132,14 +135,16 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/prepare-workspace
-        with:
-          playwright: "true"
 
       - uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
 
       - name: Prepare NX affected commands
         if: github.ref != 'refs/heads/main'
         run: git branch --track main origin/main
+
+      - uses: ./.github/actions/prepare-browser-tests
+        with:
+          target: test:e2e
 
       - name: Run e2e tests in Webkit
         run:
@@ -161,8 +166,6 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/prepare-workspace
-        with:
-          playwright: "true"
 
       - uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
 
@@ -170,25 +173,19 @@ jobs:
         if: github.ref != 'refs/heads/main'
         run: git branch --track main origin/main
 
-      # `nx affected` answers this for the other jobs. The shards call vitest
-      # directly (see below), so they have to ask before doing any work — a PR
-      # that touches neither the components nor the remote packages must not
-      # start four browsers.
-      - name: Check whether the visual suite is affected
-        id: affected
-        run: |
-          projects="$(pnpm nx show projects --affected --with-target=test:visual --json | tail -n 1)"
-          echo "affected projects: $projects"
-          if [ "$projects" = "[]" ]; then
-            echo "run=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          fi
+      # The other jobs leave the decision to `nx affected` and use this only to
+      # skip the browser install. The shards call vitest directly (see below), so
+      # here the answer gates the work itself — a PR that touches neither the
+      # components nor the remote packages must not start four browsers.
+      - uses: ./.github/actions/prepare-browser-tests
+        id: suite
+        with:
+          target: test:visual
 
       # `test:visual` only declares `^build`; building the package itself is a
       # superset of that, and one `nx run` is all the shards need to be ready.
       - name: Build the packages the visual suite renders
-        if: steps.affected.outputs.run == 'true'
+        if: steps.suite.outputs.run == 'true'
         run: pnpm nx run remote-react-components:build
 
       # Deliberately not `nx run …:test:visual`: the target is cached, and nx
@@ -199,7 +196,7 @@ jobs:
       # shard still runs its files one at a time, in one browser, against the
       # committed baselines. Same suite, four runners.
       - name: Run visual tests in Webkit (shard ${{ matrix.shard }})
-        if: steps.affected.outputs.run == 'true'
+        if: steps.suite.outputs.run == 'true'
         run:
           pnpm --filter @mittwald/flow-remote-react-components test:visual
           --shard=${{ matrix.shard }}/${{ strategy.job-total }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,7 +122,7 @@ pnpm nx test:compile components            # tsc --noEmit for one package
 
 pnpm test:browser:prepare                  # install Playwright browsers (once)
 pnpm nx test:browser components --browser.name=webkit
-pnpm affected:test:browser --parallel=1 --browser.name=webkit   # what CI runs
+pnpm affected:test:browser --parallel=1 --browser.name=webkit   # browser/e2e/visual
 pnpm nx test:visual:update remote-react-components              # update visual snapshots
 
 pnpm lint                                  # eslint + stylelint + format:check (pre-push hook runs this)

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -596,10 +596,16 @@ pnpm affected:test                                              # unit + compile
 pnpm affected:test:browser --parallel=1 --browser.name=webkit   # browser/e2e/visual
 ```
 
-> ⚠️ **Generated code must be committed.** The final CI step is
-> `git diff --exit-code`. If you changed a component with `@flr-generate` or
-> touched icons, run the relevant `build:*` target and commit the result —
-> otherwise CI fails even though your code is correct.
+Locally that is one command after the other. CI runs the same targets as
+separate jobs — `lint`, `unit`, `browser`, `e2e` and four `visual` shards — so
+its wall clock is the slowest job rather than the sum. `main` is the job that
+aggregates them and the check the branch ruleset requires; a red job turns it
+red.
+
+> ⚠️ **Generated code must be committed.** CI runs `git diff --exit-code` after
+> the unit tests. If you changed a component with `@flr-generate` or touched
+> icons, run the relevant `build:*` target and commit the result — otherwise CI
+> fails even though your code is correct.
 
 ## Code style
 
@@ -733,9 +739,9 @@ retitling the PR or changing its base.
    branch you chose in step 1.
 
 CI (`.github/workflows/test.yml`) runs lint, unit tests, and browser tests
-(WebKit) on every PR, and verifies all generated code is committed. A preview
-deployment of docs + Storybook is built for each PR so reviewers can see your
-changes live.
+(WebKit) on every PR, and verifies all generated code is committed. The jobs run
+in parallel and report through one required check, `main`. A preview deployment
+of docs + Storybook is built for each PR so reviewers can see your changes live.
 
 PRs are **squash-merged**, so the **PR title becomes the release commit** — it
 must be a valid Conventional Commit. `.github/workflows/commit-guard.yml` lints


### PR DESCRIPTION
## What & why

The PR suite ran as one sequential job and took 12-14 minutes. Measured on [run 33173796538](https://github.com/mittwald/flow/actions/runs/33173796538): lint 50s, `affected:test` 73s, Playwright 27s, and 527s of browser suites — `test:visual` alone is 368s of that. The visual suite is serial by design (`fileParallelism: false`, because Firefox drops focus styling from any page it is not showing), so nothing inside it gets faster on a single runner.

Same targets, same suites, same flags — only the packaging changes:

- **lint, unit, browser, e2e and visual are separate jobs**, so the wall clock is the slowest job instead of the sum. Everything keeps `--parallel=1`: what overlaps now are jobs, not suites inside a job.
- **The 84 visual files are sharded across four runners.** Each shard still runs its files one at a time, in one browser, against the committed baselines. vitest shards by hashing file paths, so the split is stable. Verified locally: `--shard=1/4` selects 21 files and passes against the `-darwin` baselines.
- The shards call vitest **directly**, not through nx: the target is cached and every shard would get the same task hash, so with the cache shared across jobs three of the four would be served a pass they never ran. They ask `nx show projects --affected` first, so a PR that touches neither the components nor the remote packages starts no browser.
- **The browser is installed only when a suite has something to run.** It used to sit in the workspace setup, ahead of that answer — six WebKit downloads on a PR that then reports "no projects".
- **Pushes to `main` save nx's local cache**, every job restores it — a PR starts from the builds `main` already paid for.
- The visual workflows install Firefox as well and now keep their own Playwright cache key, so neither decides what the other finds.

`main` becomes an aggregate job over `needs`. It keeps that id on purpose: it is the required status check in the branch ruleset and the check Dependabot waits for before merging its own PRs. A new job that is not in its `needs` would silently drop out of the gate — noted at the top of the workflow.

## Measured

This PR only touches CI and docs, so its own run has nothing affected and skips every suite — which measures the skip path, not the work. To measure the real one, a throwaway commit touching `packages/components` was pushed, run, and removed again. Both paths, on the final state of the branch:

| | affected ([run 33180807781](https://github.com/mittwald/flow/actions/runs/33180807781)) | nothing affected ([run 33180597907](https://github.com/mittwald/flow/actions/runs/33180597907)) |
| --- | --- | --- |
| `lint` | 104s | 86s |
| `unit` | 118s | 43s |
| `browser` | 213s (tests 127s) | 56s |
| `e2e` | 240s (tests 155s) | 42s |
| `visual (1)` | 220s (tests 93s) | 45s |
| `visual (2)` | 217s (tests 90s) | 53s |
| `visual (3)` | 262s (tests 113s) | 40s |
| `visual (4)` | 217s (tests 84s) | 45s |
| **run total** | **272s** | **95s** |

**12:00 → 4:32** for the same suite, all green. The 368s serial visual suite is 84-113s per shard; shard 3 draws the heavy files (`List` alone is 22s), which is the spread vitest's path-hash split produces.

Both caches were still cold in those runs (nothing has written `nx-Linux-*` yet, and the shards raced for the same Playwright key). Once this is on `main` and its push run seeds them, the per-job setup drops further.

The remaining fat is visible in the table: each visual shard pays its own ~56s build. Sharing it through an artifact would serialise a build job in front of the shards and cost more than it saves, so it stays parallel.

## Checklist

- [x] PR title is a Conventional Commit and matches the base branch above
- [x] `pnpm lint` is clean (pre-push hook); no source change, so no test impact
- [x] **Generated code is committed** — nothing generated changed
- [x] No user-facing strings
- [x] Docs updated: AGENTS.md + CONTRIBUTE.md describe the split
