### PR TITLE
fix(codemods): compile the transforms so a consumer install can load them

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,7 +174,12 @@ and commit the results.
   track a **dependency task's output**, use
   `{ "dependentTasksOutputFiles": "**/*", "transitive": false }` (nx hashes its
   own task outputs) — `dependsOn` alone only orders execution, it does not fold
-  the dependency's hash into the dependent.
+  the dependency's hash into the dependent. And **every** file a task produces
+  belongs in `outputs`, including a gitignored sidecar like a `*.tsbuildinfo`:
+  nx restores a cached task's outputs wholesale, so a buildinfo left out of the
+  list can survive from one run while `dist` is restored from another — after
+  which `tsc` finds it current, emits nothing, and the build reports success
+  over an incomplete `dist`.
 - **Git hooks** (simple-git-hooks): `post-checkout` and `post-merge` run
   `pnpm install` — expect installs after switching branches. `pre-push` runs
   `pnpm lint` — which includes `format:check`, so a stray unformatted

--- a/packages/codemods/AGENTS.md
+++ b/packages/codemods/AGENTS.md
@@ -15,7 +15,7 @@ the `@mittwald/flow-codemods` CLI that runs them.
 | `src/cli`, `src/cli.ts`                                          | The `upgrade`, `list` and single-codemod commands.                                                                                                                                                  |
 | `src/resolve`, `src/manifest.ts`, `src/install.ts`, `src/git.ts` | Version resolution, manifest edits, package-manager install, and the dirty-working-tree guard for `upgrade`.                                                                                        |
 | `src/run`                                                        | Drives jscodeshift's `Runner` in-process (not the CLI binary).                                                                                                                                      |
-| `dev/generate`                                                   | The three generators.                                                                                                                                                                               |
+| `dev/generate`, `dev/buildTransforms.ts`                         | The three catalogue generators, plus the transforms' CommonJS compile — see [Transforms are compiled](#transforms-are-compiled-and-that-is-not-optional).                                           |
 | `src/tests`                                                      | Cross-cutting tests: catalogue invariants, remote-scope checks, the transform-test-coverage guard, and `runTransform`, the run-through-the-real-CLI helper every fixture test uses.                 |
 
 The directory **is** the id — it appears once, instead of once per filename
@@ -58,13 +58,31 @@ independent check that it works under jscodeshift's normal invocation — not a
 reproduction of `runCodemod`'s invocation, since production and this test helper
 no longer call jscodeshift the same way.
 
-A transform no longer has to be self-contained — it may import shared helpers
-from elsewhere in `src`. But `package.json` ships
-`"files": ["dist", "src/migrations/**/transform.ts", "src/tools/to-remote-package.ts"]`:
-the published package carries the transform sources and nothing outside them
-(not `entry.md`, not the test files). Anything a transform imports must resolve
-inside what ships, or it is missing from the published package even though it
-type-checks locally.
+### Transforms are compiled, and that is not optional
+
+`package.json` ships `"files": ["dist"]`. The transforms reach a consumer as
+**compiled CommonJS** at `dist/migrations/<id>/transform.js`, produced by
+`tsconfig.transforms.json` and `dev/buildTransforms.ts` — a second compile
+beside the main one, with its own `package.json` marker (`{"type": "commonjs"}`)
+written into `dist/migrations` and `dist/tools` so Node does not read the
+emitted `.js` as ESM.
+
+The `.ts` sources are **not** published. They used to be, and every codemod died
+in every consumer install because of it: jscodeshift's worker `require()`s the
+transform path, and although it installs `@babel/register` first,
+babel-register's `only` defaults to the current working directory — a transform
+under the consumer's `node_modules` is outside it, so babel never claims the
+file, Node's own `.ts` handler takes over, and Node refuses with
+`ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING` (no opt-out). In the repo it
+worked, because there cwd _is_ inside the package. `src/run/jscodeshift.ts`
+prefers the compiled file and keeps the `.ts` as a repo-only fallback;
+`src/tests/publishedTransforms.test.ts` loads every compiled transform through
+`require` the way the worker does, so a broken or missing compile fails the
+build instead of shipping.
+
+A transform may import shared helpers from elsewhere in `src` — they are
+compiled along with it. What it must not do is reach anything that stays outside
+`dist`.
 
 ### Every transform has a test — enforced, not just conventional
 
