### PR TITLE
fix(codemods): say that action -> onAction changes the callback type

### DIFF
--- a/packages/codemods/src/migrations.generated.ts
+++ b/packages/codemods/src/migrations.generated.ts
@@ -216,7 +216,8 @@ export const migrations: Omit<MigrationEntry, "body">[] = [
     kind: "migration",
     action: "codemod",
     remotePackage: true,
-    apply: "Rename the `action` prop on `Action` to `onAction`.",
+    apply:
+      "Rename the `action` prop on `Action` to `onAction`. Not only a rename: the new prop is typed `ActionFn` (`(...args: unknown[]) => unknown`), so a function *reference* that declares a parameter no longer type-checks and needs wrapping — `onAction={() => controller.close()}` rather than `onAction={controller.close}`. Check every site where you passed a reference rather than an inline arrow; the codemod renames the prop but cannot decide this one from the source.",
   },
   {
     id: "button-props-interfaces",

--- a/packages/codemods/src/migrations/action-prop-to-on-action/entry.md
+++ b/packages/codemods/src/migrations/action-prop-to-on-action/entry.md
@@ -4,7 +4,14 @@ title: "Action: `action` renamed to `onAction`"
 kind: migration
 action: codemod
 remotePackage: true
-apply: Rename the `action` prop on `Action` to `onAction`.
+apply: >-
+  Rename the `action` prop on `Action` to `onAction`. Not only a rename: the new
+  prop is typed `ActionFn` (`(...args: unknown[]) => unknown`), so a function
+  *reference* that declares a parameter no longer type-checks and needs wrapping
+  — `onAction={() => controller.close()}` rather than
+  `onAction={controller.close}`. Check every site where you passed a reference
+  rather than an inline arrow; the codemod renames the prop but cannot decide
+  this one from the source.
 ---
 
 `Action`'s `action` prop is now called `onAction`, which matches the naming of
@@ -22,4 +29,30 @@ prop. At runtime the old prop still works: `Action` maps it to `onAction` and
 logs a deprecation warning, and an explicit `onAction` wins. The fallback will
 be removed in a future major version.
 
-A codemod renames the prop on `Action`.
+#### The type changed too
+
+`onAction` is typed `ActionFn`, which is `(...args: unknown[]) => unknown`. A
+function that declares a parameter of any narrower type is not assignable to it,
+because the parameter would receive `unknown`:
+
+```
+Type '(options?: CloseOptions | undefined) => void' is not assignable to type 'ActionFn'.
+  Types of parameters 'options' and 'args' are incompatible.
+    Type 'unknown' is not assignable to type 'CloseOptions | undefined'.
+```
+
+Wrap the call instead of passing the reference:
+
+```diff
+- <Action onAction={controller.close}>
++ <Action onAction={() => controller.close()}>
+```
+
+Only function **references** are affected. An inline arrow
+(`onAction={() => …}`), a zero-parameter function, and anything already
+accepting `unknown` are all fine.
+
+A codemod renames the prop. It deliberately does not wrap: whether the
+referenced function declares a parameter cannot be decided from the source —
+that needs type information — and wrapping everything would silently drop the
+arguments `Action` passes to handlers that do accept them.

--- a/packages/components/MIGRATION.md
+++ b/packages/components/MIGRATION.md
@@ -774,9 +774,41 @@ prop. At runtime the old prop still works: `Action` maps it to `onAction` and
 logs a deprecation warning, and an explicit `onAction` wins. The fallback will
 be removed in a future major version.
 
-A codemod renames the prop on `Action`.
+#### The type changed too
 
-**Apply:** Rename the `action` prop on `Action` to `onAction`.
+`onAction` is typed `ActionFn`, which is `(...args: unknown[]) => unknown`. A
+function that declares a parameter of any narrower type is not assignable to it,
+because the parameter would receive `unknown`:
+
+```
+Type '(options?: CloseOptions | undefined) => void' is not assignable to type 'ActionFn'.
+  Types of parameters 'options' and 'args' are incompatible.
+    Type 'unknown' is not assignable to type 'CloseOptions | undefined'.
+```
+
+Wrap the call instead of passing the reference:
+
+```diff
+- <Action onAction={controller.close}>
++ <Action onAction={() => controller.close()}>
+```
+
+Only function **references** are affected. An inline arrow
+(`onAction={() => …}`), a zero-parameter function, and anything already
+accepting `unknown` are all fine.
+
+A codemod renames the prop. It deliberately does not wrap: whether the
+referenced function declares a parameter cannot be decided from the source —
+that needs type information — and wrapping everything would silently drop the
+arguments `Action` passes to handlers that do accept them.
+
+**Apply:** Rename the `action` prop on `Action` to `onAction`. Not only a
+rename: the new prop is typed `ActionFn` (`(...args: unknown[]) => unknown`), so
+a function _reference_ that declares a parameter no longer type-checks and needs
+wrapping — `onAction={() => controller.close()}` rather than
+`onAction={controller.close}`. Check every site where you passed a reference
+rather than an inline arrow; the codemod renames the prop but cannot decide this
+one from the source.
 
 ```shell
 npx @mittwald/flow-codemods@latest action-prop-to-on-action src


### PR DESCRIPTION
`action-prop-to-on-action`'s `apply` reads, in full: *"Rename the `action` prop on
`Action` to `onAction`."* That describes a rename. It is also a type change, and
the codemod leaves broken code behind because of it.

Reported from a real unattended upgrade run as **the only break its typecheck
surfaced**, with no catalogue entry covering it. Reproduced exactly:

```
Type '(options?: CloseOptions | undefined) => void' is not assignable to type 'ActionFn'.
  Types of parameters 'options' and 'args' are incompatible.
    Type 'unknown' is not assignable to type 'CloseOptions | undefined'.
```

`onAction` is typed `ActionFn` — `(...args: unknown[]) => unknown` — so a function
*reference* declaring a narrower parameter is not assignable, and the codemod
renames the prop right past it:

```diff
- <Action action={controller.close}>        // compiles
+ <Action onAction={controller.close}>      // TS2322
```

## What changed

`apply` now names the type change and the fix (wrap the call:
`onAction={() => controller.close()}`), and says the codemod cannot decide it. The
body carries the error text and scopes the blast radius — only **references** are
affected; an inline arrow, a zero-parameter function, and anything already
accepting `unknown` are all fine. Each of those four cases was checked
individually against `tsc`, not assumed.

## Why the codemod still only renames

The report suggests the codemod could wrap a passed identifier or member
expression, since it has the callsite in hand. It cannot do that soundly: whether
the referenced function declares a parameter is **not decidable from the source**
— it needs type information — and wrapping every reference would silently drop the
arguments `Action` passes to handlers that legitimately accept them. So the
constraint is documented in the entry instead, with the exact error to search for.

## Verification

- 252 unit tests pass, `test:compile` clean, `pnpm lint` exit 0,
  `prettier --check` clean repo-wide
- `MIGRATION.md` and `migrations.generated.ts` regenerated and committed

Split out of mittwald/flow#3040 on request. The two share no file, and only that
one is a release blocker — this is a guidance correction, that one is "no codemod
runs in any consumer install".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
