### PR TITLE
fix(docs): drop the classic JSX transform debug props from live examples (fixes #3017)

### DIFF
--- a/patches/@mfalkenberg__react-live-ssr@4.1.7.patch
+++ b/patches/@mfalkenberg__react-live-ssr@4.1.7.patch
@@ -1,0 +1,26 @@
+diff --git a/dist/index.js b/dist/index.js
+index 23323a95e0092b62c6af200f599a6c03a840a99e..b3de209aa2c9d47fd9b8170cb44987142134d10b 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -195,7 +195,7 @@ var import_sucrase = require("sucrase");
+ var defaultTransforms = ["jsx", "imports"];
+ function transform(opts = {}) {
+   const transforms = Array.isArray(opts.transforms) ? opts.transforms.filter(Boolean) : defaultTransforms;
+-  return (code) => (0, import_sucrase.transform)(code, { transforms }).code;
++  return (code) => (0, import_sucrase.transform)(code, { transforms, production: true }).code;
+ }
+ 
+ // src/utils/transpile/errorBoundary.tsx
+diff --git a/dist/index.mjs b/dist/index.mjs
+index 4cf841fc3db17d0609e75e974214c53a810dde99..eb856ac964d7d8953ae9664daf63a95cd29ceef3 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -158,7 +158,7 @@ import { transform as _transform } from "sucrase";
+ var defaultTransforms = ["jsx", "imports"];
+ function transform(opts = {}) {
+   const transforms = Array.isArray(opts.transforms) ? opts.transforms.filter(Boolean) : defaultTransforms;
+-  return (code) => _transform(code, { transforms }).code;
++  return (code) => _transform(code, { transforms, production: true }).code;
+ }
+ 
+ // src/utils/transpile/errorBoundary.tsx

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   '@mittwald/flow-demo-remote-dom>typescript': npm:typescript@^7.0.2
 
 patchedDependencies:
+  '@mfalkenberg/react-live-ssr@4.1.7': 991aaa57899c8fdd0b7d8304a55bec822329fcc36d5d5178e370f4ea79117eb9
   '@mittwald/remote-dom-react@1.2.2-mittwald.10': 165efefefb651960d4019e048af092f536b859b6b5e55b610e85b2e14460d8c3
   '@quilted/threads@3.3.1': fa797cdfb8346ba050fd5d6367ccd451df47806c6ea34421e45e8cc760faf812
   '@sigstore/sign@4.1.1': 6ae6ce79a0d5087118f5c3569ba3256c50c873f0e5f829338045aa4983088864
@@ -151,7 +152,7 @@ importers:
         version: 3.12.3
       '@mfalkenberg/react-live-ssr':
         specifier: ^4.1.7
-        version: 4.1.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 4.1.7(patch_hash=991aaa57899c8fdd0b7d8304a55bec822329fcc36d5d5178e370f4ea79117eb9)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@mittwald/flow-design-tokens':
         specifier: workspace:*
         version: link:../../packages/design-tokens
@@ -12142,7 +12143,7 @@ snapshots:
       '@types/react': 19.2.18
       react: 19.2.8
 
-  '@mfalkenberg/react-live-ssr@4.1.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@mfalkenberg/react-live-ssr@4.1.7(patch_hash=991aaa57899c8fdd0b7d8304a55bec822329fcc36d5d5178e370f4ea79117eb9)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       prism-react-renderer: 2.4.1(react@19.2.8)
       react: 19.2.8

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ patchedDependencies:
   "acorn": "patches/acorn.patch"
   "@sigstore/sign@4.1.1": "patches/@sigstore__sign@4.1.1.patch"
   "@mittwald/remote-dom-react@1.2.2-mittwald.10": "patches/@mittwald__remote-dom-react@1.2.2-mittwald.10.patch"
+  "@mfalkenberg/react-live-ssr@4.1.7": "patches/@mfalkenberg__react-live-ssr@4.1.7.patch"
 
 overrides:
   "typescript": "npm:@typescript/typescript6@^6.0.2"


### PR DESCRIPTION
Fixes #3017.

104 of the 113 docs pages logged React's "Your app (or one of its dependencies) is using an outdated JSX transform" — the loudest warning in the docs app by a wide margin.

## Cause

`@mfalkenberg/react-live-ssr@4.1.7` transpiles the live code examples with sucrase and leaves `jsxRuntime` at its classic default, so it emits `React.createElement(Button, { onPress: …, __self: this, __source: {…} }, "Hi")`. React 19's dev build warns on exactly that shape — a config carrying `__self` without `key`.

## Fix

A `patches/` entry adding `production: true` to the sucrase call, in both build outputs:

```diff
-  return (code) => _transform(code, { transforms }).code;
+  return (code) => _transform(code, { transforms, production: true }).code;
```

`jsxRuntime: "automatic"` would also silence it but is the wrong tool here: react-live evaluates the transpiled code with only `React` in scope, so `_jsx` would need a runtime import the eval sandbox never provides. Reading sucrase's `JSXTransformer` confirms `production` gates *only* the `__self`/`__source` props in classic mode — the call shape stays intact.

A patch rather than a version bump because pnpm's `minimumReleaseAge` is one week and exempts only `@mittwald/*`, so even an immediate upstream release could not be consumed yet. The entry pins `4.1.7` exactly, so a later bump fails the install loudly instead of silently dropping the fix.

## Verified

- Patch applies: both `dist/index.js` and `dist/index.mjs` under the `patch_hash=…` store directory contain `production: true`, and `apps/docs/node_modules/@mfalkenberg/react-live-ssr` symlinks to that directory — not to a stale unpatched copy.
- Across six docs pages with live examples: 0 `outdated JSX transform` warnings, 0 console errors, 0 page errors, 42 preview containers all rendering non-empty.
- Editing still works — select-all, retype an example, preview re-renders with no warning and no error.
- The source shown in the editor is unchanged: `transformCode` runs before sucrase and the displayed code comes from the raw `code` prop, so neither sits on the patched path.
- `pnpm lint` 0 errors, `pnpm test` green, `git status` clean after `pnpm build`.

## Follow-up

The same one-line change belongs upstream in `@mfalkenberg/react-live-ssr` (`src/utils/transpile/transform.ts`). Once a release carrying it is a week old, `minimumReleaseAge` clears and this patch can be dropped for a plain version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
