### PR TITLE
build(components): use the next-themes client entry in Storybook

### DIFF
--- a/packages/components/.storybook/preview.tsx
+++ b/packages/components/.storybook/preview.tsx
@@ -2,7 +2,7 @@ import "../src/styles";
 import type { Preview } from "@storybook/react";
 import type React from "react";
 import { useEffect } from "react";
-import { ThemeProvider, useTheme } from "@teispace/next-themes";
+import { ThemeProvider, useTheme } from "@teispace/next-themes/client";
 import { addons } from "storybook/manager-api";
 
 const ThemeDecorator: React.FC<{


### PR DESCRIPTION
Storybook rendered a blank page — manager and story iframe alike — with `ReferenceError: process is not defined` thrown from the prebundled `@teispace/next-themes`.

## Cause

The package's default entry imports `useServerInsertedHTML` from `next/navigation`. Storybook is a plain Vite app, so Vite resolved that import and prebundled Next.js' client-navigation module graph into the dep — 5829 lines referencing `process.cwd()`, `process.nextTick` and `process.env.__NEXT_DEV_SERVER`. Vite defines only `process.env.NODE_ENV`, so the rest survived and the module threw on evaluation, taking the whole preview down.

## Fix

`.storybook/preview.tsx` now imports from `@teispace/next-themes/client`, the package's framework-agnostic entry for exactly this case (its own docs name Vite, Remix and CRA). Same `ThemeProvider` and `useTheme`; prebundles to 904 lines with no `process` reference.

`apps/docs` keeps the default entry — it is a Next.js app.

## Verified

`pnpm nx dev components` with a cleared Vite dep cache: stories render, the manager shell renders, and the light/dark toolbar toggle still flips `data-theme` on `<html>`. Console is free of the error. `test:compile` and lint pass.