### PR TITLE
ci: build the preview apps in CI and let the image only package them

### DIFF
--- a/.github/workflows/build-previews.yml
+++ b/.github/workflows/build-previews.yml
@@ -27,15 +27,38 @@ jobs:
       matrix:
         include:
           - app: docs
-            dockerfile: apps/docs/Dockerfile
+            context: apps/docs
             image_suffix: docs
           - app: storybook
-            dockerfile: packages/components/Dockerfile
+            context: packages/components
             image_suffix: storybook
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - uses: ./.github/actions/prepare-workspace
+
+      # The image used to build this itself, which meant a second toolchain
+      # install and the whole dependency chain rebuilt against a cold nx cache —
+      # 80 of the 449 seconds a docs preview took. Here the restored cache serves
+      # that chain, and the image only packages what comes out.
+      #
+      # NEXT_BASE_PATH was a build-arg for the same reason; the value is the one
+      # the Dockerfile passed.
+      - name: Build the docs
+        if: matrix.image_suffix == 'docs'
+        run: pnpm nx build docs
+        env:
+          NEXT_BASE_PATH: ""
+
+      # Two commands because `build:storybook` declares no nx dependency on the
+      # components build — the same pair the Dockerfile ran.
+      - name: Build Storybook
+        if: matrix.image_suffix == 'storybook'
+        run: |
+          pnpm nx build components
+          pnpm nx build:storybook components
 
       - name: Log in to the Container registry
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
@@ -71,8 +94,9 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: .
-          file: ${{ matrix.dockerfile }}
+          # The built output and the server config beside it, nothing else — see
+          # the context's own .dockerignore.
+          context: ${{ matrix.context }}
           push: true
           provenance: false # single-manifest image (as before v7); deploy pulls by ref
           tags:
@@ -81,8 +105,6 @@ jobs:
           labels:
             ${{ matrix.image_suffix == 'docs' && steps.meta-docs.outputs.labels
             || steps.meta-storybook.outputs.labels }}
-          build-args: |
-            NEXT_BASE_PATH=
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-previews.yml
+++ b/.github/workflows/build-previews.yml
@@ -46,6 +46,21 @@ jobs:
       #
       # NEXT_BASE_PATH was a build-arg for the same reason; the value is the one
       # the Dockerfile passed.
+      # Next keeps its compiler and render caches here. Restoring them is only
+      # possible now that the build runs on the runner rather than inside the
+      # image, where the directory started empty every time.
+      - name: Cache the Next.js build cache
+        if: matrix.image_suffix == 'docs'
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: apps/docs/.next/cache
+          key:
+            nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{
+            github.sha }}
+          restore-keys: |
+            nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
+            nextjs-${{ runner.os }}-
+
       - name: Build the docs
         if: matrix.image_suffix == 'docs'
         run: pnpm nx build docs

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -26,15 +26,38 @@ jobs:
       matrix:
         include:
           - app: docs
-            dockerfile: apps/docs/Dockerfile
+            context: apps/docs
             image_suffix: docs
           - app: storybook
-            dockerfile: packages/components/Dockerfile
+            context: packages/components
             image_suffix: storybook
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - uses: ./.github/actions/prepare-workspace
+
+      # The image used to build this itself, which meant a second toolchain
+      # install and the whole dependency chain rebuilt against a cold nx cache —
+      # 80 of the 449 seconds a docs preview took. Here the restored cache serves
+      # that chain, and the image only packages what comes out.
+      #
+      # NEXT_BASE_PATH was a build-arg for the same reason; the value is the one
+      # the Dockerfile passed.
+      - name: Build the docs
+        if: matrix.image_suffix == 'docs'
+        run: pnpm nx build docs
+        env:
+          NEXT_BASE_PATH: ""
+
+      # Two commands because `build:storybook` declares no nx dependency on the
+      # components build — the same pair the Dockerfile ran.
+      - name: Build Storybook
+        if: matrix.image_suffix == 'storybook'
+        run: |
+          pnpm nx build components
+          pnpm nx build:storybook components
 
       - name: Log in to the Container registry
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
@@ -70,8 +93,9 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: .
-          file: ${{ matrix.dockerfile }}
+          # The built output and the server config beside it, nothing else — see
+          # the context's own .dockerignore.
+          context: ${{ matrix.context }}
           push: true
           provenance: false # single-manifest image (as before v7)
           tags:
@@ -80,8 +104,6 @@ jobs:
           labels:
             ${{ matrix.image_suffix == 'docs' && steps.meta-docs.outputs.labels
             || steps.meta-storybook.outputs.labels }}