@@ -143,7 +161,7 @@ by id like any other transform.
 ## Commands
 
 ```shell
-pnpm nx build codemods        # regenerate the catalogue's generated artifacts
-pnpm nx test:unit codemods    # catalogue + fixture + idempotency tests
+pnpm nx build codemods        # generators + tsc + the transforms' CommonJS compile
+pnpm nx test:unit codemods    # catalogue + fixture + idempotency + published-load tests
 pnpm nx test:compile codemods # tsc --noEmit
 ```

--- a/packages/codemods/dev/buildTransforms.ts
+++ b/packages/codemods/dev/buildTransforms.ts
@@ -1,0 +1,35 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Compiles the transforms to CommonJS and marks the output as CommonJS.
+ *
+ * Two steps, and the second is not optional. `tsconfig.transforms.json` (see
+ * its comments for why CommonJS at all) emits `dist/migrations/<id>/
+ * transform.js` and `dist/tools/<name>.js`, but this package is `"type":
+ * "module"` — so Node would read those `.js` files as ESM and throw `exports is
+ * not defined` on the first line. A `package.json` holding `{"type":
+ * "commonjs"}` inside each output directory overrides the field for everything
+ * below it, which is what makes the emitted files loadable.
+ *
+ * The marker directories are exactly the two `outDir` subtrees the compile
+ * produces, so a transform added under either is covered without touching this
+ * file.
+ */
+const packageRoot = new URL("../", import.meta.url);
+const commonJsSubtrees = ["dist/migrations", "dist/tools"];
+
+execFileSync("tsc", ["-p", "tsconfig.transforms.json"], {
+  cwd: fileURLToPath(packageRoot),
+  stdio: "inherit",
+});
+
+for (const subtree of commonJsSubtrees) {
+  const dir = fileURLToPath(new URL(subtree, packageRoot));
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    `${dir}/package.json`,
+    `${JSON.stringify({ type: "commonjs" }, null, 2)}\n`,
+  );
+}

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -9,15 +9,13 @@
     "flow-codemods": "dist/cli.js"
   },
   "files": [
-    "dist",
-    "src/migrations/**/transform.ts",
-    "src/tools/to-remote-package.ts"
+    "dist"
   ],
   "engines": {
     "node": ">=22.0.0"
   },
   "scripts": {
-    "build": "tsx dev/generateCli.ts && tsc -p tsconfig.build.json",
+    "build": "tsx dev/generateCli.ts && tsc -p tsconfig.build.json && tsx dev/buildTransforms.ts",
     "test:compile": "tsc --noEmit",
     "test:unit": "vitest run"
   },

--- a/packages/codemods/project.json
+++ b/packages/codemods/project.json
@@ -15,6 +15,7 @@
       "inputs": ["codemods-src", "{workspaceRoot}/.prettierrc.json"],
       "outputs": [
         "{projectRoot}/dist",
+        "{projectRoot}/tsconfig.build.tsbuildinfo",
         "{projectRoot}/src/migrations.generated.ts",
         "{projectRoot}/src/flowPackages.generated.ts",
         "{workspaceRoot}/packages/components/MIGRATION.md"
@@ -25,7 +26,10 @@
       "dependsOn": ["^build", "build"],
       "inputs": [
         "codemods-src",
-        { "dependentTasksOutputFiles": "**/*", "transitive": false },
+        {
+          "dependentTasksOutputFiles": "**/*",
+          "transitive": false
+        },
         "{workspaceRoot}/apps/docs/src/content/get-started/versioning/index.mdx"
       ]
     }

--- a/packages/codemods/src/run/jscodeshift.ts
+++ b/packages/codemods/src/run/jscodeshift.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { unknownCodemodMessage } from "../catalog/entries.js";
 // jscodeshift ships no types for its Runner — `allowJs` in this repo's shared
 // tsconfig (packages/typescript-config/base.json) lets a deep import of a
@@ -9,33 +9,50 @@ import { unknownCodemodMessage } from "../catalog/entries.js";
 import { run as runJscodeshift } from "jscodeshift/src/Runner.js";
 
 /**
- * `<packageRoot>/src/migrations` and `<packageRoot>/src/tools`, from either
- * `src/run` or `dist/run`.
- *
- * `dist` mirrors `src`'s directory depth, so one pair of relative paths serves
- * the test run and the published binary. The transforms are not compiled into
- * `dist`: jscodeshift puts a transform through its own babel pipeline, so it
- * wants the `.ts` file.
+ * The package root, from either `src/run` or `dist/run` — both are two levels
+ * down, so one expression serves the test run and the published binary.
  */
