### PR TITLE
fix(codemods): install with the project's real package manager

### DIFF
--- a/packages/codemods/AGENTS.md
+++ b/packages/codemods/AGENTS.md
@@ -5,18 +5,18 @@ the `@mittwald/flow-codemods` CLI that runs them.
 
 ## Layout
 
-| Path                                                             | What it holds                                                                                                                                                                                       |
-| ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `src/migrations/<id>/entry.md`                                   | The catalogue. One directory per migration, `entry.md` holding its frontmatter plus prose body. **The source.**                                                                                     |
-| `src/migrations/<id>/transform.ts`                               | The jscodeshift transform, only for entries with `action: codemod`.                                                                                                                                 |
-| `src/migrations/<id>/transform.test.ts`                          | That transform's fixtures, including its idempotency case. Required whenever `transform.ts` exists — see below.                                                                                     |
-| `src/tools`                                                      | Transforms with no catalogue entry, each with a co-located `<name>.test.ts`. Currently only `to-remote-package` — see [Does it apply to the remote package?](#does-it-apply-to-the-remote-package). |
-| `src/catalog`                                                    | Reading, typing and selecting catalogue entries.                                                                                                                                                    |
-| `src/cli`, `src/cli.ts`                                          | The `upgrade`, `list` and single-codemod commands.                                                                                                                                                  |
-| `src/resolve`, `src/manifest.ts`, `src/install.ts`, `src/git.ts` | Version resolution, manifest edits, package-manager install, and the dirty-working-tree guard for `upgrade`.                                                                                        |
-| `src/run`                                                        | Drives jscodeshift's `Runner` in-process (not the CLI binary).                                                                                                                                      |
-| `dev/generate`, `dev/buildTransforms.ts`                         | The three catalogue generators, plus the transforms' CommonJS compile — see [Transforms are compiled](#transforms-are-compiled-and-that-is-not-optional).                                           |
-| `src/tests`                                                      | Cross-cutting tests: catalogue invariants, remote-scope checks, the transform-test-coverage guard, and `runTransform`, the run-through-the-real-CLI helper every fixture test uses.                 |
+| Path                                                             | What it holds                                                                                                                                                                                                    |
+| ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/migrations/<id>/entry.md`                                   | The catalogue. One directory per migration, `entry.md` holding its frontmatter plus prose body. **The source.**                                                                                                  |
+| `src/migrations/<id>/transform.ts`                               | The jscodeshift transform, only for entries with `action: codemod`.                                                                                                                                              |
+| `src/migrations/<id>/transform.test.ts`                          | That transform's fixtures, including its idempotency case. Required whenever `transform.ts` exists — see below.                                                                                                  |
+| `src/tools`                                                      | Transforms with no catalogue entry, each with a co-located `<name>.test.ts`. Currently only `to-remote-package` — see [Does it apply to the remote package?](#does-it-apply-to-the-remote-package).              |
+| `src/catalog`                                                    | Reading, typing and selecting catalogue entries.                                                                                                                                                                 |
+| `src/cli`, `src/cli.ts`                                          | The `upgrade`, `list` and single-codemod commands.                                                                                                                                                               |
+| `src/resolve`, `src/manifest.ts`, `src/install.ts`, `src/git.ts` | Version resolution, manifest edits, the package-manager install (detection up the tree, `packageManager` pin, corepack bridge — via `package-manager-detector`), and the dirty-working-tree guard for `upgrade`. |
+| `src/run`                                                        | Drives jscodeshift's `Runner` in-process (not the CLI binary).                                                                                                                                                   |
+| `dev/generate`, `dev/buildTransforms.ts`                         | The three catalogue generators, plus the transforms' CommonJS compile — see [Transforms are compiled](#transforms-are-compiled-and-that-is-not-optional).                                                        |
+| `src/tests`                                                      | Cross-cutting tests: catalogue invariants, remote-scope checks, the transform-test-coverage guard, and `runTransform`, the run-through-the-real-CLI helper every fixture test uses.                              |
 
 The directory **is** the id — it appears once, instead of once per filename
 spread across three separate directories. A migration with no codemod is a
@@ -83,6 +83,35 @@ build instead of shipping.
 A transform may import shared helpers from elsewhere in `src` — they are
 compiled along with it. What it must not do is reach anything that stays outside
 `dist`.
+
+### The install is detected, not assumed
+
+`src/install.ts` wraps `package-manager-detector` (zero dependencies) for both
+detection and command resolution; execution stays ours, because that is where
+the test seam (`InstallRunner`, `Probe`), the frozen-lockfile quirks and the
+Windows `shell` flag live.
+
+Three things there are load-bearing and easy to undo by accident:
+
+- **Detection walks up.** A workspace package has no lockfile, and detecting in
+  `cwd` alone fell through to `npm install` — which dies on a `workspace:*`
+  manifest, after `upgrade` already rewrote `package.json`.
+- **pnpm gets `--no-frozen-lockfile`, yarn gets
+  `YARN_ENABLE_IMMUTABLE_INSTALLS=false`.** `upgrade` just made the lockfile
+  stale on purpose, and both managers freeze it themselves when they detect CI.
+  The library's `"install"` is the plain install for every agent, so these
+  quirks are not something it will hand us.
+- **The `packageManager` pin is checked before corepack is used.** Corepack
+  ignores `PATH` and downloads into its own cache, so always routing through it
+  would send every pinned project — most of them — through a download, offline
+  CI included. The comparison is `semver.satisfies`, not a string compare: the
+  library reports a `\d+(\.\d+){0,2}` match, so `pnpm@8` yields the pin `"8"`
+  against a reported `8.15.0`.
+
+`resolveInvoke` is the same detection used for prose: it decides whether a
+printed command says `npx`, `pnpm dlx`, `yarn dlx` or `bun x`. That is why the
+bare `list` is no longer manifest-free — a deliberate trade, recorded in the
+README.
 
 ### Every transform has a test — enforced, not just conventional
 

--- a/packages/codemods/README.md
+++ b/packages/codemods/README.md
@@ -1,19 +1,28 @@
 # @mittwald/flow-codemods
 
 Codemods and an upgrade CLI for consumers of [Flow](https://flow.mittwald.de),
-mittwald's design system. Run it with `npx` — there is no reason to install it
-as a dependency.
+mittwald's design system. Run it one-off — there is no reason to install it as a
+dependency.
 
 ```shell
 npx @mittwald/flow-codemods@latest upgrade
 ```
 
+Use whatever your project's package manager calls that: `npx …` (npm, and Yarn
+Classic, which has no `dlx`), `pnpm dlx …`, `yarn dlx …`, `bun x …`. Every
+command the CLI prints for you to copy uses the form it detected for your
+project, so the examples below stay on `npx` only because a README cannot know.
+
 ## Commands
 
 ### `upgrade [revision]`
 
-Bumps every `@mittwald/flow-*` dependency in `package.json` to a resolved
-target, installs, then runs the codemod of every migration up to that target.
+Bumps every Flow-line dependency in `package.json` to a resolved target,
+installs, then runs the codemod of every migration up to that target.
+
+"Flow line" is wider than `@mittwald/flow-*`: every package published from the
+Flow monorepo shares one version, so `@mittwald/ext-bridge`,
+`@mittwald/mstudio-ext-react-components` and `@mittwald/react-tunnel` move too.
 
 `revision` is one of:
 
@@ -32,6 +41,24 @@ version some dependency lacks.
 versions your package supports, not one it installs, and narrowing `^1.0.0` to
 `^1.0.14` would change what _your_ consumers are allowed to install. That is
 your call, not the command's.
+
+#### Which package manager installs
+
+Detected by walking **up** from the directory you run in: lockfiles first, then
+`packageManager`, then `devEngines.packageManager`, then the metadata a manager
+leaves in `node_modules`. Walking up is what makes a workspace package work — it
+has no lockfile of its own, and detecting in that directory alone used to fall
+back to `npm install`, which on a `workspace:*` manifest fails outright. npm
+stays the fallback when nothing says anything: it is always there next to Node.
+
+A `packageManager` pin is honoured. If the binary on `PATH` already satisfies
+it, that one runs; otherwise the install goes through corepack (with the
+download prompt disabled, since this runs unattended). If neither works, the
+command refuses **before** installing and names the pin, the version it found,
+and where to get the right one — rather than installing with the wrong manager.
+
+The log line names the agent, the pin and the command it actually ran, so a
+wrong detection is visible instead of silent.
 
 After installing, `upgrade` runs the codemod of every migration whose `since` is
 at or below the target and prints the ones with no codemod, for you to apply by
@@ -65,8 +92,10 @@ Shows migrations — codemod and by-hand alike — without touching the project.
 read-only planning entry point: run it before `upgrade` to see what a bump would
 involve.
 
-- `list` (no argument) — the whole catalogue. Offline: reads no manifest, hits
-  no network.
+- `list` (no argument) — the whole catalogue. Hits no network. It does read
+  lockfiles and `package.json` up the tree, but only to work out whether the
+  commands it prints should say `npx`, `pnpm dlx`, `yarn dlx` or `bun x` — a
+  command you can paste is worth more than never touching a manifest.
 - `list [revision]` — the same manifest read, registry fetch, and revision
   resolution `upgrade [revision]` does, showing exactly the range it would act
   on, without writing anything. `revision` takes the same values as `upgrade`'s

--- a/packages/codemods/dev/generate/migrationGuide.ts
+++ b/packages/codemods/dev/generate/migrationGuide.ts
@@ -31,6 +31,11 @@ performed, and re-running a codemod is a no-op.
 
 It refuses to run on a dirty working tree (\`--allow-dirty\` overrides that) and
 rewrites files in place, so review the diff afterwards.
+
+Every command on this page is written with \`npx\`, because a generated file
+cannot know your package manager. Substitute the equivalent if yours differs:
+\`pnpm dlx\`, \`yarn dlx\` (Yarn Classic has no \`dlx\` — it uses \`npx\`), or
+\`bun x\`. The CLI's own output does detect it and prints the right form.
 `;
 
 const remoteNote = "also applies to `@mittwald/flow-remote-react-components`";
@@ -49,7 +54,9 @@ const renderEntry = (entry: MigrationEntry): string => {
 
   const invocation =
     entry.action === "codemod"
-      ? `\`\`\`shell\nnpx @mittwald/flow-codemods@latest ${entry.id} src\n\`\`\`\n`
+      ? // `src` and `npx` are both assumptions a generated file has to make —
+        // see the note in `intro`. The CLI prints the detected form instead.
+        `\`\`\`shell\nnpx @mittwald/flow-codemods@latest ${entry.id} src\n\`\`\`\n`
       : "";
 
   return [

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mittwald/flow-codemods",
-  "version": "1.2.0-next.0",
+  "version": "1.1.3",
   "type": "module",
   "description": "Codemods and an upgrade CLI for consumers of Flow, mittwald's design system",
   "homepage": "https://flow.mittwald.de",

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mittwald/flow-codemods",
-  "version": "1.1.3",
+  "version": "1.2.0-next.0",
   "type": "module",
   "description": "Codemods and an upgrade CLI for consumers of Flow, mittwald's design system",
   "homepage": "https://flow.mittwald.de",
@@ -22,6 +22,7 @@
   "dependencies": {
     "@inquirer/prompts": "^7.9.0",
     "jscodeshift": "^17.3.0",
+    "package-manager-detector": "^1.8.0",
     "picocolors": "^1.1.1",
     "registry-url": "^7.2.0",
     "semver": "^7.8.5"

--- a/packages/codemods/src/cli.ts
+++ b/packages/codemods/src/cli.ts
@@ -2,7 +2,7 @@
 import { readFileSync } from "node:fs";
 import { parseArguments } from "./cli/args.js";
 import { createChoose } from "./cli/choose.js";
-import { runSingleCodemod } from "./cli/codemod.js";
+import { displaySourcePath, runSingleCodemod } from "./cli/codemod.js";
 import { defaultListDeps, runList } from "./cli/list.js";
 import { defaultUpgradeDeps, runUpgrade } from "./cli/upgrade.js";
 
@@ -71,6 +71,11 @@ const main = async (): Promise<number> => {
         // (or none at all), and beyond ~100 columns long prose gets harder to
         // read rather than easier.
         width: Math.min(Math.max(process.stdout.columns ?? 80, 60), 100),
+        // The per-entry command `list` prints has to name the path this project
+        // actually uses; hardcoding `src` handed readers a command that fails on
+        // any other layout. `--path` wins, otherwise the same `src`-or-cwd
+        // choice a real run would make.
+        path: displaySourcePath(parsed.path, process.cwd()),
       });
     case "codemod":
       return await runSingleCodemod(parsed, {

--- a/packages/codemods/src/cli.ts
+++ b/packages/codemods/src/cli.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { parseArguments } from "./cli/args.js";
 import { createChoose } from "./cli/choose.js";
 import { displaySourcePath, runSingleCodemod } from "./cli/codemod.js";
+import { resolveInvoke } from "./install.js";
 import { defaultListDeps, runList } from "./cli/list.js";
 import { defaultUpgradeDeps, runUpgrade } from "./cli/upgrade.js";
 
@@ -76,6 +77,11 @@ const main = async (): Promise<number> => {
         // any other layout. `--path` wins, otherwise the same `src`-or-cwd
         // choice a real run would make.
         path: displaySourcePath(parsed.path, process.cwd()),
+        // `npx` is wrong for a pnpm, Yarn Berry or Bun project. Detecting the
+        // manager here costs the bare `list` its "reads no manifest" property —
+        // a deliberate trade: a command the reader can actually paste beats the
+        // purity of that claim. It still hits no network.
+        invoke: await resolveInvoke(process.cwd()),
       });
     case "codemod":
       return await runSingleCodemod(parsed, {

--- a/packages/codemods/src/cli/codemod.ts
+++ b/packages/codemods/src/cli/codemod.ts
@@ -29,6 +29,32 @@ export const resolveSourcePath = (
   return exists(join(cwd, "src")) ? join(cwd, "src") : cwd;
 };
 
+/**
+ * The same choice as `resolveSourcePath`, in the form a reader would type.
+ *
+ * `list` prints a runnable command per codemod entry, and it used to hardcode
+ * `src` there. On a project whose sources are anywhere else, pasting that line
+ * runs the codemod against a directory that does not exist — and the run then
+ * reports "no files under <path> were processed. Is the path right?", sending
+ * the reader after a path they were handed. So the printed command has to carry
+ * the path actually in use.
+ *
+ * Relative, not the absolute result of `resolveSourcePath`: a copy-pasteable
+ * command should stay short and keep working from the same directory the reader
+ * already is in. `"."` when the resolved path is `cwd` itself — a bare command
+ * with no argument would default back to `src` and pick the wrong tree.
+ */
+export const displaySourcePath = (
+  explicit: string | undefined,
+  cwd: string,
+  exists: (path: string) => boolean = existsSync,
+): string => {
+  if (explicit !== undefined) {
+    return explicit;
+  }
+  return exists(join(cwd, "src")) ? "src" : ".";
+};
+
 export interface CodemodCommandDeps {
   cwd: string;
   log: (message: string) => void;

--- a/packages/codemods/src/cli/list.ts
+++ b/packages/codemods/src/cli/list.ts
@@ -23,6 +23,15 @@ export interface RenderListInput {
   /** Terminal width to wrap prose to. */
   width?: number;
   /**
+   * How to invoke this package in a printed command — e.g. `npx
+   * @mittwald/flow-codemods@latest` or `pnpm dlx …`.
+   *
+   * Defaults to the `npx` form, which is right for npm and for Yarn Classic
+   * (which has no `dlx`). A pnpm, Yarn Berry or Bun project gets a command it
+   * cannot paste otherwise.
+   */
+  invoke?: string;
+  /**
    * The path argument to print in each codemod entry's runnable command.
    *
    * Defaults to `src` — the same default `resolveSourcePath` applies — but a
@@ -142,6 +151,14 @@ const painter = (color: boolean): Painter => {
   };
 };
 
+/**
+ * The invocation to print when nobody says otherwise.
+ *
+ * `npx` is also correct for Yarn Classic, which has no `dlx` — the library
+ * resolves both to it.
+ */
+export const defaultInvoke = "npx @mittwald/flow-codemods@latest";
+
 const indent = "  ";
 const labelWidth = 8;
 
@@ -185,6 +202,7 @@ const renderEntry = (
   color: boolean,
   catchUp: boolean,
   path: string,
+  invoke: string,
 ): string => {
   const paint = painter(color);
   const action = actions[entry.action];
@@ -213,7 +231,7 @@ const renderEntry = (
     lines.push(
       "",
       `${indent}${paint.dim("$")} ${paint.code(
-        `npx @mittwald/flow-codemods@latest ${entry.id} ${path}`,
+        `${invoke} ${entry.id} ${path}`,
       )}`,
     );
   }
@@ -324,6 +342,7 @@ export const renderList = ({
   color = false,
   width = 80,
   path = "src",
+  invoke = defaultInvoke,
   frame = true,
 }: RenderListInput): string => {
   // The two paths differ in their bounds, deliberately: unbounded, this is a
@@ -366,7 +385,14 @@ export const renderList = ({
 
   const body = selected
     .map((entry) =>
-      renderEntry(entry, width, color, isCatchUp(entry, range?.from), path),
+      renderEntry(
+        entry,
+        width,
+        color,
+        isCatchUp(entry, range?.from),
+        path,
+        invoke,
+      ),
     )
     .join("\n\n");
 
@@ -395,6 +421,8 @@ export interface ListDeps extends RangeDeps {
   width?: number;
   /** Printed in each codemod entry's command — see `RenderListInput.path`. */
   path?: string;
+  /** Printed as the command's prefix — see `RenderListInput.invoke`. */
+  invoke?: string;
 }
 
 export const defaultListDeps = (cwd: string): ListDeps => ({
@@ -430,6 +458,7 @@ export const runList = async (
         color: deps.color,
         width: deps.width,
         path: deps.path,
+        invoke: deps.invoke,
       }),
     );
     return 0;
@@ -449,6 +478,7 @@ export const runList = async (
       color: deps.color,
       width: deps.width,
       path: deps.path,
+      invoke: deps.invoke,
     }),
   );
   return 0;

--- a/packages/codemods/src/cli/list.ts
+++ b/packages/codemods/src/cli/list.ts
@@ -23,6 +23,15 @@ export interface RenderListInput {
   /** Terminal width to wrap prose to. */
   width?: number;
   /**
+   * The path argument to print in each codemod entry's runnable command.
+   *
+   * Defaults to `src` — the same default `resolveSourcePath` applies — but a
+   * caller that knows better must say so, or the printed command sends the
+   * reader at a directory their project does not have. See
+   * `displaySourcePath`.
+   */
+  path?: string;
+  /**
    * Render the frame around the entries: the context on top (the range, the
    * catch-up legend) and the summary at the bottom (the counts). On by default.
    * `upgrade` turns it off for its by-hand section: it already printed its own
@@ -175,6 +184,7 @@ const renderEntry = (
   width: number,
   color: boolean,
   catchUp: boolean,
+  path: string,
 ): string => {
   const paint = painter(color);
   const action = actions[entry.action];
@@ -203,7 +213,7 @@ const renderEntry = (
     lines.push(
       "",
       `${indent}${paint.dim("$")} ${paint.code(
-        `npx @mittwald/flow-codemods@latest ${entry.id} src`,
+        `npx @mittwald/flow-codemods@latest ${entry.id} ${path}`,
       )}`,
     );
   }
@@ -313,6 +323,7 @@ export const renderList = ({
   json,
   color = false,
   width = 80,
+  path = "src",
   frame = true,
 }: RenderListInput): string => {
   // The two paths differ in their bounds, deliberately: unbounded, this is a
@@ -355,7 +366,7 @@ export const renderList = ({
 
   const body = selected
     .map((entry) =>
-      renderEntry(entry, width, color, isCatchUp(entry, range?.from)),
+      renderEntry(entry, width, color, isCatchUp(entry, range?.from), path),
     )
     .join("\n\n");
 
@@ -382,6 +393,8 @@ export interface ListDeps extends RangeDeps {
   write: (text: string) => void;
   color?: boolean;
   width?: number;
+  /** Printed in each codemod entry's command — see `RenderListInput.path`. */
+  path?: string;
 }
 
 export const defaultListDeps = (cwd: string): ListDeps => ({
@@ -416,6 +429,7 @@ export const runList = async (
         json: parsed.json,
         color: deps.color,
         width: deps.width,
+        path: deps.path,
       }),
     );
     return 0;
@@ -434,6 +448,7 @@ export const runList = async (
       json: parsed.json,
       color: deps.color,
       width: deps.width,
+      path: deps.path,
     }),
   );
   return 0;

--- a/packages/codemods/src/cli/upgrade.ts
+++ b/packages/codemods/src/cli/upgrade.ts
@@ -15,7 +15,7 @@ import { fetchVersions } from "../resolve/registry.js";
 import { readInstalledVersion, resolveRange } from "../resolve/range.js";
 import { runCodemod, type CodemodResult } from "../run/jscodeshift.js";
 import type { ParsedCommand } from "./args.js";
-import { resolveSourcePath } from "./codemod.js";
+import { displaySourcePath, resolveSourcePath } from "./codemod.js";
 import { renderList } from "./list.js";
 
 export interface UpgradeDeps {
@@ -270,6 +270,9 @@ export const runUpgrade = async (
         entries: byHand,
         range: { from: current, to: target },
         json: false,
+        // The same path this run used, so a command copied out of the by-hand
+        // block works instead of falling back to a hardcoded `src`.
+        path: displaySourcePath(parsed.path, cwd),
         frame: false,
       }),
     );

--- a/packages/codemods/src/cli/upgrade.ts
+++ b/packages/codemods/src/cli/upgrade.ts
@@ -7,6 +7,7 @@ import { flowPackages } from "../flowPackages.generated.js";
 import { hasUncommittedChanges } from "../git.js";
 import {
   detectPackageManagerIn,
+  resolveInvoke,
   runInstall,
   type InstallRunner,
 } from "../install.js";
@@ -168,13 +169,18 @@ export const runUpgrade = async (
     );
     reportDependencies();
 
-    const manager = detectPackageManagerIn(cwd);
-    log(`Installing with ${manager}`);
+    const manager = await detectPackageManagerIn(cwd);
     try {
-      deps.install(manager, cwd);
+      // Logged after the run, not before: `install` returns what it actually
+      // ran — agent, pin and command line — so a wrong detection is visible in
+      // the output instead of hidden behind a bare manager name. On a throw the
+      // recovery message below carries the reason anyway.
+      log(`Installed with ${deps.install(manager, cwd)}`);
     } catch (error) {
       log(
-        `The dependency bump was written but the install failed, so package.json is on\n${target} while node_modules still holds ${current}.\n\nEither re-run this command once the install works, or undo the bump with\n  git checkout package.json\n\n${
+        `The dependency bump was written but the install failed, so package.json is on\n${target} while node_modules still holds ${current}.\n\nDetected package manager: ${manager.agent}${
+          manager.version === undefined ? "" : ` (pinned ${manager.version})`
+        }. If that is wrong, finish the install yourself with the right one —\nthe bump in package.json is already correct.\n\nOtherwise re-run this command once the install works, or undo the bump with\n  git checkout package.json\n\n${
           error instanceof Error ? error.message : error
         }`,
       );
@@ -273,6 +279,7 @@ export const runUpgrade = async (
         // The same path this run used, so a command copied out of the by-hand
         // block works instead of falling back to a hardcoded `src`.
         path: displaySourcePath(parsed.path, cwd),
+        invoke: await resolveInvoke(cwd),
         frame: false,
       }),
     );

--- a/packages/codemods/src/install.ts
+++ b/packages/codemods/src/install.ts
@@ -1,44 +1,59 @@
 import { execFileSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import { join } from "node:path";
-
-export type PackageManager = "pnpm" | "npm" | "yarn" | "bun";
-
-/** Lockfile to manager, in precedence order. */
-const lockfiles: [string, PackageManager][] = [
-  ["pnpm-lock.yaml", "pnpm"],
-  // Both Bun lockfile names: `bun.lock` (text) is the default only from Bun
-  // 1.2; before that Bun writes the binary `bun.lockb`, which plenty of
-  // projects still have. Missing it would fall through to the npm default and
-  // run `npm install` on a Bun project, leaving a stray package-lock.json.
-  ["bun.lock", "bun"],
-  ["bun.lockb", "bun"],
-  ["yarn.lock", "yarn"],
-  ["package-lock.json", "npm"],
-];
+import { satisfies, validRange } from "semver";
+import { resolveCommand } from "package-manager-detector/commands";
+import { INSTALL_PAGE } from "package-manager-detector/constants";
+import { detect } from "package-manager-detector/detect";
+import type { Agent, DetectResult } from "package-manager-detector";
 
 /**
- * The package manager a project uses, from the lockfiles present.
+ * The project's package manager, as `upgrade` needs to know it.
  *
- * Npm is the fallback: it is the one manager that is always available next to
- * Node, so a project with no lockfile still gets an install rather than an
- * error.
+ * `agent` is what resolves a command (`yarn` and `yarn@berry` want different
+ * ones); `version` is the pin from `packageManager`, when there is one, and is
+ * the string `"berry"` rather than a number for Yarn 2+ — see `pinnedRange`.
  */
-export const detectPackageManager = (present: string[]): PackageManager => {
-  for (const [lockfile, manager] of lockfiles) {
-    if (present.includes(lockfile)) {
-      return manager;
-    }
-  }
-  return "npm";
-};
+export type PackageManager = Pick<DetectResult, "name" | "agent" | "version">;
 
-export const detectPackageManagerIn = (cwd: string): PackageManager =>
-  detectPackageManager(
-    lockfiles
-      .map(([lockfile]) => lockfile)
-      .filter((lockfile) => existsSync(join(cwd, lockfile))),
-  );
+/** Every strategy the library offers, in the order it applies them. */
+const strategies = [
+  "lockfile",
+  "packageManager-field",
+  "devEngines-field",
+  // Not in the library's default set. `upgrade` always runs on an installed
+  // project — it reads `node_modules` to learn the current Flow version — so the
+  // marker a manager leaves in there is a real signal, and the last one before
+  // the npm fallback.
+  "install-metadata",
+] as const;
+
+/** What a project with no signal at all gets. */
+const fallback: PackageManager = { name: "npm", agent: "npm" };
+
+/**
+ * The package manager for the project at `cwd`.
+ *
+ * Detection walks **up** from `cwd`, which is the whole point: the previous
+ * implementation looked for lockfiles in `cwd` only, and a workspace package
+ * has none of its own. In a Yarn or pnpm monorepo it therefore fell through to
+ * the npm default and ran `npm install`, which on a workspace manifest dies
+ * with `EUNSUPPORTEDPROTOCOL Unsupported URL Type "workspace:"` — after
+ * `upgrade` had already rewritten `package.json`. It also ignored
+ * `packageManager` entirely.
+ *
+ * Per directory the strategies are applied in order, so a lockfile in `cwd`
+ * still beats a `packageManager` pin in a parent — and when the lockfile
+ * strategy hits, the library reads that same directory's `package.json` and
+ * lets its pin win. That is the precedence we want, and it is the library's,
+ * not ours.
+ *
+ * Npm on `null`, preserving the old fallback: it is the one manager always
+ * present next to Node, so a project with no signal gets an install rather than
+ * an error.
+ */
+export const detectPackageManagerIn = async (
+  cwd: string,
+): Promise<PackageManager> =>
+  (await detect({ cwd, strategies: [...strategies] })) ?? fallback;
 
 export interface InstallCommand {
   command: string;
@@ -48,7 +63,7 @@ export interface InstallCommand {
 }
 
 /**
- * How to install with a given manager, so that the install actually updates the
+ * How to install with `agent`, so that the install actually updates the
  * lockfile.
  *
  * `upgrade` has just rewritten `package.json`, so the lockfile is deliberately
@@ -56,26 +71,147 @@ export interface InstallCommand {
  * themselves when they detect CI, where an install then _fails_ instead of
  * updating — and CI is exactly where this runs unattended. pnpm takes a flag;
  * Yarn's flag differs between Classic and Berry, so it gets the environment
- * variable instead, which Classic ignores harmlessly.
+ * variable instead, which Classic ignores harmlessly. Keeping the env var also
+ * keeps this one code path rather than branching on a Berry detection being
+ * right.
+ *
+ * The command itself comes from the library. Its `"install"` is the plain
+ * install for every agent — the frozen variants are a separate command there —
+ * so these quirks stay ours.
  */
-export const installCommand = (manager: PackageManager): InstallCommand => {
-  switch (manager) {
-    case "pnpm":
-      return {
-        command: "pnpm",
-        args: ["install", "--no-frozen-lockfile"],
-        env: {},
-      };
-    case "yarn":
-      return {
-        command: "yarn",
-        args: ["install"],
-        env: { YARN_ENABLE_IMMUTABLE_INSTALLS: "false" },
-      };
-    case "npm":
-    case "bun":
-      return { command: manager, args: ["install"], env: {} };
+export const installCommand = (agent: Agent): InstallCommand => {
+  const frozenOptOut = agent.startsWith("pnpm") ? ["--no-frozen-lockfile"] : [];
+  const resolved = resolveCommand(agent, "install", frozenOptOut);
+
+  if (resolved === null) {
+    throw new Error(
+      `${agent} has no install command. Install the dependencies yourself, then re-run this command.`,
+    );
   }
+
+  return {
+    command: resolved.command,
+    args: resolved.args,
+    env: agent.startsWith("yarn")
+      ? { YARN_ENABLE_IMMUTABLE_INSTALLS: "false" }
+      : {},
+  };
+};
+
+/**
+ * The pin as a semver range, or `undefined` when there is nothing to check.
+ *
+ * Two values have to be filtered out. `"berry"` is what the library reports for
+ * Yarn 2+ — a specifier, not a version — and for an unparseable
+ * `packageManager` it hands back the raw string. Neither is a range, and
+ * `satisfies` would throw on both.
+ *
+ * A full pin like `8.15.0` is a valid range meaning exactly that version, so
+ * one comparison covers both `pnpm@8` and `pnpm@8.15.0`. That is also why this
+ * is `satisfies` and not a string compare: the library reports the
+ * `\d+(\.\d+){0,2}` match out of the field, so `packageManager: "pnpm@8"`
+ * yields the pin `"8"` while the binary reports `8.15.0` — a string compare
+ * would send a perfectly fine setup through corepack.
+ */
+export const pinnedRange = (version: string | undefined): string | undefined =>
+  version !== undefined && version !== "berry" && validRange(version) !== null
+    ? version
+    : undefined;
+
+/**
+ * Runs a command and returns its trimmed stdout, or `undefined` if it fails.
+ *
+ * Injected so the pin logic is testable without shelling out — the same reason
+ * `InstallRunner` exists. It is not a CLI flag: the seam belongs in the code.
+ */
+export type Probe = (command: string, args: string[]) => string | undefined;
+
+export const runProbe: Probe = (command, args) => {
+  try {
+    return execFileSync(command, args, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      shell: process.platform === "win32",
+    }).trim();
+  } catch {
+    return undefined;
+  }
+};
+
+export interface InstallPlan {
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+  /** How this reads in the log — agent, pin, and the command actually run. */
+  description: string;
+}
+
+/**
+ * What to run for `manager`, honouring a `packageManager` pin.
+ *
+ * The decision tree, and why it checks before reaching for corepack:
+ *
+ * | Situation                                         | Behaviour                 |
+ * | ------------------------------------------------- | ------------------------- |
+ * | No pin, or the `"berry"` specifier                | run directly              |
+ * | Pin, binary present, version satisfies it         | run directly              |
+ * | Pin, mismatch or binary missing, corepack present | run under corepack        |
+ * | Pin, mismatch or missing, no corepack             | throw, before any install |
+ *
+ * Corepack ignores `PATH` and downloads into its own cache, so "always
+ * corepack" would send every project that has a `packageManager` field — most
+ * of them — through a download, offline CI included. pnpm 9.7+ additionally
+ * installs its own pinned version, so for pnpm the direct path is usually
+ * already right.
+ *
+ * `COREPACK_ENABLE_DOWNLOAD_PROMPT=0` is required rather than tidy: corepack
+ * prompts interactively before a first download, and `upgrade` runs unattended
+ * (`-y` is implied with no TTY). Only one `install` is spawned under corepack —
+ * no nested per-task spawns — so the corepack footgun in the repo's root
+ * `AGENTS.md` does not apply.
+ */
+export const planInstall = (
+  manager: PackageManager,
+  probe: Probe = runProbe,
+): InstallPlan => {
+  const { command, args, env } = installCommand(manager.agent);
+  const line = [command, ...args].join(" ");
+  const pin = pinnedRange(manager.version);
+
+  if (pin === undefined) {
+    return { command, args, env, description: `${manager.agent} — ${line}` };
+  }
+
+  const found = probe(command, ["--version"]);
+  if (found !== undefined && satisfies(found, pin)) {
+    return {
+      command,
+      args,
+      env,
+      description: `${manager.agent} ${found} — ${line}`,
+    };
+  }
+
+  if (probe("corepack", ["--version"]) === undefined) {
+    throw new Error(
+      `This project pins ${manager.name}@${pin} in "packageManager", but ${
+        found === undefined
+          ? `${command} is not on PATH`
+          : `the ${command} on PATH is ${found}`
+      }, and corepack is not available to bridge the gap.\n\nInstall ${
+        manager.name
+      }@${pin} (${
+        INSTALL_PAGE[manager.agent]
+      }) or enable corepack, then re-run this command. Nothing has been installed.`,
+    );
+  }
+
+  return {
+    command: "corepack",
+    args: [command, ...args],
+    env: { ...env, COREPACK_ENABLE_DOWNLOAD_PROMPT: "0" },
+    description: `${manager.agent} ${pin} via corepack — corepack ${line}`,
+  };
 };
 
 /**
@@ -83,14 +219,45 @@ export const installCommand = (manager: PackageManager): InstallCommand => {
  *
  * A named type rather than a bare call so tests can substitute it. There is no
  * `--no-install` flag: the seam belongs in the code, not in the CLI surface.
+ *
+ * Returns the plan's description so the caller can log what actually ran — a
+ * wrong detection then shows up in the output instead of silently installing
+ * with the wrong manager.
  */
-export type InstallRunner = (manager: PackageManager, cwd: string) => void;
+export type InstallRunner = (manager: PackageManager, cwd: string) => string;
 
 export const runInstall: InstallRunner = (manager, cwd) => {
-  const { command, args, env } = installCommand(manager);
-  execFileSync(command, args, {
+  const plan = planInstall(manager);
+  execFileSync(plan.command, plan.args, {
     cwd,
     stdio: "inherit",
-    env: { ...process.env, ...env },
+    env: { ...process.env, ...plan.env },
+    // Node has refused to spawn `.cmd`/`.bat` without a shell since 2024, which
+    // is why every non-npm manager died with ENOENT on Windows. Every argument
+    // here is our own literal or the library's, so there is no quoting hazard.
+    shell: process.platform === "win32",
   });
+  return plan.description;
+};
+
+/**
+ * How to tell a reader to invoke this package, for the manager they use.
+ *
+ * `npx …` for npm and Yarn Classic (which has no `dlx`), `pnpm dlx …`, `yarn
+ * dlx …`, `bun x …`. The package name is passed as an argument rather than
+ * baked in, so the library decides the whole prefix.
+ *
+ * Falls back to the `npx` form when the agent has no `execute` command: a
+ * printed hint is worth more than a gap, and npx is the one form every reader
+ * can run.
+ */
+export const resolveInvoke = async (
+  cwd: string,
+  pkg = "@mittwald/flow-codemods@latest",
+): Promise<string> => {
+  const { agent } = await detectPackageManagerIn(cwd);
+  const resolved = resolveCommand(agent, "execute", [pkg]);
+  return resolved === null
+    ? `npx ${pkg}`
+    : [resolved.command, ...resolved.args].join(" ");
 };

--- a/packages/codemods/src/tests/codemodCommand.test.ts
+++ b/packages/codemods/src/tests/codemodCommand.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import { parseArguments } from "../cli/args";
 import {
+  displaySourcePath,
   resolveSourcePath,
   runSingleCodemod,
   type CodemodCommandDeps,
@@ -30,6 +31,36 @@ describe("resolveSourcePath", () => {
     expect(resolveSourcePath(undefined, "/project", () => false)).toBe(
       "/project",
     );
+  });
+});
+
+describe("displaySourcePath", () => {
+  test("an explicit path is printed as the reader typed it", () => {
+    // Not resolved against cwd: this goes into a copy-pasteable command, and an
+    // absolute path there is both longer and no more correct.
+    expect(displaySourcePath("packages/ui/lib", "/project", () => true)).toBe(
+      "packages/ui/lib",
+    );
+  });
+
+  test("src when src exists", () => {
+    expect(
+      displaySourcePath(undefined, "/project", (path) => path.endsWith("src")),
+    ).toBe("src");
+  });
+
+  test("a dot when it does not — never an omitted argument", () => {
+    // A printed command with no path argument would default back to `src`,
+    // which is the tree this project does not have.
+    expect(displaySourcePath(undefined, "/project", () => false)).toBe(".");
+  });
+
+  test("agrees with resolveSourcePath about which tree it means", () => {
+    const exists = (path: string) => path.endsWith("src");
+    expect(resolveSourcePath(undefined, "/project", exists)).toBe(
+      "/project/src",
+    );
+    expect(displaySourcePath(undefined, "/project", exists)).toBe("src");
   });
 });
 

--- a/packages/codemods/src/tests/install.test.ts
+++ b/packages/codemods/src/tests/install.test.ts
@@ -1,44 +1,84 @@
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "vitest";
 import {
-  detectPackageManager,
   detectPackageManagerIn,
+  resolveInvoke,
   installCommand,
+  pinnedRange,
+  planInstall,
+  type PackageManager,
+  type Probe,
 } from "../install";
 
-describe("detectPackageManager", () => {
-  test("recognises each lockfile", () => {
-    expect(detectPackageManager(["pnpm-lock.yaml"])).toBe("pnpm");
-    expect(detectPackageManager(["package-lock.json"])).toBe("npm");
-    expect(detectPackageManager(["yarn.lock"])).toBe("yarn");
-    expect(detectPackageManager(["bun.lock"])).toBe("bun");
-  });
+const project = (
+  files: Record<string, string>,
+): { root: string; nested: string } => {
+  const root = mkdtempSync(join(tmpdir(), "flow-codemods-install-"));
+  const nested = join(root, "packages", "app");
+  mkdirSync(nested, { recursive: true });
 
-  test("prefers pnpm when several lockfiles are present", () => {
-    expect(detectPackageManager(["package-lock.json", "pnpm-lock.yaml"])).toBe(
-      "pnpm",
-    );
-  });
+  for (const [name, content] of Object.entries(files)) {
+    writeFileSync(join(root, name), content);
+  }
+  return { root, nested };
+};
 
-  test("falls back to npm when there is no lockfile", () => {
-    expect(detectPackageManager([])).toBe("npm");
-  });
-});
+const manifest = (fields: Record<string, unknown>): string =>
+  JSON.stringify({ name: "fixture", ...fields });
 
 describe("detectPackageManagerIn", () => {
-  test("resolves bun from the binary lockfile on disk", () => {
-    const dir = mkdtempSync(join(tmpdir(), "flow-codemods-install-"));
-    writeFileSync(join(dir, "bun.lockb"), "");
-
-    expect(detectPackageManagerIn(dir)).toBe("bun");
+  test("recognises a lockfile in the directory itself", async () => {
+    const { root } = project({ "pnpm-lock.yaml": "" });
+    expect((await detectPackageManagerIn(root)).agent).toBe("pnpm");
   });
 
-  test("falls back to npm when the directory has no lockfile", () => {
-    const dir = mkdtempSync(join(tmpdir(), "flow-codemods-install-"));
+  test("recognises the binary bun lockfile", async () => {
+    // `bun.lockb` predates Bun 1.2's text `bun.lock` and plenty of projects
+    // still have it. Missing it used to mean `npm install` on a Bun project.
+    const { root } = project({ "bun.lockb": "" });
+    expect((await detectPackageManagerIn(root)).agent).toBe("bun");
+  });
 
-    expect(detectPackageManagerIn(dir)).toBe("npm");
+  test("walks up to the workspace root — the monorepo bug", async () => {
+    // The regression this rewrite exists for: a workspace package has no
+    // lockfile of its own, so detection in the directory alone fell through to
+    // npm and ran `npm install` on a `workspace:*` manifest, which dies with
+    // EUNSUPPORTEDPROTOCOL after the bump was already written.
+    const { nested } = project({ "yarn.lock": "" });
+    expect((await detectPackageManagerIn(nested)).agent).toBe("yarn");
+  });
+
+  test("honours a packageManager pin with no lockfile anywhere", async () => {
+    const { nested } = project({
+      "package.json": manifest({ packageManager: "pnpm@8.15.0" }),
+    });
+    const detected = await detectPackageManagerIn(nested);
+    expect(detected.agent).toBe("pnpm");
+    expect(detected.version).toBe("8.15.0");
+  });
+
+  test("reads yarn 4 as berry, not as classic", async () => {
+    const { root } = project({
+      "package.json": manifest({ packageManager: "yarn@4.6.0" }),
+    });
+    // The distinction decides `yarn dlx` vs `npx` for the printed commands.
+    expect((await detectPackageManagerIn(root)).agent).toBe("yarn@berry");
+  });
+
+  test("honours devEngines.packageManager", async () => {
+    const { root } = project({
+      "package.json": manifest({
+        devEngines: { packageManager: { name: "pnpm" } },
+      }),
+    });
+    expect((await detectPackageManagerIn(root)).agent).toBe("pnpm");
+  });
+
+  test("falls back to npm when nothing says anything", async () => {
+    const { root } = project({});
+    expect((await detectPackageManagerIn(root)).agent).toBe("npm");
   });
 });
 
@@ -46,7 +86,7 @@ describe("installCommand", () => {
   test("npm and bun install plainly", () => {
     expect(installCommand("npm")).toEqual({
       command: "npm",
-      args: ["install"],
+      args: ["i"],
       env: {},
     });
     expect(installCommand("bun")).toEqual({
@@ -58,18 +98,165 @@ describe("installCommand", () => {
 
   // `upgrade` has just made the lockfile stale on purpose, and both of these
   // freeze the lockfile by themselves in CI, where the install would then fail.
-  test("pnpm is told not to freeze the lockfile", () => {
-    expect(installCommand("pnpm").args).toEqual([
-      "install",
-      "--no-frozen-lockfile",
-    ]);
+  test.each(["pnpm", "pnpm@6", "pnpm-rush"] as const)(
+    "%s is told not to freeze the lockfile",
+    (agent) => {
+      expect(installCommand(agent).args).toContain("--no-frozen-lockfile");
+    },
+  );
+
+  test.each(["yarn", "yarn@berry"] as const)(
+    "%s gets the env var, because its flag differs between v1 and v2",
+    (agent) => {
+      expect(installCommand(agent).env).toEqual({
+        YARN_ENABLE_IMMUTABLE_INSTALLS: "false",
+      });
+    },
+  );
+});
+
+describe("pinnedRange", () => {
+  test("a full version is a range meaning exactly it", () => {
+    expect(pinnedRange("8.15.0")).toBe("8.15.0");
   });
 
-  test("yarn gets the env var, because its flag differs between v1 and v2", () => {
-    expect(installCommand("yarn")).toEqual({
-      command: "yarn",
-      args: ["install"],
-      env: { YARN_ENABLE_IMMUTABLE_INSTALLS: "false" },
+  test("a major-only pin is a range too", () => {
+    expect(pinnedRange("8")).toBe("8");
+  });
+
+  test('"berry" is a specifier, not a version', () => {
+    // `satisfies` would throw on it.
+    expect(pinnedRange("berry")).toBeUndefined();
+  });
+
+  test("an unparseable packageManager value is not a range", () => {
+    expect(pinnedRange("pnpm@not-a-version")).toBeUndefined();
+  });
+
+  test("no pin at all", () => {
+    expect(pinnedRange(undefined)).toBeUndefined();
+  });
+});
+
+describe("planInstall", () => {
+  const pinned: PackageManager = {
+    name: "pnpm",
+    agent: "pnpm",
+    version: "8.15.0",
+  };
+  const unpinned: PackageManager = { name: "pnpm", agent: "pnpm" };
+
+  const probeReturning =
+    (versions: Record<string, string | undefined>): Probe =>
+    (command) =>
+      versions[command];
+
+  test("no pin runs directly and never probes", () => {
+    let probed = false;
+    const plan = planInstall(unpinned, () => {
+      probed = true;
+      return undefined;
     });
+    expect(probed).toBe(false);
+    expect(plan.command).toBe("pnpm");
+    expect(plan.description).toBe("pnpm — pnpm i --no-frozen-lockfile");
+  });
+
+  test("a satisfied pin runs directly", () => {
+    const plan = planInstall(pinned, probeReturning({ pnpm: "8.15.0" }));
+    expect(plan.command).toBe("pnpm");
+    expect(plan.description).toContain("8.15.0");
+  });
+
+  test("a major-only pin is satisfied by any matching patch", () => {
+    // The reason this is `satisfies` and not a string compare: a string compare
+    // would send this perfectly fine setup through corepack.
+    const plan = planInstall(
+      { name: "pnpm", agent: "pnpm", version: "8" },
+      probeReturning({ pnpm: "8.15.0" }),
+    );
+    expect(plan.command).toBe("pnpm");
+  });
+
+  test("a mismatched pin goes through corepack", () => {
+    const plan = planInstall(
+      pinned,
+      probeReturning({ pnpm: "10.2.0", corepack: "0.29.0" }),
+    );
+    expect(plan.command).toBe("corepack");
+    expect(plan.args).toEqual(["pnpm", "i", "--no-frozen-lockfile"]);
+    // Required, not tidy: corepack prompts before a first download, and this
+    // runs unattended.
+    expect(plan.env.COREPACK_ENABLE_DOWNLOAD_PROMPT).toBe("0");
+  });
+
+  test("a missing binary goes through corepack too", () => {
+    const plan = planInstall(pinned, probeReturning({ corepack: "0.29.0" }));
+    expect(plan.command).toBe("corepack");
+  });
+
+  test("a mismatch with no corepack throws before installing anything", () => {
+    expect(() =>
+      planInstall(pinned, probeReturning({ pnpm: "10.2.0" })),
+    ).toThrow(/pins pnpm@8\.15\.0.*is 10\.2\.0.*corepack is not available/s);
+  });
+
+  test("the refusal names where to get the pinned manager", () => {
+    expect(() => planInstall(pinned, probeReturning({}))).toThrow(
+      /pnpm\.io\/installation/,
+    );
+  });
+
+  test("berry is not treated as a pin to check", () => {
+    let probed = false;
+    const plan = planInstall(
+      { name: "yarn", agent: "yarn@berry", version: "berry" },
+      () => {
+        probed = true;
+        return undefined;
+      },
+    );
+    expect(probed).toBe(false);
+    expect(plan.command).toBe("yarn");
+    expect(plan.env).toEqual({ YARN_ENABLE_IMMUTABLE_INSTALLS: "false" });
+  });
+});
+
+describe("resolveInvoke", () => {
+  test("pnpm gets dlx", async () => {
+    const { root } = project({ "pnpm-lock.yaml": "" });
+    expect(await resolveInvoke(root, "pkg@latest")).toBe("pnpm dlx pkg@latest");
+  });
+
+  test("yarn berry gets dlx, classic gets npx", async () => {
+    // Yarn Classic has no `dlx`; the library resolves it to npx, and that is
+    // correct rather than a fallback.
+    const berry = project({
+      "package.json": manifest({ packageManager: "yarn@4.6.0" }),
+    });
+    const classic = project({ "yarn.lock": "" });
+    expect(await resolveInvoke(berry.root, "pkg@latest")).toBe(
+      "yarn dlx pkg@latest",
+    );
+    expect(await resolveInvoke(classic.root, "pkg@latest")).toBe(
+      "npx pkg@latest",
+    );
+  });
+
+  test("bun gets bun x", async () => {
+    const { root } = project({ "bun.lock": "" });
+    expect(await resolveInvoke(root, "pkg@latest")).toBe("bun x pkg@latest");
+  });
+
+  test("npx when nothing is detected", async () => {
+    const { root } = project({});
+    expect(await resolveInvoke(root, "pkg@latest")).toBe("npx pkg@latest");
+  });
+
+  test("resolves from the workspace root for a nested package", async () => {
+    const { nested } = project({ "pnpm-lock.yaml": "" });
+    expect(await resolveInvoke(nested, "pkg@latest")).toBe(
+      "pnpm dlx pkg@latest",
+    );
   });
 });

--- a/packages/codemods/src/tests/list.test.ts
+++ b/packages/codemods/src/tests/list.test.ts
@@ -44,6 +44,26 @@ describe("renderList as text", () => {
     expect(text).toContain("flow-codemods@latest with-codemod");
   });
 
+  test("defaults the printed path to src", () => {
+    expect(text).toContain("flow-codemods@latest with-codemod src");
+  });
+
+  test("prints the path in use instead of a hardcoded src", () => {
+    // The whole point: a project whose sources are elsewhere used to be handed
+    // a command aimed at a directory it does not have, and the failing run then
+    // blamed the path.
+    const printed = renderList({
+      entries,
+      range: { from: "1.0.0", to: "2.0.0" },
+      json: false,
+      path: "packages/ui/lib",
+    });
+    expect(printed).toContain(
+      "flow-codemods@latest with-codemod packages/ui/lib",
+    );
+    expect(printed).not.toContain("with-codemod src");
+  });
+
   test("shows apply, which is what an agent acts on", () => {
     expect(text).toContain("apply by-hand");
   });

--- a/packages/codemods/src/tests/list.test.ts
+++ b/packages/codemods/src/tests/list.test.ts
@@ -48,6 +48,21 @@ describe("renderList as text", () => {
     expect(text).toContain("flow-codemods@latest with-codemod src");
   });
 
+  test("prints the invocation the reader's package manager wants", () => {
+    // `npx` is wrong for pnpm, Yarn Berry and Bun.
+    const printed = renderList({
+      entries,
+      range: { from: "1.0.0", to: "2.0.0" },
+      json: false,
+      invoke: "pnpm dlx @mittwald/flow-codemods@latest",
+      path: "app",
+    });
+    expect(printed).toContain(
+      "pnpm dlx @mittwald/flow-codemods@latest with-codemod app",
+    );
+    expect(printed).not.toContain("npx");
+  });
+
   test("prints the path in use instead of a hardcoded src", () => {
     // The whole point: a project whose sources are elsewhere used to be handed
     // a command aimed at a directory it does not have, and the failing run then

--- a/packages/codemods/src/tests/upgrade.test.ts
+++ b/packages/codemods/src/tests/upgrade.test.ts
@@ -25,6 +25,7 @@ const manifestOf = (dir: string): { dependencies: Record<string, string> } =>
   };
 
 interface Recorded {
+  /** The detected agent per install — `install` now returns its description. */
   installs: string[];
   codemods: string[];
   output: string[];
@@ -37,7 +38,10 @@ const deps = (
 ): UpgradeDeps => ({
   cwd,
   fetchVersions: async () => registry,
-  install: (manager) => recorded.installs.push(manager),
+  install: (manager) => {
+    recorded.installs.push(manager.agent);
+    return `${manager.agent} — stubbed`;
+  },
   // Async: `UpgradeDeps["runCodemod"]` is `typeof runCodemod`, and the real
   // implementation is async — a sync double would not be assignable to it.
   runCodemod: async ({ id }) => {
@@ -93,7 +97,10 @@ describe("runUpgrade", () => {
     await runUpgrade(
       parseArguments(["upgrade", "major", "-y"]),
       deps(cwd, recorded, {
-        install: () => order.push("install"),
+        install: () => {
+          order.push("install");
+          return "stubbed";
+        },
         runCodemod: async ({ id }) => {
           order.push(`codemod:${id}`);
           return {
@@ -271,9 +278,10 @@ describe("runUpgrade", () => {
       parseArguments(["upgrade", "major", "-y"]),
       deps(cwd, recorded, {
         install: (manager) => {
-          recorded.installs.push(manager);
+          recorded.installs.push(manager.agent);
           duringInstall =
             manifestOf(cwd).dependencies["@mittwald/flow-react-components"];
+          return `${manager.agent} — stubbed`;
         },
       }),
     );

--- a/packages/components/MIGRATION.md
+++ b/packages/components/MIGRATION.md
@@ -21,6 +21,11 @@ performed, and re-running a codemod is a no-op.
 It refuses to run on a dirty working tree (`--allow-dirty` overrides that) and
 rewrites files in place, so review the diff afterwards.
 
+Every command on this page is written with `npx`, because a generated file
+cannot know your package manager. Substitute the equivalent if yours differs:
+`pnpm dlx`, `yarn dlx` (Yarn Classic has no `dlx` — it uses `npx`), or `bun x`.
+The CLI's own output does detect it and prints the right form.
+
 ---
 
 <a id="use-design-tokens-build-metadata-removed"></a>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -394,6 +394,9 @@ importers:
       jscodeshift:
         specifier: ^17.3.0
         version: 17.4.0(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(supports-color@10.2.2)
+      package-manager-detector:
+        specifier: ^1.8.0
+        version: 1.8.0
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -5366,11 +5369,6 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  baseline-browser-mapping@2.11.6:
-    resolution: {integrity: sha512-69D/imtToCsIcAl8WBS2YaRwA4jO/j0HhU+hELqMEu9f54MoUtI6+XH5mrKU8rEFNEk/Ui1I2MK4/JkWacclGw==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
 
@@ -5512,9 +5510,6 @@ packages:
   camelcase@9.0.0:
     resolution: {integrity: sha512-TO9xmyXTZ9HUHI8M1OnvExxYB0eYVS/1e5s7IDMTAoIcwUd+aNcFODs6Xk83mobk0velyHFQgA1yIrvYc6wclw==}
     engines: {node: '>=20'}
-
-  caniuse-lite@1.0.30001806:
-    resolution: {integrity: sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==}
 
   caniuse-lite@1.0.30001809:
     resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
@@ -6180,9 +6175,6 @@ packages:
   es-iterator-helpers@1.4.0:
     resolution: {integrity: sha512-c/A0P0oxkACDc+cKWw8evLXK83oBKgn0qPOqCYT4x9uolpCIJAcYvJC9QYKNDRPsTeGyCrQ326jrvgZWdCdK5Q==}
     engines: {node: '>= 0.4'}
-
-  es-module-lexer@2.3.1:
-    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
 
   es-module-lexer@2.3.2:
     resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
@@ -8266,6 +8258,9 @@ packages:
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  package-manager-detector@1.8.0:
+    resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
 
   pacote@21.5.1:
     resolution: {integrity: sha512-KvcJ9iy3crysCsgqc4+PknH/w6jkrp8JN36mpZBPwNaDRwTfMZD37YzRazNstiZUOhuF5pno9f78n9mEJBavwg==}
@@ -14164,9 +14159,9 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.1
-      vitest: 4.1.11(@types/node@25.9.5)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(happy-dom@20.11.6)(msw@2.7.3(@types/node@25.9.5)(typescript@7.0.2))(vite@8.2.2(@types/node@25.9.5)(esbuild@0.28.2)(less@4.6.6)(sass-embedded@1.100.0)(sass@1.103.1)(stylus@0.62.0(supports-color@10.2.2))(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0))
+      vitest: 4.1.11(@types/node@25.9.5)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(happy-dom@20.11.6)(msw@2.7.3(@types/node@25.9.5)(@typescript/typescript6@6.0.2))(vite@8.2.2(@types/node@25.9.5)(esbuild@0.28.2)(less@4.6.6)(sass-embedded@1.100.0)(sass@1.103.1)(stylus@0.62.0(supports-color@10.2.2))(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0))
     optionalDependencies:
-      '@vitest/browser': 4.1.11(msw@2.7.3(@types/node@25.9.5)(typescript@7.0.2))(vite@8.2.2(@types/node@25.9.5)(esbuild@0.28.2)(less@4.6.6)(sass-embedded@1.100.0)(sass@1.103.1)(stylus@0.62.0(supports-color@10.2.2))(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.11)
+      '@vitest/browser': 4.1.11(msw@2.7.3(@types/node@25.9.5)(@typescript/typescript6@6.0.2))(vite@8.2.2(@types/node@25.9.5)(esbuild@0.28.2)(less@4.6.6)(sass-embedded@1.100.0)(sass@1.103.1)(stylus@0.62.0(supports-color@10.2.2))(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.11)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -14738,8 +14733,6 @@ snapshots:
 
   baseline-browser-mapping@2.11.18: {}
 
-  baseline-browser-mapping@2.11.6: {}
-
   before-after-hook@4.0.0: {}
 
   big.js@5.2.2: {}
@@ -14845,8 +14838,8 @@ snapshots:
 
   browserslist@4.28.7:
     dependencies:
-      baseline-browser-mapping: 2.11.6
-      caniuse-lite: 1.0.30001806
+      baseline-browser-mapping: 2.11.18
+      caniuse-lite: 1.0.30001809
       electron-to-chromium: 1.5.398
       node-releases: 2.0.51
       update-browserslist-db: 1.2.3(browserslist@4.28.7)
@@ -14922,8 +14915,6 @@ snapshots:
   camelcase@6.3.0: {}
 
   camelcase@9.0.0: {}
-
-  caniuse-lite@1.0.30001806: {}
 
   caniuse-lite@1.0.30001809: {}
 
@@ -15658,8 +15649,6 @@ snapshots:
       internal-slot: 1.1.0
       iterator.prototype: 1.1.5
       math-intrinsics: 1.1.0
-
-  es-module-lexer@2.3.1: {}
 
   es-module-lexer@2.3.2: {}
 
@@ -18371,6 +18360,8 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  package-manager-detector@1.8.0: {}
+
   pacote@21.5.1(supports-color@10.2.2):
     dependencies:
       '@gar/promise-retry': 1.0.3
@@ -20582,7 +20573,7 @@ snapshots:
       browserslist: 4.28.7
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.24.4
-      es-module-lexer: 2.3.1
+      es-module-lexer: 2.3.2
       eslint-scope: 5.1.1
       events: 3.3.0
       graceful-fs: 4.2.11


### PR DESCRIPTION
`upgrade` detected a package manager lockfiles-in-cwd-only, and the execution had
three further holes. All of it is live in the published `latest` — the upgrade
CLI shipped in 1.1.0 — so this targets `main` as a `fix`, not `next`.

Implements the approved design in
`2026-08-31-upgrade-cli-package-manager-design.md`.

## The install

**The reported failure:** a Yarn 4 workspace package. It has no lockfile of its
own, so detection fell through to npm and ran `npm install` on a `workspace:*`
manifest — `EUNSUPPORTEDPROTOCOL`, after the bump was already written.

`package-manager-detector@1.8.0` (MIT, **zero dependencies**) does detection and
command resolution; execution stays ours, because that is where the test seams,
the frozen-lockfile quirks and the Windows handling live. Its behaviour was
verified against the installed package rather than from memory: strategies apply
in order per directory walking up, `version` is the string `"berry"` for Yarn 2+,
and its `"install"` is the plain install for every agent (the frozen variants are
a separate command there).

- **Detection walks up**, and covers `packageManager`,
  `devEngines.packageManager` and the `node_modules` install metadata as well as
  lockfiles. npm stays the fallback.
- **A `packageManager` pin is honoured.** Binary satisfies it → run directly;
  mismatch or missing → corepack with `COREPACK_ENABLE_DOWNLOAD_PROMPT=0`; no
  corepack → refuse *before* installing, naming the pin, the found version and
  the install page. Checked rather than always-corepack because corepack ignores
  `PATH` and downloads into its own cache, which would hit offline CI. The check
  is `semver.satisfies`, not a string compare: `pnpm@8` yields the pin `"8"`
  against a reported `8.15.0`.
- **`shell` on win32.** Node has refused to spawn `.cmd` without a shell since
  2024, so every non-npm manager died with ENOENT there.
- **The log names agent, pin and the command actually run**, so a wrong detection
  is visible instead of silent. The failure message also names the detected
  manager and says the bump itself is already correct.

## The commands it prints

`resolveInvoke` gives every printed command the right prefix — `npx` (npm and
Yarn Classic, which has no `dlx`), `pnpm dlx`, `yarn dlx`, `bun x` — and
`displaySourcePath` gives it the right path. `list` used to hardcode `src`, so on
a project whose sources live elsewhere, pasting the printed line ran the codemod
against a directory that does not exist, and the failing run then blamed the path.

Verified end to end from a nested package of a pnpm workspace: `list` prints
`pnpm dlx @mittwald/flow-codemods@latest <id> .` — manager from the workspace
root, path from the package.

**Accepted trade:** the bare `list` now reads lockfiles and `package.json` up the
tree, so "reads no manifest" is gone from the README. It still hits no network. A
command a reader can paste beats that claim. `MIGRATION.md` stays on `npx` — it is
generated and cannot know the reader's manager — but now says so and names the
equivalents.

## Scope

The two catalogue findings from the same upgrade run that used to sit here have
moved to their own PR against `main`: mittwald/flow#3047. What is left is the
CLI work, which is why the base and the type changed.

## Verification

- 307 unit tests pass, `test:compile` clean, `pnpm lint` clean (0 errors,
  prettier green), `pnpm nx build codemods` regenerates nothing further
- `install.test.ts` covers the monorepo walk-up, the Yarn-4-as-berry distinction,
  `devEngines`, the pin tree with a stubbed probe (match → direct, mismatch →
  corepack, no corepack → throws naming both versions), and that `"berry"` is
  never treated as a pin
- Test-merged with mittwald/flow#3047: no conflict, and the merged tree
  regenerates `MIGRATION.md` byte-identically

## Follow-up

Two sentences in the versioning-page prompt (mittwald/flow#3038) become redundant
once this ships: the note that `list` hardcodes `src`, and the warning that
package-manager detection is directory-local. Both stay harmless — they are
defensive advice, not claims that become wrong — and they are correct for every
currently published version. Worth trimming in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
