### PR TITLE
ci: shard the visual and cross-version suites, and gate PRs on the iframe harness

### DIFF
--- a/.github/actions/prepare-cross-version/action.yml
+++ b/.github/actions/prepare-cross-version/action.yml
@@ -1,0 +1,41 @@
+name: Prepare cross-version tests
+description:
+  The browser both cross-version harnesses render in, and the old published
+  versions they render.
+
+runs:
+  using: composite
+  steps:
+    # Both harnesses are WebKit-only, so this is the same cache the PR suites
+    # fill — not the two-browser one the visual workflows keep.
+    - name: Cache the Playwright browser
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+      with:
+        path: ~/.cache/ms-playwright
+        key:
+          playwright-webkit-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          playwright-webkit-${{ runner.os }}-
+
+    - name: Install the Playwright browser
+      shell: bash
+      run: pnpm exec playwright install --with-deps webkit
+
+    # Restore only: `cross-version-resolve` writes this cache, and every job
+    # below reads what it left. A published tarball never changes and `prepare`
+    # skips a version it already finds, so a partial hit installs the rest and a
+    # stale one costs nothing.
+    - name: Restore the installed old versions
+      uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+      with:
+        path: packages/remote-react-components/node_modules/.cross-version
+        key: cross-version-${{ runner.os }}-${{ hashFiles('lerna.json') }}
+        restore-keys: |
+          cross-version-${{ runner.os }}-
+
+    # Builds the host packages the harnesses consume from dist (nx-cached) and
+    # writes `cross-version.manifest.json`. Uncached on purpose: it resolves the
+    # target versions against the registry.
+    - name: Build the host packages and install the old published versions
+      shell: bash
+      run: pnpm nx run remote-react-components:test:cross-version:prepare

--- a/.github/actions/run-visual-shard/action.yml
+++ b/.github/actions/run-visual-shard/action.yml
@@ -1,0 +1,70 @@
+name: Run one visual shard
+description:
+  Installs the browsers the visual suite renders in, builds what it renders, and
+  runs one shard of it.
+
+inputs:
+  shard:
+    description: This shard's 1-based index.
+    required: true
+  shards:
+    description: How many shards the suite is split into.
+    required: true
+  attempts:
+    description:
+      How often to run the shard before calling it failed. Firefox
+      intermittently hangs on a single file in headless CI — a hang vitest's
+      per-test `retry` cannot recover, only a fresh browser process can. A real
+      diff fails every attempt.
+    default: "1"
+
+runs:
+  using: composite
+  steps:
+    # Both browsers, because the suite renders one theme in each (WebKit light,
+    # Firefox dark) and a full run needs both. Keyed apart from test.yml's
+    # WebKit-only cache, which would otherwise decide what this one finds.
+    - name: Cache the Playwright browsers
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          playwright-${{ runner.os }}-
+
+    - name: Install the Playwright browsers
+      shell: bash
+      run: pnpm test:browser:prepare --only-shell
+
+    # `test:visual` only declares `^build`; building the package itself is a
+    # superset of that. Outside the retry loop below: a hung browser leaves the
+    # build valid, and nx would serve it from cache anyway.
+    - name: Build the packages the visual suite renders
+      shell: bash
+      run: pnpm nx run remote-react-components:build
+
+    # Deliberately not `nx run …:test:visual`: the target is cached and every
+    # shard would be handed the same task hash, so a shared cache would serve
+    # most of them a pass they never ran.
+    #
+    # vitest shards by hashing the file paths, so the split is stable and each
+    # shard still runs its files one at a time, in both browsers, against the
+    # committed baselines. Same suite, spread over runners.
+    - name: Run visual tests (shard ${{ inputs.shard }}/${{ inputs.shards }})
+      shell: bash
+      run: |
+        shard="${{ inputs.shard }}/${{ inputs.shards }}"
+        attempts="${{ inputs.attempts }}"
+        for attempt in $(seq 1 "$attempts"); do
+          echo "::group::Visual tests, shard $shard (attempt $attempt/$attempts)"
+          if pnpm --filter @mittwald/flow-remote-react-components test:visual --shard="$shard"; then
+            echo "::endgroup::"
+            exit 0
+          fi
+          echo "::endgroup::"
+          if [ "$attempt" -lt "$attempts" ]; then
+            echo "::warning::Shard $shard failed on attempt $attempt/$attempts (likely a flaky firefox hang), retrying..."
+          fi
+        done
+        echo "::error::Shard $shard failed."
+        exit 1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,15 +21,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
-        with:
-          node-version: 24
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/prepare-workspace
 
       - name: Test components
         run: pnpm nx test:unit components --coverage.enabled true

--- a/.github/workflows/test-cross-version-label.yml
+++ b/.github/workflows/test-cross-version-label.yml
@@ -54,15 +54,7 @@ jobs:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
-        with:
-          node-version: 24
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/prepare-workspace
 
       - name: Cache Playwright browsers
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0