-const migrationsDir = fileURLToPath(
-  new URL("../../src/migrations", import.meta.url),
-);
-const toolsDir = fileURLToPath(new URL("../../src/tools", import.meta.url));
+const packageRoot = fileURLToPath(new URL("../../", import.meta.url));
 
 /**
- * The transform file for `id`: `src/migrations/<id>/transform.ts` when `id`
- * names a migration, otherwise `src/tools/<id>.ts`.
+ * Where a transform for `id` may live, most preferred first.
  *
- * Deliberately independent of the catalogue: `to-remote-package` is a transform
- * with no catalogue entry (it is a port, not a migration — see `notAMigration`
- * in `src/tests/remoteScope.test.ts`), and it still has to be runnable by id.
- * It lives in `src/tools` rather than `src/migrations` for exactly that reason
- * — there is no migration directory to put it beside.
+ * The compiled CommonJS in `dist` comes first, and in a published install it is
+ * the only one that works. jscodeshift's worker `require()`s this path; it
+ * installs `@babel/register` beforehand, but babel-register's `only` defaults
+ * to the current working directory, so a transform inside the consumer's
+ * `node_modules` is never claimed by babel. Node's own `.ts` handler takes over
+ * and refuses — `ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`, no opt-out — and
+ * every codemod dies before touching a file. See `tsconfig.transforms.json`.
+ *
+ * The `.ts` sources stay as a fallback for running out of the repo (`tsx`, the
+ * unit tests, `dist` not built yet), where cwd _is_ inside the package and
+ * babel-register does claim them. They are no longer published: `files` ships
+ * `dist` only, so the path that cannot work is absent from the tarball rather
+ * than merely deprioritised.
+ *
+ * `src/tools` is searched alongside `src/migrations` because
+ * `to-remote-package` is a transform with no catalogue entry (a port, not a
+ * migration — see `notAMigration` in `src/tests/remoteScope.test.ts`) and still
+ * has to be runnable by id.
  */
