### PR TITLE
test(remote-react-components): extract the scenario-focus wait into a documented lib

### DIFF
--- a/packages/remote-react-components/AGENTS.md
+++ b/packages/remote-react-components/AGENTS.md
@@ -33,6 +33,15 @@ explainer in [docs/remote-ui.md](../../docs/remote-ui.md)).
   the new prop/variant/layout is captured. Because every scenario runs in both
   `Local` and `Remote`, this single test guards the component and its remote
   path at once.
+- **The screenshot preamble does not wait for the focus.** It settles on DOM
+  mutations, and `:focus` / `:focus-within` are pseudo-classes — so a scenario
+  whose step closes an overlay (react-aria restores the focus to the trigger
+  asynchronously) or whose reference encodes a focus ring has to synchronize on
+  the focus itself, with `waitForFocusInTheScenario()` /
+  `waitForFocusOutsideTheScenario()` from `src/tests/lib/scenarioFocus.ts`.
+  Skipping it costs a ~1% diff in whichever environment lost the race — a random
+  per-run failure, not a reproducible one, because both environments share one
+  reference. See `CONTRIBUTE.md` → _Waiting for the focus_.
 - **The browser also selects the theme:** webkit renders light, firefox renders
   dark (`dev/vitest/setupVisualTheme.ts`), so one run covers both themes and the
   `*-firefox-*.png` baselines are dark by design. A run filtered with

--- a/packages/remote-react-components/CONTRIBUTE.md
+++ b/packages/remote-react-components/CONTRIBUTE.md
@@ -124,6 +124,46 @@ the screenshots used in CI (Linux) are updated as well.
 The best way to learn how tests are structured is to look at existing test
 cases.
 
+### Waiting for the focus
+
+`testScreenshot`'s preamble waits for the document to stop **mutating**. A focus
+move is not a mutation — `:focus` / `:focus-within` are pseudo-classes — and a
+react-aria focus restore fired by an unmounting popover lands after the quiet
+window anyway. Nothing in the preamble can wait for it.
+
+So synchronize on the focus yourself, with the helpers in
+`src/tests/lib/scenarioFocus.ts`, whenever a step or a capture depends on where
+the focus sits:
+
+```tsx
+await userEvent.keyboard("{enter}"); // closes the calendar, restores the focus
+
+await waitForFocusInTheScenario(); // the restore has landed
+
+await userEvent.keyboard("{tab}");
+
+await waitForFocusOutsideTheScenario(); // Tab has taken the focus out again
+
+await testScreenshot("DatePicker - date selected");
+```
+
+Two situations need this:
+
+- **A step that closes an overlay** (Escape, Enter on a calendar cell, a click
+  on a menu item). react-aria restores the focus to the trigger asynchronously,
+  and a key press sent into that window is undone by the restore landing after
+  it — the scenario continues from a state it never asked for.
+- **A capture whose reference encodes a focus ring**, or the absence of one.
+
+Skipping the wait costs a ~1% diff in whichever environment lost the race. Both
+environments share one reference, so it shows up as a random per-run failure
+rather than as a race — and no amount of sleeping fixes it. `Local` renders
+synchronously and usually wins, `Remote` applies every interaction a serializer
+round trip late, so a green `Local` says nothing about `Remote`.
+
+A plain `click()` or `fill()` needs no wait: the locator action resolves after
+the browser has moved the focus.
+
 ### Notes on Chromium
 
 Due to its wide adoption, Chromium would normally be a good choice as a test