--- a/.github/workflows/test-visual-label.yml
+++ b/.github/workflows/test-visual-label.yml
@@ -100,6 +100,10 @@ jobs:
         with:
           name: visual-diffs-${{ matrix.shard }}
           path: packages/**/.vitest-attachments/**
+          # `.vitest-attachments` is a dot directory, and the action drops those
+          # unless told otherwise — which is why this upload has been finding
+          # "no files" and every failing run so far came without its diffs.
+          include-hidden-files: true
           if-no-files-found: ignore
           retention-days: 7
 

--- a/.github/workflows/test-visual-label.yml
+++ b/.github/workflows/test-visual-label.yml
@@ -94,16 +94,47 @@ jobs:
           shard: ${{ matrix.shard }}
           shards: ${{ strategy.job-total }}
 
+      # vitest writes the diffs into `.vitest-attachments`, six directory levels
+      # deep. Uploaded as they lie, the zip opens on a dot directory Finder does
+      # not show, wrapped around folders a reviewer has to click through — and
+      # the action skips hidden paths entirely unless told not to, which is why
+      # every failing run so far reported "no files were found".
+      #
+      # So flatten: the images land next to each other, and opening the download
+      # is enough to see what changed. Their names already carry scenario,
+      # browser and platform. Only the per-scenario images are worth handing
+      # over — the loose blobs beside them are the report's own attachments.
+      #
+      # `packages/*/` (not `**/`) also leaves out the copies pnpm links into
+      # other packages' node_modules, which the old glob uploaded a second time.
+      - name: Collect the visual diffs
+        if: failure()
+        run: |
+          mkdir -p visual-diffs
+          for attachments in packages/*/.vitest-attachments; do
+            [ -d "$attachments" ] || continue
+            find "$attachments" -type f \
+              \( -name '*-diff-*.png' -o -name '*-actual-*.png' \
+                 -o -name '*-reference-*.png' \) -print0 |
+              while IFS= read -r -d '' image; do
+                target="visual-diffs/$(basename "$image")"
+                # A scenario description is unique within its test file, not
+                # across them — so name the file after it when one collides.
+                if [ -e "$target" ]; then
+                  scenario="$(basename "$(dirname "$image")" .browser.test.tsx)"
+                  target="visual-diffs/$scenario-$(basename "$image")"
+                fi
+                cp "$image" "$target"
+              done
+          done
+          ls -1 visual-diffs
+
       - name: Upload visual diffs
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: visual-diffs-${{ matrix.shard }}
-          path: packages/**/.vitest-attachments/**
-          # `.vitest-attachments` is a dot directory, and the action drops those
-          # unless told otherwise — which is why this upload has been finding
-          # "no files" and every failing run so far came without its diffs.
-          include-hidden-files: true
+          path: visual-diffs/**
           if-no-files-found: ignore
           retention-days: 7
 

--- a/.github/workflows/test-visual-label.yml
+++ b/.github/workflows/test-visual-label.yml
@@ -13,20 +13,25 @@ on:
       - reopened
       - synchronize
 
+# one at a time per branch; re-labeling supersedes an in-flight run
+concurrency:
+  group: visual-regression-run@${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
-  run-visual-tests:
+  # The gate for the whole run: the shards and the summary hang off this job, so
+  # a skip here skips them too.
+  prepare:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 5
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.head_ref != github.event.repository.default_branch &&
        (github.event.label.name == 'run-visual-tests' ||
         github.event.pull_request.user.login == 'dependabot[bot]'))
-
-    # one at a time per branch; re-labeling supersedes an in-flight run
-    concurrency:
-      group: visual-regression-run@${{ github.head_ref }}
-      cancel-in-progress: true
 
     permissions:
       contents: read # checkout only; this run never pushes
@@ -59,60 +64,69 @@ jobs:
                 }
             }
 
+  # The suite is serial by design (`fileParallelism: false` — firefox drops focus
+  # styling from any page it is not showing), and it renders every file in both
+  # browsers, so one runner spent 24-34 minutes on it. Sharding is the only split
+  # that keeps each file's conditions identical: every shard still runs its own
+  # files one at a time, in its own browser process.
+  run-visual-tests:
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      # A failing shard must not cancel the others — the diffs of the shards
+      # still running are what tell you whether the change is broad or local.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6]
+
+    steps:
       - name: Checkout selected branch
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: ./.github/actions/prepare-workspace
 
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      - uses: ./.github/actions/run-visual-shard
         with:
-          node-version: 24
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
-
-      - name: Cache Playwright browsers
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            playwright-${{ runner.os }}-
-
-      - run: pnpm test:browser:prepare --only-shell
-
-      - name: Run visual tests
-        # File parallelism is off in the visual project's vitest config, not here:
-        # firefox drops focus styling from any page that is not the focused one.
-        run: |
-          pnpm nx run-many -t test:visual --parallel=1
+          shard: ${{ matrix.shard }}
+          shards: ${{ strategy.job-total }}
 
       - name: Upload visual diffs
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: visual-diffs
+          name: visual-diffs-${{ matrix.shard }}
           path: packages/**/.vitest-attachments/**
           if-no-files-found: ignore
           retention-days: 7
 
+  # Reports for the run as a whole: one comment, whatever the shards did.
+  summary:
+    needs: run-visual-tests
+    if: always() && needs.run-visual-tests.result != 'skipped'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
       - name: Summary
-        if: always()
         run: |
           runUrl="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           {
-            if [[ "${{ job.status }}" == "success" ]]; then
+            if [[ "${{ needs.run-visual-tests.result }}" == "success" ]]; then
               echo "### ✅ Visual Regression Tests Passed"
               echo ""
               echo "All visual snapshots match the committed baselines."
             else
               echo "### ❌ Visual Regression Tests Failed"
               echo ""
-              echo "The visual test step did not pass. If snapshots differ from the committed baselines, download the **visual-diffs** artifact from [this run]($runUrl) to inspect the actual/diff images (the artifact is absent if the run failed before comparison, e.g. during install or browser setup)."
+              echo "At least one shard did not pass. If snapshots differ from the committed baselines, download the **visual-diffs-*** artifacts from [this run]($runUrl) to inspect the actual/diff images (a shard that failed before comparison, e.g. during install or browser setup, leaves none)."
               echo ""
               echo "If the differences are intentional, update the baselines by adding the \`update-screenshots\` label to the PR."
             fi
@@ -120,10 +134,10 @@ jobs:
           cat "$RUNNER_TEMP/visual-summary.md" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Comment summary on PR
-        # Same read-only-token reason as above. On a Dependabot PR the check run
-        # and its step summary are the signal; nothing auto-merges while it is
-        # red.
-        if: always() && github.event.action == 'labeled'
+        # Same read-only-token reason as the label removal above. On a Dependabot
+        # PR the check run and its step summary are the signal; nothing
+        # auto-merges while it is red.
+        if: github.event.action == 'labeled'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/test-visual-scheduled.yml
+++ b/.github/workflows/test-visual-scheduled.yml
@@ -54,9 +54,20 @@ jobs:
                   type: "mrkdwn"
                   text: "Visual tests failed. For more details, see the [output of the failed action](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
 
-  cross-version:
+  # The cross-version job used to be one runner spending ~24 minutes, 19 of them
+  # in the in-process harness: it renders the whole 84-file visual corpus once
+  # for the current reference and once per installed old version, in a loop. The
+  # versions are independent, so they no longer wait for each other — and each
+  # version's corpus is split the way the visual suite is.
+  #
+  # `resolve` exists because the target versions are resolved from the registry
+  # at run time (`selectTargetVersions.ts`): a matrix hard-coding them would
+  # silently stop covering a version the alpha fallback renamed.
+  cross-version-resolve:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 20
+    outputs:
+      targets: ${{ steps.manifest.outputs.targets }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
@@ -64,65 +75,177 @@ jobs:
 
       - uses: ./.github/actions/prepare-workspace
 
-      - name: Cache Playwright browsers
+      # Published tarballs never change and `prepare` skips a version it already
+      # finds, so this both saves the install and keeps the jobs below off the
+      # registry. Written here, restored there.
+      - name: Cache the installed old versions
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          path: packages/remote-react-components/node_modules/.cross-version
+          key: cross-version-${{ runner.os }}-${{ hashFiles('lerna.json') }}
           restore-keys: |
-            playwright-${{ runner.os }}-
+            cross-version-${{ runner.os }}-
 
-      - name: Prepare browser tests
-        run: pnpm test:browser:prepare --only-shell
-
-      - name: Build host packages and install old published versions
-        # `test:cross-version:prepare` declares `^build` as an nx dependency, so
-        # this single `pnpm nx run` builds the host packages the harnesses consume
-        # from dist (@mittwald/flow-react-components incl. /internal, and
-        # @mittwald/flow-remote-react-renderer — nx-cached) and then runs prepare,
-        # which resolves + npm-installs the target old versions (network) and
-        # writes cross-version.manifest.json. No separate build step needed.
-        # The two suites below stay separate direct-script steps on purpose: each
-        # exposes its own `failures` output for the Slack alert, and the in-process
-        # suite runs even if the iframe one fails. Running a suite via `nx run`
-        # would re-trigger this non-cached network prepare on every step.
+      - name: Build the host packages and install the old published versions
         run: pnpm nx run remote-react-components:test:cross-version:prepare
 
+      - name: Read the resolved targets
+        id: manifest
+        run: |
+          manifest=packages/remote-react-components/cross-version.manifest.json
+          targets="$(jq -c '[.targets[].category]' "$manifest")"
+          echo "resolved: $targets"
+          if [ "$targets" = "[]" ]; then
+            echo "::error::The manifest resolved no target versions, so nothing would be compared. See the prepare output above."
+            exit 1
+          fi
+          echo "targets=$targets" >> "$GITHUB_OUTPUT"
+
+  # Every version, one job: the whole harness is ~74s, so there is nothing to
+  # split. Its per-version retry stays in the runner.
+  cross-version-iframe:
+    needs: cross-version-resolve
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/prepare-workspace
+
+      - uses: ./.github/actions/prepare-cross-version
+
+      # Renders each installed old remote version through the current host over
+      # the real iframe connection and compares its host HTML to an ephemeral
+      # reference rendered from the current version. WebKit-only. The
+      # @quilted/threads handshake intermittently wedges a whole version's run
+      # under CI load ("Could not establish remote connection: Timeout reached")
+      # — a transient infra flake, not a diff, which only a fresh server pair
+      # recovers, so the runner retries each version in-process
+      # (`attemptsPerVersion`). A real HTML divergence still fails on every
+      # attempt.
       - name: Run cross-version smoke tests
         id: crossversion
-        # Renders each installed old remote version through the current host over
-        # the real iframe connection and compares its host HTML to an ephemeral
-        # reference rendered from the current version. WebKit-only. The
-        # @quilted/threads handshake intermittently wedges a whole version's run
-        # under CI load ("Could not establish remote connection: Timeout reached")
-        # — a transient infra flake, not a diff, and only a fresh server pair
-        # recovers it. The runner now retries EACH version in-process with fresh
-        # servers (`attemptsPerVersion`), so a single flaky version no longer reds
-        # the run. That replaces the old "re-run the entire step 3x" loop, which
-        # never converged (a different version flaked each attempt) and tripled
-        # the runtime. A real HTML divergence still fails on every attempt. Runs
-        # the package script directly (not `nx run`) so it doesn't re-trigger the
-        # non-cached network prepare above; the `failures` output feeds the Slack
-        # alert.
         run:
-          corepack pnpm --filter @mittwald/flow-remote-react-components
+          pnpm --filter @mittwald/flow-remote-react-components
           test:cross-version
 
+      - name: Keep the failures for the alert
+        if: failure() && steps.crossversion.outputs.failures != ''
+        env:
+          FAILURES: ${{ steps.crossversion.outputs.failures }}
+        run: |
+          mkdir -p failures
+          printf '%s\n' "$FAILURES" > failures/iframe.txt
+
+      - name: Upload the failures
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: cross-version-failures-iframe
+          path: failures/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  # One job per version and file shard. Each regenerates the current reference
+  # for its own shard — the reference is per file, so a shard may only compare
+  # what it also generated.
+  cross-version-inprocess:
+    needs: cross-version-resolve
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      # One failing version says nothing about the others, and the run is meant
+      # to report all of them at once.
+      fail-fast: false
+      matrix:
+        target: ${{ fromJSON(needs.cross-version-resolve.outputs.targets) }}
+        # Keep in step with CROSS_VERSION_SHARDS below — a two-dimensional
+        # matrix has no `strategy.job-total` that means "shards".
+        shard: [1, 2, 3]
+    env:
+      CROSS_VERSION_SHARDS: 3
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/prepare-workspace
+
+      - uses: ./.github/actions/prepare-cross-version
+
+      # Reuses the broad visual-test corpus in-process. WebKit-only. Unlike the
+      # iframe suite it has no real connection to time out; its config already
+      # sets vitest `retry: 2` to absorb the occasional per-test webkit flake, so
+      # no step-level retry is needed here.
       - name: Run in-process cross-version tests
-        id: crossversion_inprocess
-        if:
-          always() && (steps.crossversion.outcome == 'success' ||
-          steps.crossversion.outcome == 'failure')
-        # Reuses the broad visual-test corpus in-process. WebKit-only. Unlike the
-        # iframe suite it has no real connection to time out; its config already
-        # sets vitest `retry: 2` to absorb the occasional per-test webkit flake,
-        # so no step-level retry is needed here.
+        id: crossversion
+        env:
+          FLOW_CROSS_VERSION_TARGETS: ${{ matrix.target }}
+          FLOW_CROSS_VERSION_SHARD:
+            ${{ matrix.shard }}/${{ env.CROSS_VERSION_SHARDS }}
         run:
-          corepack pnpm --filter @mittwald/flow-remote-react-components
+          pnpm --filter @mittwald/flow-remote-react-components
           test:cross-version-inprocess
 
-      - name: Send alerting message to Slack
+      - name: Keep the failures for the alert
+        if: failure() && steps.crossversion.outputs.failures != ''
+        env:
+          FAILURES: ${{ steps.crossversion.outputs.failures }}
+        run: |
+          mkdir -p failures
+          printf '%s\n' "$FAILURES" \
+            > "failures/inprocess-${{ matrix.target }}-${{ matrix.shard }}.txt"
+
+      - name: Upload the failures
         if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name:
+            cross-version-failures-inprocess-${{ matrix.target }}-${{
+            matrix.shard }}
+          path: failures/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  # The shards cannot each alert, and matrix jobs have no shared output — so the
+  # failing ones leave their lists behind as artifacts and this collects them
+  # into the one message the channel used to get.
+  cross-version-alert:
+    needs:
+      - cross-version-resolve
+      - cross-version-iframe
+      - cross-version-inprocess
+    if: failure()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Collect the failures
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          pattern: cross-version-failures-*
+          path: failures
+          merge-multiple: true
+        continue-on-error: true
+
+      - name: Compose the report
+        id: report
+        run: |
+          read_section() {
+            # shellcheck disable=SC2086
+            cat $1 2>/dev/null || true
+          }
+          {
+            echo "iframe<<CROSSVER_IFRAME_EOF"
+            read_section "failures/iframe.txt"
+            echo "CROSSVER_IFRAME_EOF"
+            echo "inprocess<<CROSSVER_INPROCESS_EOF"
+            read_section "failures/inprocess-*.txt"
+            echo "CROSSVER_INPROCESS_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Send alerting message to Slack
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -142,14 +265,14 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ${{ toJSON(format('*Iframe harness*{0}{1}', '\n', steps.crossversion.outputs.failures || 'No failures reported.')) }}
+                    "text": ${{ toJSON(format('*Iframe harness*{0}{1}', '\n', steps.report.outputs.iframe || 'No failures reported.')) }}
                   }
                 },
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ${{ toJSON(format('*In-process harness*{0}{1}', '\n', steps.crossversion_inprocess.outputs.failures || 'No failures reported.')) }}
+                    "text": ${{ toJSON(format('*In-process harness*{0}{1}', '\n', steps.report.outputs.inprocess || 'No failures reported.')) }}
                   }
                 },
                 {

--- a/.github/workflows/test-visual-scheduled.yml
+++ b/.github/workflows/test-visual-scheduled.yml
@@ -8,59 +8,40 @@ permissions:
   contents: read
 
 jobs:
-  main:
+  # The suite is serial by design (`fileParallelism: false` — firefox drops focus
+  # styling from any page it is not showing), and it renders every file in both
+  # browsers, so one runner spent 24-34 minutes on it. Sharding is the only split
+  # that keeps each file's conditions identical: every shard still runs its own
+  # files one at a time, in its own browser process. The retry lives inside the
+  # shard now, so a flaky firefox hang re-runs a sixth of the suite, not all of
+  # it.
+  visual:
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6]
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: ./.github/actions/prepare-workspace
 
-      - name: Setup Node.js
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      - uses: ./.github/actions/run-visual-shard
         with:
-          node-version: 24
-          cache: pnpm
+          shard: ${{ matrix.shard }}
+          shards: ${{ strategy.job-total }}
+          attempts: "3"
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Cache Playwright browsers
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            playwright-${{ runner.os }}-
-
-      - name: Prepare browser tests
-        run: pnpm test:browser:prepare --only-shell
-
-      - name: Run visual tests
-        # Run without file parallelism, because firefox has issues with parallel visual tests.
-        # Retry the whole step because firefox intermittently *hangs* (not a snapshot diff) on a
-        # single visual test file in headless CI, which aborts the run with exit code 1 even though
-        # every test that runs passes. A hang can't be recovered by vitest's per-test `retry`, so we
-        # re-run the step with a fresh vitest/browser process. Successful `^build` deps are served
-        # from the nx cache, so retries only re-execute test:visual.
-        run: |
-          for attempt in 1 2 3; do
-            echo "::group::Visual tests (attempt $attempt/3)"
-            if pnpm nx run-many -t test:visual --parallel=1; then
-              echo "::endgroup::"
-              exit 0
-            fi
-            echo "::endgroup::"
-            echo "::warning::Visual tests failed on attempt $attempt/3 (likely a flaky firefox hang), retrying..."
-          done
-          echo "::error::Visual tests still failing after 3 attempts."
-          exit 1
-
+  alert:
+    needs: visual
+    if: failure()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
       - name: Send alerting message to Slack
-        if: failure()
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/test-visual-scheduled.yml
+++ b/.github/workflows/test-visual-scheduled.yml
@@ -62,17 +62,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-
-      - name: Setup Node.js
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
-        with:
-          node-version: 24
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/prepare-workspace
 
       - name: Cache Playwright browsers
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,6 +150,59 @@ jobs:
         run:
           pnpm nx affected --targets=test:e2e --parallel=1 --browser.name=webkit
 
+  # 74 seconds of the ~24 minutes the scheduled cross-version job spends — and
+  # the half that checks the attribute-level contract with published extensions,
+  # which is what removing a component or changing its rendered structure
+  # breaks. Running it here means the PR that breaks it says so, instead of the
+  # next scheduled run saying so after the merge. The broad in-process harness
+  # stays on the schedule: it renders the whole visual corpus per version.
+  cross-version:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/prepare-workspace
+
+      - uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
+
+      - name: Prepare NX affected commands
+        if: github.ref != 'refs/heads/main'
+        run: git branch --track main origin/main
+
+      - uses: ./.github/actions/prepare-browser-tests
+        id: suite
+        with:
+          target: test:cross-version
+
+      # Published tarballs never change, and `prepare` skips a version it
+      # already finds — so a hit costs nothing to be stale, and a miss installs
+      # only what is missing. Keyed on lerna.json because the version it holds is
+      # what the target set is resolved relative to.
+      - name: Restore the installed old versions
+        if: steps.suite.outputs.run == 'true'
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: packages/remote-react-components/node_modules/.cross-version
+          key: cross-version-${{ runner.os }}-${{ hashFiles('lerna.json') }}
+          restore-keys: |
+            cross-version-${{ runner.os }}-
+
+      - name: Build the host packages and install the old published versions
+        if: steps.suite.outputs.run == 'true'
+        run: pnpm nx run remote-react-components:test:cross-version:prepare
+
+      # The package script directly, not `nx run`: the target depends on the
+      # prepare above, which is uncached on purpose (it talks to the registry)
+      # and would run a second time.
+      - name: Run cross-version smoke tests in Webkit
+        if: steps.suite.outputs.run == 'true'
+        run:
+          pnpm --filter @mittwald/flow-remote-react-components
+          test:cross-version
+
   visual:
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -213,6 +266,7 @@ jobs:
       - browser
       - e2e
       - visual
+      - cross-version
     steps:
       - name: Check the test jobs
         if: >

--- a/packages/remote-react-components/CONTRIBUTE.md
+++ b/packages/remote-react-components/CONTRIBUTE.md
@@ -153,6 +153,12 @@ In addition, visual tests are run **with all supported browsers** twice a day to
 detect potential issues early. To verify both themes on a pull request, add the
 `run-visual-tests` label — it runs every browser.
 
+Every path is sharded across runners (vitest's `--shard`), because the suite is
+serial by design and a single runner is the wrong unit for it. A shard still
+runs its own files one at a time, in its own browser process, against the same
+baselines — what it renders is identical to a single-runner run. A failure names
+the shard; its diff images are in that shard's `visual-diffs-*` artifact.
+
 ## Cross-version smoke tests
 
 Extension developers ship remote apps built against a **published** version of

--- a/packages/remote-react-components/dev/cross-version/crossVersionRunner.test.ts
+++ b/packages/remote-react-components/dev/cross-version/crossVersionRunner.test.ts
@@ -1,0 +1,52 @@
+import { selectRequestedTargets } from "./crossVersionRunner";
+import { describe, expect, it } from "vitest";
+
+const targets = [
+  { category: "previous", version: "1.0.10" },
+  { category: "firstOfLine", version: "1.0.0" },
+  { category: "latestOfPreviousLine", version: "0.2.0-alpha.1058" },
+];
+
+describe("selectRequestedTargets", () => {
+  it("runs every target when nothing is requested", () => {
+    expect(selectRequestedTargets(targets, undefined)).toEqual(targets);
+    expect(selectRequestedTargets(targets, "")).toEqual(targets);
+    expect(selectRequestedTargets(targets, "  ")).toEqual(targets);
+  });
+
+  it("selects by category", () => {
+    expect(selectRequestedTargets(targets, "firstOfLine")).toEqual([
+      targets[1],
+    ]);
+  });
+
+  it("selects by version", () => {
+    expect(selectRequestedTargets(targets, "0.2.0-alpha.1058")).toEqual([
+      targets[2],
+    ]);
+  });
+
+  it("selects several, however they are spaced", () => {
+    expect(selectRequestedTargets(targets, "previous, 1.0.0")).toEqual([
+      targets[0],
+      targets[1],
+    ]);
+  });
+
+  it("names a target once, even when asked for twice", () => {
+    expect(selectRequestedTargets(targets, "previous,1.0.10")).toEqual([
+      targets[0],
+    ]);
+  });
+
+  /*
+   * The matrix runs one job per target. A job whose target the manifest no
+   * longer holds — a publish gap, a category the alpha fallback renamed — must
+   * fail rather than report a pass over an empty selection.
+   */
+  it("fails on a target the manifest does not hold", () => {
+    expect(() => selectRequestedTargets(targets, "previous,2.0.0")).toThrow(
+      /no target "2\.0\.0"/,
+    );
+  });
+});

--- a/packages/remote-react-components/dev/cross-version/crossVersionRunner.ts
+++ b/packages/remote-react-components/dev/cross-version/crossVersionRunner.ts
@@ -107,6 +107,54 @@ const readManifest = (logPrefix: string): Manifest => {
   }
 };
 
+/**
+ * The file shard this process runs, as vitest's `<index>/<count>`, or undefined
+ * for the whole suite. A version's corpus is the same 84 files the visual suite
+ * has, so CI splits it the same way — see `FLOW_CROSS_VERSION_TARGETS` for the
+ * other axis.
+ */
+const shard = process.env.FLOW_CROSS_VERSION_SHARD;
+
+/**
+ * The targets this process was asked for: a comma-separated list of categories
+ * (`previous`) or versions (`1.0.10`) in `FLOW_CROSS_VERSION_TARGETS`, or all
+ * of the manifest's when unset.
+ *
+ * A request naming something the manifest does not hold throws. One matrix job
+ * per target means a target that silently vanished — a publish gap, a changed
+ * category in the alpha fallback — would otherwise report a pass over nothing.
+ */
+export const selectRequestedTargets = (
+  targets: ManifestTarget[],
+  request = process.env.FLOW_CROSS_VERSION_TARGETS,
+): ManifestTarget[] => {
+  const requested = (request ?? "")
+    .split(",")
+    .map((name) => name.trim())
+    .filter((name) => name.length > 0);
+
+  if (requested.length === 0) {
+    return targets;
+  }
+
+  const selected = requested.map((name) => {
+    const target = targets.find(
+      (candidate) => candidate.category === name || candidate.version === name,
+    );
+    if (target === undefined) {
+      const available = targets
+        .map(({ category, version }) => `${category}=${version}`)
+        .join(", ");
+      throw new Error(
+        `cross-version: the manifest holds no target "${name}" (has: ${available}).`,
+      );
+    }
+    return target;
+  });
+
+  return [...new Map(selected.map((t) => [t.version, t])).values()];
+};
+
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
 
@@ -159,6 +207,12 @@ const runSuite = (
     "--reporter=default",
     "--reporter=json",
     `--outputFile=${jsonPath}`,
+    /*
+     * Before `--update`, which takes an optional value and would swallow what
+     * follows it. The reference pass shards with the comparison run on purpose:
+     * a shard may only compare the files it also generated references for.
+     */
+    ...(shard === undefined ? [] : [`--shard=${shard}`]),
     ...(update ? ["--update"] : []),
   ];
 
@@ -313,7 +367,7 @@ const withGitHubGroup = <T>(name: string, run: () => T): T => {
 export const runCrossVersion = (options: RunCrossVersionOptions): void => {
   const { labels, reference } = options;
   const { logPrefix } = labels;
-  const { targets } = readManifest(logPrefix);
+  const targets = selectRequestedTargets(readManifest(logPrefix).targets);
 
   if (targets.length === 0) {
     console.error(

--- a/packages/remote-react-components/package.json
+++ b/packages/remote-react-components/package.json
@@ -43,8 +43,8 @@
     "test:e2e": "vitest run --config=e2e/remote-test-server/vitest.config.ts --browser.headless",
     "test:e2e:dev": "vitest dev --config=e2e/remote-test-server/vitest.config.ts",
     "test:e2e:prepare": "pnpm rimraf e2e/remote-test-server/.vitest",
-    "test:unit": "vitest run --project=unit --passWithNoTests",
-    "test:unit:dev": "vitest dev --project=unit --passWithNoTests",
+    "test:unit": "vitest run --project=unit* --passWithNoTests",
+    "test:unit:dev": "vitest dev --project=unit* --passWithNoTests",
     "test:visual": "vitest run --project=visual --browser.headless",
     "test:visual:dev": "vitest dev --project=visual",
     "test:visual:update": "vitest run --project=visual --browser.headless --update"

--- a/packages/remote-react-components/src/tests/visual/DatePicker.browser.test.tsx
+++ b/packages/remote-react-components/src/tests/visual/DatePicker.browser.test.tsx
@@ -1,6 +1,16 @@
 import { testEnvironments } from "@/tests/lib/environments";
-import { test, vi } from "vitest";
+import { rootContainerLocator } from "@/tests/lib/RootContainer";
+import { expect, test, vi } from "vitest";
 import { page, userEvent } from "vitest/browser";
+
+/**
+ * Whether the focus sits in the scenario at all — the field's ring is pure CSS
+ * (`:focus-within` on the form control, `:focus` on the segment), so this is
+ * exactly what the reference encodes. The calendar renders in a portal outside
+ * the container, so an open one reads as `false`.
+ */
+const focusIsInTheScenario = () =>
+  rootContainerLocator.element().contains(document.activeElement);
 
 test.each(testEnvironments)(
   "DatePicker states (%s)",
@@ -53,7 +63,26 @@ test.each(testEnvironments)(
     await testScreenshot("DatePicker - calendar visible");
 
     await userEvent.keyboard("{enter}");
+
+    /*
+     * Enter closes the calendar, and react-aria restores the focus to the
+     * field's first segment as the popover unmounts. Tab pressed into that
+     * window is undone by the restore that lands after it: the focus ends up
+     * back on the segment, and the capture shows a focused field where the
+     * reference has none — a ~1% diff, in whichever environment lost the race
+     * (they share one reference).
+     *
+     * The screenshot preamble cannot cover this. A focus move is a CSS
+     * pseudo-class change, not a mutation its settle can observe, and the
+     * restore arrives after the quiet window either way. So wait for the field
+     * to have the focus back before handing it on.
+     */
+    await expect.poll(focusIsInTheScenario).toBe(true);
+
     await userEvent.keyboard("{tab}");
+
+    // ... and for Tab to have taken it out again, which is the state captured.
+    await expect.poll(focusIsInTheScenario).toBe(false);
 
     await testScreenshot("DatePicker - date selected");
   },


### PR DESCRIPTION
## What & why

Follow-up to #3005, which brought the PR suite from ~12 to ~4:30 by splitting it into parallel jobs. What was left after it were the two long-running suites: the visual regression run (label + schedule) and the cross-version smoke tests.

Both are serial by design and both were one runner each. Sharding is the split that keeps every file's conditions identical: a shard runs its own files one at a time, in its own browser process, against the same references.

### Visual suite

All 84 files in **both** browsers on one runner, ~13 minutes ([808s](https://github.com/mittwald/flow/actions/runs/33184713492) on a control run of `main`, 768s on the last green scheduled one) — up to 34 minutes when it fails, because the retry re-ran the whole suite three times. Now six shards, driven by a shared `run-visual-shard` action; the retry moved *into* the shard.

- **Label workflow**: `prepare` (removes the label) → the shards → a `summary` job that comments once for the run.
- **Scheduled workflow**: the shards plus an `alert` job.

### Cross-version suite

~24 minutes, and three consecutive runs put **1138s of it in the in-process harness alone**: it renders the whole 84-file visual corpus once for the current reference and once per installed old version, in a node loop. The versions do not depend on each other.

The runner takes two knobs — `FLOW_CROSS_VERSION_TARGETS` for a subset of the manifest, `FLOW_CROSS_VERSION_SHARD` for a file shard (the reference pass shards with it: a shard may only compare what it also generated) — and CI drives them as a matrix of version × shard. A requested target the manifest does not hold throws, rather than passing over an empty selection.

`cross-version-resolve` runs first because the targets are resolved against the registry at run time; a hard-coded matrix would quietly stop covering a version the alpha fallback renamed. It also fills the cache of installed old versions, keeping the nine jobs behind it off the registry — published tarballs never change, and `prepare` skips a version it already finds. The iframe harness stays one job: 74s for every version is nothing to split. Failing shards leave their lists as artifacts, which the alert collects into the one Slack message the channel used to get. Both harnesses are WebKit-only, so these jobs no longer install Firefox.

**The iframe harness also moves onto affected PRs.** It is the half that checks the attribute-level contract with published extensions — what removing a component or reordering host output breaks — and at 74s it fits. AGENTS.md lists that regression class as a recurring trap precisely because it is currently found by the next scheduled run, after the merge.

## Three things this surfaced

**`DatePicker interaction` had a focus race.** Enter closes the calendar and react-aria restores the focus to the field's first segment as the popover unmounts — so a Tab pressed into that window is undone by the restore landing after it, and the capture shows a focused field where the reference has none. It failed **3 of 3** sharded runs while the unsharded control on `main` passed: the race is decided by machine load, and faster runners lose it. The scenario now states its own ordering. Same screenshots, same references, only waits added.

**`pnpm test:unit` ran zero tests in `remote-react-components`.** The script selected `--project=unit`, whose include is `src/**/*.test.tsx` — and every test under `src` is a `.browser.test.tsx`. The four files under `dev/` and `e2e/` sat in the `unit-dev` project nothing ever selected: 34 tests, 0.4s, never run — including the guards for `normalizeHtml` and `structuralHtml`, the two normalizers the cross-version docs say to never weaken. `--project=unit*` picks both up, the glob `components` already uses.

**The visual diff artifact never contained anything.** `.vitest-attachments` is a dot directory, and `upload-artifact` skips hidden paths unless told not to, so every failing run logged `No files were found`. The diffs are now collected into one flat `visual-diffs/` — opening the download is enough to see what changed.

## Measured

Scheduled workflow, whole run (visual **and** cross-version):

| | before | after |
| --- | --- | --- |
| run total | [1428s](https://github.com/mittwald/flow/actions/runs/33318648402) / 1405s | **[591s](https://github.com/mittwald/flow/actions/runs/33363704314)** |
| visual | 808s, one job | 200-261s × 6 shards |
| cross-version | 1424s, one job | resolve 165s → iframe 212s, in-process 296-364s × 9 |

PR suite with the new cross-version gate: [311s](https://github.com/mittwald/flow/actions/runs/33363698408), where `cross-version` (301s) sits alongside `visual (3)` (279s) and `browser` (260s) rather than extending the critical path.

Coverage checked, not assumed: the visual shards run 28 specs each, 14 Firefox + 14 WebKit, 6 × 28 = the 84 files × 2 browsers the single job ran; the cross-version matrix resolved to 3 targets × 3 shards, the same three versions the loop covered.

## Checklist

- [x] PR title is a Conventional Commit and matches the base branch above
- [x] `pnpm lint` is clean
- [x] **Generated code is committed** — nothing generated changed
- [x] No user-facing strings
- [x] Docs updated: `packages/remote-react-components/CONTRIBUTE.md` describes the sharding