-          build-args: |
-            NEXT_BASE_PATH=
 
       - name: Trigger docs redeploy webhook
         if: matrix.image_suffix == 'docs'

--- a/apps/docs/.dockerignore
+++ b/apps/docs/.dockerignore
@@ -1,0 +1,6 @@
+# The context holds one thing: what `nx build docs` produced, plus the server
+# config next to it. Everything else here — src, node_modules, .next — would
+# only be uploaded to the daemon to be ignored.
+*
+!out
+!nginx.conf

--- a/apps/docs/Dockerfile
+++ b/apps/docs/Dockerfile
@@ -1,25 +1,14 @@
-FROM node:24-alpine AS builder
+# The docs are built in CI and this image only serves them. A builder stage here
+# installed the toolchain a second time and rebuilt the workspace with a cold nx
+# cache — 80 of the 449 seconds a preview took, on top of a pnpm install CI had
+# already done. The build moved to the workflow; see build-previews.yml.
+#
+# The context is this directory, so the paths below are relative to it and only
+# the built output is sent to the daemon (see .dockerignore).
+FROM nginx:alpine
 
-ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable
-
-WORKDIR /app
-
-COPY . .
-
-RUN pnpm install --frozen-lockfile
-
-ARG NEXT_BASE_PATH=""
-ENV NEXT_BASE_PATH=$NEXT_BASE_PATH
-
-RUN pnpm nx build docs
-
-FROM nginx:alpine AS runner
-
-COPY --from=builder /app/apps/docs/out /usr/share/nginx/html
-COPY apps/docs/nginx.conf /etc/nginx/conf.d/default.conf
+COPY out /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]
-

--- a/packages/components/.dockerignore
+++ b/packages/components/.dockerignore
@@ -1,0 +1,5 @@
+# The context holds one thing: what `build:storybook` produced, plus the server
+# config next to it. `src` and `node_modules` have no business in the image.
+*
+!storybook-static
+!nginx.conf

--- a/packages/components/Dockerfile
+++ b/packages/components/Dockerfile
@@ -1,24 +1,9 @@
-FROM node:24-alpine AS builder
+# Storybook is built in CI and this image only serves it — same reasoning as
+# apps/docs/Dockerfile. The context is this directory.
+FROM nginx:alpine
 
-ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable
-
-WORKDIR /app
-
-COPY . .
-
-RUN pnpm install --frozen-lockfile
-
-RUN pnpm nx run-many --target=build --projects=components
-
-RUN pnpm nx build:storybook components
-
-FROM nginx:alpine AS runner
-
-COPY --from=builder /app/packages/components/storybook-static /usr/share/nginx/html
-COPY packages/components/nginx.conf /etc/nginx/conf.d/default.conf
+COPY storybook-static /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]
-


### PR DESCRIPTION
## What & why

Both preview images built themselves: `COPY . .`, a second `pnpm install`, and the whole workspace rebuilt against an nx cache that is empty inside a container. Measured on [a preview before this PR](https://github.com/mittwald/flow/actions/runs/33364147147), the docs image took 449s:

| | |
| --- | --- |
| `COPY . .` + `pnpm install` | 25s |
| workspace dependency chain (tokens, icons, components + generators) | 56s |
| `next build` compile | 30s |
| **generating 501 static pages, 3 workers** | **4.3 min** |
| push | 49s |

The dependency chain is the part CI already has. The workflow now builds the app with the nx cache `main` seeds, and the Dockerfile is reduced to nginx plus the output beside it. Each image also gets its own build context, so the daemon receives the built output rather than 52MB of source it would ignore. `deploy-main.yml` builds the same two images and gets the same change.

Building on the runner is also what makes Next's own cache reusable: inside the image `.next/cache` started empty every time.

## Measured

`Build the docs`, on this branch, same commit:

| | `.next/cache` | |
| --- | --- | --- |
| before this PR, inside the image | — | 358s (plus 25s install) |
| runner build | cold | 300s |
| runner build | cold | 270s |
| runner build | **warm** | **232s** |
| runner build | **warm** | **240s** |

Two samples per state, because the cold pair alone spreads 30s — the ~50s between the groups is larger than the spread inside them, and both warm runs land together.

Whole jobs: docs **459s → 340-355s**, storybook **124s → 91s**.

The static export is still three quarters of the docs build and is untouched by any of this. What is left to try there is more cores (it runs 501 pages on 3 workers, and unlike the visual suite it parallelises), or generating fewer pages — both decisions for the team rather than a CI change.

## Checklist

- [x] PR title is a Conventional Commit and matches the base branch above
- [x] `pnpm lint` is clean
- [x] **Generated code is committed** — nothing generated changed
- [x] No user-facing strings
- [x] Docs unaffected