--- a/packages/remote-react-components/src/tests/lib/scenarioFocus.ts
+++ b/packages/remote-react-components/src/tests/lib/scenarioFocus.ts
@@ -1,0 +1,77 @@
+import { rootContainerLocator } from "@/tests/lib/RootContainer";
+import { expect } from "vitest";
+
+/*
+ * Synchronizing a visual scenario on the FOCUS — the one thing the screenshot
+ * preamble cannot do for you.
+ *
+ * `prepareForScreenshot` (see `@/tests/lib/environments`) waits for the document
+ * to stop MUTATING. A focus move is not a mutation: `:focus` and `:focus-within`
+ * are pseudo-classes, so nothing the MutationObserver watches changes, and a
+ * react-aria focus restore fired by an unmounting popover lands after the quiet
+ * window anyway.
+ *
+ * So reach for these helpers whenever a scenario's next step or its capture
+ * depends on where the focus sits:
+ *
+ * - **A step that closes an overlay** — Escape, Enter on a calendar cell, a
+ *   click on a menu item. react-aria restores the focus to the trigger while the
+ *   popover unmounts, asynchronously. A key press sent into that window is
+ *   undone by the restore landing after it, and the scenario continues from a
+ *   state it never asked for.
+ * - **A capture whose reference encodes a focus ring** — or the absence of one.
+ *
+ * Losing the race costs a ~1% diff in whichever environment lost it. Both
+ * environments share one reference, so it reads as a random per-run failure
+ * rather than as a race — and it is not one a bigger sleep fixes.
+ *
+ * `Local` renders synchronously and usually wins these races; `Remote` applies
+ * every interaction a serializer round trip late. A scenario passing in `Local`
+ * therefore says nothing about `Remote`.
+ *
+ * A plain `click()` or `fill()` needs no wait — the locator action resolves after
+ * the browser has moved the focus.
+ */
+
+/**
+ * Whether the focus sits in the scenario at all, i.e. inside the container the
+ * visual suite renders into and captures.
+ *
+ * A field's focus ring is pure CSS (`:focus-within` on the form control,
+ * `:focus` on a segment), so this is exactly what the reference encodes.
+ * Popovers render in a portal outside the container, so an open one holding the
+ * focus reads as `false`.
+ */
+export const focusIsInTheScenario = (): boolean =>
+  rootContainerLocator.element().contains(document.activeElement);
+
+/*
+ * The move being waited for is a single tick in `Local`; `Remote` adds a
+ * serializer round trip, and CI hardware is slower again. Same scale as the
+ * preamble's `settleTimeout`, and far below the project's 60s `testTimeout` — so
+ * a scenario that never gets there fails with the message below instead of
+ * timing out anonymously.
+ */
+const focusTimeout = 2000;
+
+/** Waits until the focus has (re-)entered the scenario. */
+export const waitForFocusInTheScenario = async (): Promise<void> => {
+  await expect
+    .poll(focusIsInTheScenario, {
+      timeout: focusTimeout,
+      message:
+        "The focus never entered the scenario, so the capture would have shown an unfocused component.",
+    })
+    .toBe(true);
+};
+
+/** Waits until the focus has left the scenario. */
+export const waitForFocusOutsideTheScenario = async (): Promise<void> => {
+  await expect
+    .poll(focusIsInTheScenario, {
+      timeout: focusTimeout,
+      message:
+        "The focus never left the scenario, so the capture would have shown a focused component.",
+    })
+    .toBe(false);
+};

--- a/packages/remote-react-components/src/tests/visual/DatePicker.browser.test.tsx
+++ b/packages/remote-react-components/src/tests/visual/DatePicker.browser.test.tsx
@@ -1,16 +1,10 @@
 import { testEnvironments } from "@/tests/lib/environments";
-import { rootContainerLocator } from "@/tests/lib/RootContainer";
-import { expect, test, vi } from "vitest";
+import {
+  waitForFocusInTheScenario,
+  waitForFocusOutsideTheScenario,
+} from "@/tests/lib/scenarioFocus";
+import { test, vi } from "vitest";
 import { page, userEvent } from "vitest/browser";