-const transformPath = (id: string): string => {
-  const migrationPath = `${migrationsDir}/${id}/transform.ts`;
-  return existsSync(migrationPath) ? migrationPath : `${toolsDir}/${id}.ts`;
-};
+const candidatePaths = (id: string): string[] => [
+  `${packageRoot}dist/migrations/${id}/transform.js`,
+  `${packageRoot}dist/tools/${id}.js`,
+  `${packageRoot}src/migrations/${id}/transform.ts`,
+  `${packageRoot}src/tools/${id}.ts`,
+];
+
+/** The transform file for `id`, or `undefined` when no candidate exists. */
+const findTransform = (id: string): string | undefined =>
+  candidatePaths(id).find((candidate) => existsSync(candidate));
+
+/**
+ * The transform file for `id`, falling back to the last candidate so callers
+ * that only report a path still have one to name.
+ */
+const transformPath = (id: string): string =>
+  findTransform(id) ?? `${packageRoot}src/tools/${id}.ts`;
 
 /**
  * Whether `id` names a transform file on disk.
@@ -87,7 +104,10 @@ interface RunnerStats {
  * `processedNothing` exists because jscodeshift reports a path with no matching
  * files and a worker that died before touching one the same way: every counter
  * zero, no error. The caller must not render that as "0 files changed", which
- * reads like success.
+ * reads like success. The load check below removes the most common cause of the
+ * second case, so `processedNothing` now means the path far more often than it
+ * used to — but not always: a worker can still die for a reason a successful
+ * load does not predict, so the flag keeps its deliberately vague name.
  */
 export const runCodemod = async ({
   id,
@@ -99,6 +119,31 @@ export const runCodemod = async ({
 
   if (!existsSync(transform)) {
     throw new Error(unknownCodemodMessage(id));
+  }
+
+  // Load the transform here, in this process, before handing its path to
+  // jscodeshift.
+  //
+  // A worker that cannot load the transform dies before it touches a file, and
+  // the Runner then resolves with every counter at zero — indistinguishable
+  // from a path that matched nothing (see `processedNothing`). The stack trace
+  // goes to the worker's stderr, where the summary line the caller prints
+  // contradicts it by guessing at the path instead. Loading it up front turns
+  // that class of failure into a thrown error naming the real cause, which is
+  // the only way a caller can tell "this migration got no run at all" from
+  // "this migration had nothing to do".
+  //
+  // Safe to do: every shipped transform imports nothing but types, so loading
+  // one has no side effects and costs a file read.
+  try {
+    await import(pathToFileURL(transform).href);
+  } catch (error) {
+    throw new Error(
+      `${id} could not be loaded from ${transform}: ${
+        error instanceof Error ? error.message : error
+      }`,
+      { cause: error },
+    );
   }
 
   let stats: RunnerStats;

--- a/packages/codemods/src/tests/publishedTransforms.test.ts
+++ b/packages/codemods/src/tests/publishedTransforms.test.ts
@@ -1,0 +1,82 @@
+import { createRequire } from "node:module";
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+import { allEntries } from "../catalog/entries";
+
+/**
+ * What a consumer install can actually load.
+ *
+ * `files` ships `dist` and nothing else, and jscodeshift's worker `require()`s
+ * the transform path. So the only thing that matters for a published run is
+ * whether `dist` holds a CommonJS transform per codemod, loadable by `require`
+ * with no babel and no type stripping involved.
+ *
+ * This is a build-output test on purpose. The unit tests run the `.ts` sources
+ * through babel-register (cwd is inside the package there, so babel claims
+ * them), which is exactly why the published package could ship transforms that
+ * no consumer could load while every fixture test stayed green — the failure
+ * this file exists to catch. `test:unit` depends on `build`, so `dist` is
+ * current when it runs.
+ */
+const packageRoot = new URL("../../", import.meta.url);
+const require = createRequire(import.meta.url);
+
+const distPath = (relative: string): string =>
+  fileURLToPath(new URL(`dist/${relative}`, packageRoot));
+
+const codemodIds = allEntries
+  .filter((entry) => entry.action === "codemod")
+  .map((entry) => entry.id);
+
+describe("the published package can load its transforms", () => {
+  test("there is at least one codemod to check", () => {
+    expect(codemodIds.length).toBeGreaterThan(0);
+  });
+
+  test.each(codemodIds)("%s is compiled into dist", (id) => {
+    expect(existsSync(distPath(`migrations/${id}/transform.js`))).toBe(true);
+  });
+
+  test.each(codemodIds)("%s loads through require and is a function", (id) => {
+    // `require`, not `import`: this is the call jscodeshift's worker makes, and
+    // it is what fails when the output is ESM or the CommonJS marker is missing.
+    const loaded = require(distPath(`migrations/${id}/transform.js`)) as {
+      default?: unknown;
+    };
+    expect(typeof loaded.default).toBe("function");
+  });
+
+  test("to-remote-package is compiled too", () => {
+    const path = distPath("tools/to-remote-package.js");
+    expect(existsSync(path)).toBe(true);
+    expect(typeof (require(path) as { default?: unknown }).default).toBe(
+      "function",
+    );
+  });
+
+  test.each(["migrations", "tools"])(
+    "dist/%s is marked as CommonJS",
+    (subtree) => {
+      // Without this marker Node reads the emitted `.js` as ESM — the package is
+      // `"type": "module"` — and the first line (`Object.defineProperty(exports,
+      // …)`) throws `exports is not defined`.
+      const marker = JSON.parse(
+        readFileSync(distPath(`${subtree}/package.json`), "utf8"),
+      ) as { type?: string };
+      expect(marker.type).toBe("commonjs");
+    },
+  );
+
+  test("no transform source is published", () => {
+    // The `.ts` sources are the path that cannot work in a consumer install:
+    // babel-register's `only` defaults to cwd, so a transform under the
+    // consumer's `node_modules` falls through to Node's `.ts` handler, which
+    // refuses with ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING. Keeping them out
+    // of `files` makes that unreachable rather than merely deprioritised.
+    const manifest = JSON.parse(
+      readFileSync(fileURLToPath(new URL("package.json", packageRoot)), "utf8"),
+    ) as { files?: string[] };
+    expect(manifest.files).toEqual(["dist"]);
+  });
+});

--- a/packages/codemods/tsconfig.build.json
+++ b/packages/codemods/tsconfig.build.json
@@ -5,6 +5,14 @@
     "rootDir": "src",
     // Outside `dist`, which `files` ships to consumers — the buildinfo is a
     // local incremental-build cache, not a build artefact for npm.
+    //
+    // Because it sits outside `dist`, it has to be listed in the build target's
+    // `outputs` in `project.json`, next to `dist` itself. nx restores a cached
+    // task's outputs wholesale; if it restored `dist` from one run while this
+    // file survived from another, tsc would find the buildinfo current, emit
+    // **nothing**, and the build would report success over an incomplete `dist`.
+    // Caching the two together keeps them describing the same artefacts. Do not
+    // drop that entry.
     "tsBuildInfoFile": "tsconfig.build.tsbuildinfo",
     // Excluding src/tests, the transforms and their co-located tests shrinks
     // the program to 2 files (cli.ts, cli/args.ts). The native `tsc`

--- a/packages/codemods/tsconfig.transforms.json
+++ b/packages/codemods/tsconfig.transforms.json
@@ -1,0 +1,40 @@
+{
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    // CommonJS, deliberately, and the one thing this config exists for.
+    //
+    // jscodeshift's worker `require()`s the transform file. It installs
+    // `@babel/register` first, but babel-register's `only` defaults to the
+    // current working directory — a transform inside the consumer's
+    // `node_modules` is outside it, so babel never claims the file and Node's
+    // own `.ts` handler takes over. Node then refuses:
+    // ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING ("Stripping types is
+    // currently unsupported for files under node_modules"), which has no
+    // opt-out. Every codemod died that way in a published install.
+    //
+    // ESM output would not fix it either: `require()` of ESM only works from
+    // Node 22.12, and `engines` allows 22.0. Plain CommonJS is loadable by
+    // every supported Node with no babel involved at all — which the shipped
+    // transforms can afford, because each imports nothing but *types* from
+    // jscodeshift, so the emitted JavaScript has no runtime imports.
+    // `moduleResolution` is deliberately absent: TypeScript 7 removed `node10`,
+    // and `module: commonjs` implies the resolution this needs anyway. The base
+    // config sets `module: "preserve"`, which is what has to be overridden here.
+    "module": "commonjs",
+    // `.js` under a `"type": "module"` package is ESM, so the emitted files
+    // need a `{"type": "commonjs"}` marker beside them. `dev/buildTransforms.ts`
+    // writes it after this compile — see the comment there.
+    "verbatimModuleSyntax": false,
+    // Nothing imports a transform as a module: jscodeshift loads it by path.
+    "declaration": false,
+    "declarationMap": false,
+    "composite": false,
+    "tsBuildInfoFile": "tsconfig.transforms.tsbuildinfo",
+    "types": ["node"]
+  },
+  "exclude": ["src/**/*.test.ts"],
+  "extends": "./tsconfig.json",
+  "include": ["src/migrations/**/transform.ts", "src/tools/*.ts"]
+}

--- a/packages/codemods/tsconfig.transforms.json
+++ b/packages/codemods/tsconfig.transforms.json
@@ -31,7 +31,19 @@
     "declaration": false,
     "declarationMap": false,
     "composite": false,
-    "tsBuildInfoFile": "tsconfig.transforms.tsbuildinfo",
+    // Not incremental, deliberately — the base config turns it on. nx treats
+    // `{projectRoot}/dist` as this project's task output and restores it
+    // wholesale from cache, while a buildinfo file lives outside `dist` and is
+    // not an output. The two desynchronise: `dist/migrations` comes back from a
+    // cached run that predates this compile, the buildinfo still says everything
+    // is up to date, and tsc emits **nothing** while reporting success. The
+    // package then ships with no transforms at all — the exact failure this
+    // second compile exists to prevent, reintroduced by its own build cache.
+    // (`src/tests/publishedTransforms.test.ts` is what caught it.)
+    //
+    // Nothing is lost: the program is a handful of files that import only types,
+    // so a full emit is instant.
+    "incremental": false,
     "types": ["node"]
   },
   "exclude": ["src/**/*.test.ts"],


### PR DESCRIPTION
**Every codemod died in every published install.** `files` shipped the transforms
as raw TypeScript, and jscodeshift's worker `require()`s that path. It installs
`@babel/register` first, but babel-register's `only` defaults to the current
working directory — a transform under the consumer's `node_modules` is outside it,
so babel never claims the file. Node's own `.ts` handler takes over and refuses:

```
Error [ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING]: Stripping types is currently
unsupported for files under node_modules, for ".../src/migrations/align-to-combine/transform.ts"
    at setup (.../jscodeshift/src/Worker.js:93:18)
align-to-combine: no files under .../app were processed. Is the path right?
```

Reproduced against a fresh build in a `files`-faithful layout: exit 1, file
untouched. The restriction is deliberate in Node and has no opt-out flag, so it
applies to any install where the package lives in `node_modules` — every consumer
install.

**Nothing in the repo could see it.** Inside the package, cwd *is* the package, so
babel claims the sources and every fixture test passes on the one path a consumer
never takes.

Reported from a real unattended upgrade run, through the feedback prompt in
mittwald/flow#3038.

## The fix

- `tsconfig.transforms.json` + `dev/buildTransforms.ts`: a second compile emitting
  **CommonJS** into `dist/migrations` and `dist/tools`, with a
  `{"type": "commonjs"}` marker written into each — the package is
  `"type": "module"`, so the emitted `.js` would otherwise be read as ESM and
  throw `exports is not defined` on its first line.
- CommonJS rather than ESM because `require()` of ESM needs Node 22.12 and
  `engines` allows 22.0. Affordable because **every shipped transform imports
  nothing but types**, so the output has no runtime imports at all.
- `files` drops the `.ts` entries. The path that cannot work is absent from the
  tarball rather than merely deprioritised; `src/run/jscodeshift.ts` prefers the
  compiled file and keeps the sources as a repo-only fallback for `tsx` and the
  unit tests.

## Also: a crashed codemod no longer reports as an empty path

`runCodemod` loads the transform in-process before handing its path to
jscodeshift. A worker that cannot load it dies before touching a file and the
Runner resolves with every counter at zero — indistinguishable from a path that
matched nothing, which is exactly why this failure surfaced as "no files under
`<path>` were processed. Is the path right?" while the real cause sat in the
worker's stderr. Loading up front turns it into a thrown error naming the cause.

## And: the second commit is the same bug, one layer up

While splitting this branch the new test caught the build **reporting success and
shipping no transforms at all** — the failure this PR exists to prevent,
reintroduced by its own build cache. Two independent causes, both a
`*.tsbuildinfo` outliving the `dist` it describes: nx restores a cached task's
outputs wholesale, so a buildinfo that is not itself an output can come back from
one run while `dist` comes back from another, after which tsc finds everything
current and emits nothing.

- `tsconfig.transforms.json` is no longer incremental — the base config turns it
  on, and it buys nothing for a handful of files that import only types.
- `tsconfig.build.tsbuildinfo` joins the build target's `outputs` beside `dist`,
  so nx caches and restores them together. **This one is pre-existing**: the main
  compile has always had the hole, and a hand-deleted `dist` reproduces it. It
  cannot be fixed the same way, because `composite` from the shared library preset
  requires `incremental`.

The rule is general, so the root `AGENTS.md` nx-wiring note now says it: every
file a task produces belongs in `outputs`, gitignored sidecars included.

## Verification

- The consumer repro now reports `1 file(s) changed` and rewrites the file
- `src/tests/publishedTransforms.test.ts` loads every compiled transform through
  `require`, the way the worker does, and asserts the CommonJS markers and that
  `files` is `["dist"]`. A build-output test on purpose: it is the only kind that
  could have caught either bug — and it caught the second one within the hour
- With the buildinfo deleted and `dist` wiped, a build emits all eleven
  transforms; deleting `dist` *and* the buildinfo and letting nx restore from
  cache brings back both, complete
- 277 unit tests pass (252 before), `test:compile` clean, `pnpm lint` exit 0

## Companion PRs

Split so each carries one release meaning:

- mittwald/flow#3043 — `fix`, `main`: the `action -> onAction` type change (was
  here; shares no file with this)
- mittwald/flow#3042 — `fix`, `main`: the SegmentedControl → RadioGroup direction
- mittwald/flow#3038 — `docs`: the upgrade and feedback prompts
- mittwald/flow#3041 — `feat`, `next`: package-manager detection and two codemods

**Merge this one first.** Until it lands, the codemod half of `upgrade` does
nothing for anybody.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
