### PR TITLE
perf(components): stop shipping design-token build metadata to the browser

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,8 @@ RemoteRoot + remote React components  ───►  RemoteRenderer + RemoteRecei
 Base tokens (colors, font, sizes, …) are taboo — never invent or modify them.
 Adding **component tokens** for a new component is fine: model them on existing
 components and ask when unsure. [style-dictionary](https://styledictionary.com/)
-compiles YAML → `dist/css` (CSS variables) and `dist/json`.
+compiles YAML → `dist/css` (CSS variables), `dist/json` (full, with build
+metadata) and `dist/json-runtime` (values only — what browser bundles import).
 
 ## Repository map
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -102,6 +102,24 @@ export default tseslint.config(
     },
   },
   {
+    // Anything under src/ can end up in a browser bundle.
+    files: ["**/src/**"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["@mittwald/flow-design-tokens/json/*"],
+              message:
+                "Import @mittwald/flow-design-tokens/json-runtime/* instead. The json build carries style-dictionary metadata (filePath, isSource, original, attributes) on every token — 94 % of the file, and 1.37 MB of dead weight in the bundle. json-runtime holds the same values with only `value` and `path`. Need `original` for build-time tooling? Read json outside src/.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
     // Node ES-module CLI scripts (run by GitHub Actions, not bundled).
     files: [".github/scripts/**/*.mjs"],
     languageOptions: {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -112,7 +112,7 @@ export default tseslint.config(
             {
               group: ["@mittwald/flow-design-tokens/json/*"],
               message:
-                "Import @mittwald/flow-design-tokens/json-runtime/* instead. The json build carries style-dictionary metadata (filePath, isSource, original, attributes) on every token — 94 % of the file, and 1.37 MB of dead weight in the bundle. json-runtime holds the same values with only `value` and `path`. Need `original` for build-time tooling? Read json outside src/.",
+                "Import @mittwald/flow-design-tokens/json-runtime/* instead. The json build carries style-dictionary metadata (filePath, isSource, original, attributes) on every token, which dwarfs the values and lands in the bundle as dead weight. json-runtime holds the same values with only `value` and `path`. Need `original` for build-time tooling? Read json outside src/.",
             },
           ],
         },

--- a/packages/components/MIGRATION.md
+++ b/packages/components/MIGRATION.md
@@ -23,6 +23,38 @@ separately, and only when coming from `0.1.0`.
 
 ---
 
+## From version `1.0.11` to `>=1.0.12`
+
+### `useDesignTokens()` no longer returns style-dictionary build metadata
+
+The hook imported the design tokens' full style-dictionary output, which carries
+`filePath`, `isSource`, `original`, `name`, `attributes` and `key` on every one
+of the 1538 tokens. That metadata is 94 % of the payload and meant nothing in a
+browser — it put 1.37 MB of JavaScript into every bundle that touched the
+package. The hook now reads a runtime build of the same tokens.
+
+Every token keeps `value` and `path`, unchanged and with identical values, so
+the common access patterns are untouched:
+
+```tsx
+const tokens = useDesignTokens();
+tokens["loading-spinner"]["transition-duration"].value; // still works
+tokens.axis.color.path; // still works
+```
+
+Only the build metadata is gone. If you read one of those fields, take it from
+`@mittwald/flow-design-tokens/json/all-light.json` (or `all-dark.json`) directly
+— that artifact is unchanged. Do not import it into browser code; it is the
+reason this change exists.
+
+```diff
+- const source = useDesignTokens().button["corner-radius"].filePath;
++ import tokens from "@mittwald/flow-design-tokens/json/all-light.json";
++ const source = tokens.button["corner-radius"].filePath;
+```
+
+---
+
 ## From version `0.2.0-alpha.1055` to `>=0.2.0-alpha.1056`
 
 ### SegmentedControl deprecated

--- a/packages/components/src/lib/theming/hooks/useDesignTokens.ts
+++ b/packages/components/src/lib/theming/hooks/useDesignTokens.ts
@@ -1,5 +1,5 @@
-import lightTokens from "@mittwald/flow-design-tokens/json/all-light.json";
-import darkTokens from "@mittwald/flow-design-tokens/json/all-dark.json";
+import lightTokens from "@mittwald/flow-design-tokens/json-runtime/all-light.json";
+import darkTokens from "@mittwald/flow-design-tokens/json-runtime/all-dark.json";
 import { useResolvedTheme } from "./useResolvedTheme";
 
 export const useDesignTokens = () => {

--- a/packages/components/src/lib/theming/types.ts
+++ b/packages/components/src/lib/theming/types.ts
@@ -1,4 +1,4 @@
-import type tokens from "@mittwald/flow-design-tokens/json/all-light.json";
+import type tokens from "@mittwald/flow-design-tokens/json-runtime/all-light.json";
 
 export type Theme = "light" | "dark" | "system";
 export type ResolvedTheme = Exclude<Theme, "system">;

--- a/packages/components/src/lib/tokens/CategoricalColors.ts
+++ b/packages/components/src/lib/tokens/CategoricalColors.ts
@@ -1,4 +1,4 @@
-import tokens from "@mittwald/flow-design-tokens/json/all-light.json";
+import tokens from "@mittwald/flow-design-tokens/json-runtime/all-light.json";
 
 export const categoricalColors = Object.keys(
   tokens.color.categorical,

--- a/packages/design-tokens/AGENTS.md
+++ b/packages/design-tokens/AGENTS.md
@@ -17,6 +17,17 @@ Design tokens for mittwald Flow. See the [root AGENTS.md](../../AGENTS.md).
   to keep visual balance as the text grows? → `rem`.
 - `node build-tokens.js` (nx target `build`) compiles them with
   [style-dictionary](https://styledictionary.com/) to `dist/css/*` (CSS
-  variables; theme variants keyed by `data-theme`) and `dist/json/*`.
+  variables; theme variants keyed by `data-theme`), `dist/json/*` and
+  `dist/json-runtime/*`.
+- **`json` vs. `json-runtime`.** Both hold the same 1538 tokens. `json` is
+  style-dictionary's full output — every token carries its build metadata
+  (`filePath`, `isSource`, `original`, `attributes`, …), which is 94 % of the
+  file and turns 49 KB of values into 834 KB. `json-runtime` keeps only `value`
+  and `path` per token, in the same nested shape. **Anything that reaches a
+  browser bundle imports `json-runtime`** — `json` is for build-time and
+  tooling, where the metadata is the point. A `no-restricted-imports` rule in
+  [eslint.config.js](../../eslint.config.js) enforces this for every `src/`, so
+  build-time code that genuinely needs `original` (the unresolved reference —
+  1315 of 1538 tokens have one) has to live outside `src/`.
 - Consumers: `components` SCSS uses the CSS variables; some runtime helpers
-  (e.g. categorical chart colors) read the JSON output.
+  (e.g. `useDesignTokens`, categorical chart colors) read `json-runtime`.

--- a/packages/design-tokens/AGENTS.md
+++ b/packages/design-tokens/AGENTS.md
@@ -19,15 +19,16 @@ Design tokens for mittwald Flow. See the [root AGENTS.md](../../AGENTS.md).
   [style-dictionary](https://styledictionary.com/) to `dist/css/*` (CSS
   variables; theme variants keyed by `data-theme`), `dist/json/*` and
   `dist/json-runtime/*`.
-- **`json` vs. `json-runtime`.** Both hold the same 1538 tokens. `json` is
-  style-dictionary's full output — every token carries its build metadata
-  (`filePath`, `isSource`, `original`, `attributes`, …), which is 94 % of the
-  file and turns 49 KB of values into 834 KB. `json-runtime` keeps only `value`
-  and `path` per token, in the same nested shape. **Anything that reaches a
-  browser bundle imports `json-runtime`** — `json` is for build-time and
-  tooling, where the metadata is the point. A `no-restricted-imports` rule in
-  [eslint.config.js](../../eslint.config.js) enforces this for every `src/`, so
-  build-time code that genuinely needs `original` (the unresolved reference —
-  1315 of 1538 tokens have one) has to live outside `src/`.
+- **`json` vs. `json-runtime`.** Both hold the same tokens with the same values,
+  in the same nested shape. `json` is style-dictionary's full output — every
+  token carries its build metadata (`filePath`, `isSource`, `original`,
+  `attributes`, …), which dwarfs the values themselves and makes the file
+  roughly an order of magnitude larger. `json-runtime` keeps only `value` and
+  `path`. **Anything that reaches a browser bundle imports `json-runtime`** —
+  `json` is for build-time and tooling, where the metadata is the point. A
+  `no-restricted-imports` rule in [eslint.config.js](../../eslint.config.js)
+  enforces this for every `src/`, so build-time code that genuinely needs
+  `original` (the unresolved reference, which most tokens have) has to live
+  outside `src/`.
 - Consumers: `components` SCSS uses the CSS variables; some runtime helpers
   (e.g. `useDesignTokens`, categorical chart colors) read `json-runtime`.

--- a/packages/design-tokens/build-tokens.js
+++ b/packages/design-tokens/build-tokens.js
@@ -20,6 +20,35 @@ StyleDictionary.registerTransform({
   },
 });
 
+/*
+ * The `json` format emits every token with its build metadata — `filePath`,
+ * `isSource`, `original`, `attributes` and more. That is 94 % of the file, and
+ * none of it means anything in a browser: it turns 49 KB of values into 834 KB.
+ * Runtime consumers (`useDesignTokens`) import this leaner tree instead, which
+ * keeps only the two fields they read.
+ */
+StyleDictionary.registerFormat({
+  name: "json/flow-runtime",
+  format: ({ dictionary }) => {
+    const tree = {};
+
+    for (const token of dictionary.allTokens) {
+      const groups = token.path.slice(0, -1);
+      const name = token.path.at(-1);
+      let node = tree;
+
+      for (const group of groups) {
+        node[group] ??= {};
+        node = node[group];
+      }
+
+      node[name] = { value: token.value, path: token.path };
+    }
+
+    return `${JSON.stringify(tree, null, 2)}\n`;
+  },
+});
+
 StyleDictionary.registerFormat({
   name: "css/variables-layered",
   format: async ({ dictionary, options = {}, file }) => {
@@ -128,6 +157,11 @@ const buildConfig = ({
         {
           format: "json",
           destination: `json/${destination}.json`,
+          filter: filter,
+        },
+        {
+          format: "json/flow-runtime",
+          destination: `json-runtime/${destination}.json`,
           filter: filter,
         },
       ],

--- a/packages/design-tokens/build-tokens.js
+++ b/packages/design-tokens/build-tokens.js
@@ -21,11 +21,10 @@ StyleDictionary.registerTransform({
 });
 
 /*
- * The `json` format emits every token with its build metadata — `filePath`,
- * `isSource`, `original`, `attributes` and more. That is 94 % of the file, and
- * none of it means anything in a browser: it turns 49 KB of values into 834 KB.
- * Runtime consumers (`useDesignTokens`) import this leaner tree instead, which
- * keeps only the two fields they read.
+ * The `json` format's build metadata (`filePath`, `isSource`, `original`, …)
+ * dwarfs the values and means nothing in a browser, so runtime consumers
+ * (`useDesignTokens`) import this tree instead: same shape, only `value` and
+ * `path`.
  */
 StyleDictionary.registerFormat({
   name: "json/flow-runtime",

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -8,7 +8,8 @@
   "exports": {
     "./css/*": "./dist/css/*",
     "./css-layered/*": "./dist/css-layered/*",
-    "./json/*": "./dist/json/*"
+    "./json/*": "./dist/json/*",
+    "./json-runtime/*": "./dist/json-runtime/*"
   },
   "files": [
     "dist"


### PR DESCRIPTION
`useDesignTokens` imported the design tokens' full style-dictionary output. Every one of the 1538 tokens carries `filePath`, `isSource`, `original`, `name`, `attributes` and `key` — 94 % of the file, turning 49 KB of values into 834 KB per theme. Both themes are imported statically and the hook hangs off the default entry, so no consumer can tree-shake it. `CategoricalColors` pulled the same file just to read `Object.keys(tokens.color.categorical)`.

style-dictionary now emits a second, leaner build to `dist/json-runtime/` — same nested shape, only `value` and `path` per token. The three imports in `components` point at it. No other code changes: every consumer reads `.value`, the docs' `DesignTokenTable` additionally `.path`.

|                      | before  | after  |
| -------------------- | ------- | ------ |
| chunks in the bundle | 1371 KB | 330 KB |
| over the wire (gzip) | 105 KB  | 33 KB  |

`dist/json/` is unchanged. It stays a published export: `original` — the unresolved reference, on 1315 of 1538 tokens — exists nowhere else in machine-readable form. A `no-restricted-imports` rule keeps it out of every `src/`, which is where this went wrong in the first place.

## Why this targets `main` and not a major line

`useDesignTokens` is not part of `public.ts`, and [the semver contract](https://github.com/mittwald/flow/blob/main/docs/release-workflow.md#the-public-contract) lists TypeScript types and design-token values as explicitly best-effort. `MIGRATION.md` documents the removed fields for anyone who read them, and points at `json/all-light.json` as the build-time source.

## Verification

- All 1538 values byte-identical between the two builds — nothing renders differently.
- `test:compile`, 206 unit tests, 250 browser tests (webkit), 354 visual tests (incl. CartesianChart and LoadingSpinner), `affected:test` across 7 projects, `pnpm lint` — green.
- Clean build confirms the fat chunks are gone rather than merely unreferenced.
- Docs Colors page renders unchanged (12 tables, 128 rows, swatches resolve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)