-
-/**
- * Whether the focus sits in the scenario at all — the field's ring is pure CSS
- * (`:focus-within` on the form control, `:focus` on the segment), so this is
- * exactly what the reference encodes. The calendar renders in a portal outside
- * the container, so an open one reads as `false`.
- */
-const focusIsInTheScenario = () =>
-  rootContainerLocator.element().contains(document.activeElement);
 
 test.each(testEnvironments)(
   "DatePicker states (%s)",
@@ -67,22 +61,17 @@ test.each(testEnvironments)(
     /*
      * Enter closes the calendar, and react-aria restores the focus to the
      * field's first segment as the popover unmounts. Tab pressed into that
-     * window is undone by the restore that lands after it: the focus ends up
-     * back on the segment, and the capture shows a focused field where the
-     * reference has none — a ~1% diff, in whichever environment lost the race
-     * (they share one reference).
-     *
-     * The screenshot preamble cannot cover this. A focus move is a CSS
-     * pseudo-class change, not a mutation its settle can observe, and the
-     * restore arrives after the quiet window either way. So wait for the field
-     * to have the focus back before handing it on.
+     * window is undone by the restore landing after it: the focus ends up back
+     * on the segment, and the capture shows a focused field where the reference
+     * has none. So wait for the restore first — see `@/tests/lib/scenarioFocus`
+     * for why the screenshot preamble cannot cover this.
      */
-    await expect.poll(focusIsInTheScenario).toBe(true);
+    await waitForFocusInTheScenario();
 
     await userEvent.keyboard("{tab}");
 
-    // ... and for Tab to have taken it out again, which is the state captured.
-    await expect.poll(focusIsInTheScenario).toBe(false);
+    // ... and then for Tab to have taken it out again, the state captured below.
+    await waitForFocusOutsideTheScenario();
 
     await testScreenshot("DatePicker - date selected");
   },

--- a/packages/remote-react-components/src/tests/visual/DateRangePicker.browser.test.tsx
+++ b/packages/remote-react-components/src/tests/visual/DateRangePicker.browser.test.tsx
@@ -1,4 +1,5 @@
 import { testEnvironments } from "@/tests/lib/environments";
+import { waitForFocusInTheScenario } from "@/tests/lib/scenarioFocus";
 import { test, vi } from "vitest";
 import { page, userEvent } from "vitest/browser";
 import { CalendarDate } from "@internationalized/date";
@@ -60,6 +61,15 @@ test.each(testEnvironments)(
     await testScreenshot("DateRangePicker - start date selected");
 
     await userEvent.keyboard("{enter}");
+
+    /*
+     * The second Enter completes the range, which closes the calendar and lets
+     * react-aria restore the focus to the field. The capture below shows that
+     * focused field, so wait for the restore instead of racing it — see
+     * `@/tests/lib/scenarioFocus`.
+     */
+    await waitForFocusInTheScenario();
+
     await testScreenshot("DateRangePicker - range selected");
   },
 );


### PR DESCRIPTION
`testScreenshot`'s preamble settles on DOM **mutations**. A focus move is not one — `:focus` / `:focus-within` are pseudo-classes — and a react-aria focus restore fired by an unmounting popover lands after the quiet window anyway. #3006 worked around that in `DatePicker.browser.test.tsx` with a local `focusIsInTheScenario` helper, so the knowledge lived in exactly one file and the next scenario hitting the race had nothing to find.

## What changed

**New `src/tests/lib/scenarioFocus.ts`**

- `focusIsInTheScenario()` — the primitive, unchanged.
- `waitForFocusInTheScenario()` / `waitForFocusOutsideTheScenario()` — carry the poll budget (2s, same scale as the preamble's `settleTimeout`) and a message naming what the capture would have shown, instead of an anonymous poll timeout.
- Module docblock: the gap in the preamble, and the two situations that need a wait — a step that closes an overlay (react-aria restores the focus to the trigger asynchronously, and a key press sent into that window is undone by the restore landing after it), or a capture whose reference encodes a focus ring. A plain `click()` / `fill()` needs none.

**Documented for the next agent** — `CONTRIBUTE.md` gets a *Waiting for the focus* section with a code example, `AGENTS.md` a bullet beside the other visual rules (the root guide sends agents to the nearest `AGENTS.md`).

**`DateRangePicker interaction` had the same setup and raced it.** The second Enter completes the range, closes the calendar and triggers the restore; the capture right after shows that focused field. It waits now.

## Why it is worth a lib

Losing the race costs a ~1% diff in whichever environment lost it. Both environments share one reference, so it surfaces as a random per-run failure rather than as a race — and no bigger sleep fixes it. `Local` renders synchronously and usually wins; `Remote` applies every interaction a serializer round trip late, so a green `Local` says nothing about `Remote`.

## Verification

- `pnpm nx run remote-react-components:test:visual --browser.name=webkit DatePicker.browser` → 4 passed
- `pnpm nx run remote-react-components:test:visual --browser.name=webkit DateRangePicker.browser` → 8 passed
- **No baseline changed.** The committed references already encode the restored-focus state; the wait only stops `Remote` from losing the race on a slower runner.
- `test:compile`, eslint and prettier clean.

`run-visual-tests` is on the PR: the change moves *when* a screenshot is captured, so both browsers — and therefore both themes — should confirm it verify-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)