### PR TITLE
fix(Tabs): forward aria-label to the tab list

### DIFF
--- a/apps/docs/src/content/components/structure/tabs/examples/aria-label.tsx
+++ b/apps/docs/src/content/components/structure/tabs/examples/aria-label.tsx
@@ -1,0 +1,16 @@
+import {
+  Tab,
+  Tabs,
+  TabTitle,
+} from "@mittwald/flow-react-components";
+
+<Tabs aria-label="Verbindungsart">
+  <Tab>
+    <TabTitle>Mit App verbinden</TabTitle>
+    App Content
+  </Tab>
+  <Tab>
+    <TabTitle>Mit Container verbinden</TabTitle>
+    Container Content
+  </Tab>
+</Tabs>;

--- a/apps/docs/src/content/components/structure/tabs/index.mdx
+++ b/apps/docs/src/content/components/structure/tabs/index.mdx
@@ -62,6 +62,29 @@ aktiv sein, legst du das über `defaultSelectedKey` fest.
 
 ---
 
+# Beschriftung
+
+Tabs haben keinen `Label`-Slot – die Tab-Leiste beschriftet sich über ihre
+Tab-Titel. Benennt die Überschrift der umgebenden `Section` die Gruppe bereits,
+reicht das. Wenn nicht, gib der Tab-Leiste über `aria-label` einen eigenen Namen
+– oder verweise mit `aria-labelledby` auf eine vorhandene Überschrift, damit der
+Name nur an einer Stelle gepflegt wird.
+
+```tsx
+<Tabs aria-label="Verbindungsart">
+  <Tab>
+    <TabTitle>Mit App verbinden</TabTitle>
+    App Content
+  </Tab>
+  <Tab>
+    <TabTitle>Mit Container verbinden</TabTitle>
+    Container Content
+  </Tab>
+</Tabs>
+```
+
+---
+
 # Reihenfolge der Tabs
 
 Werden innerhalb eines Tabs Inhalte nachgeladen, kann sich durch das Rerendering

--- a/apps/docs/src/content/components/structure/tabs/index.mdx
+++ b/apps/docs/src/content/components/structure/tabs/index.mdx
@@ -70,18 +70,7 @@ reicht das. Wenn nicht, gib der Tab-Leiste über `aria-label` einen eigenen Name
 – oder verweise mit `aria-labelledby` auf eine vorhandene Überschrift, damit der
 Name nur an einer Stelle gepflegt wird.
 
-```tsx
-<Tabs aria-label="Verbindungsart">
-  <Tab>
-    <TabTitle>Mit App verbinden</TabTitle>
-    App Content
-  </Tab>
-  <Tab>
-    <TabTitle>Mit Container verbinden</TabTitle>
-    Container Content
-  </Tab>
-</Tabs>
-```
+<LiveCodeEditor example="aria-label" editorCollapsed />
 
 ---
 

--- a/packages/components/src/components/Tabs/Tabs.browser.test.tsx
+++ b/packages/components/src/components/Tabs/Tabs.browser.test.tsx
@@ -1,0 +1,54 @@
+import { render } from "vitest-browser-react";
+import { page } from "vitest/browser";
+import { Tab, Tabs, TabTitle } from "@/components/Tabs";
+import { Heading } from "@/components/Heading";
+import { Section } from "@/components/Section";
+import { Text } from "@/components/Text";
+import type { ReactNode } from "react";
+
+const renderTabs = (props: {
+  "aria-label"?: string;
+  "aria-labelledby"?: string;
+  before?: ReactNode;
+}) =>
+  render(
+    <>
+      {props.before}
+      <Tabs
+        aria-label={props["aria-label"]}
+        aria-labelledby={props["aria-labelledby"]}
+      >
+        <Tab id="general">
+          <TabTitle>Comms</TabTitle>
+          <Section>
+            <Text>Comms</Text>
+          </Section>
+        </Tab>
+        <Tab id="storage">
+          <TabTitle>Cargo hold</TabTitle>
+          <Section>
+            <Text>Cargo hold</Text>
+          </Section>
+        </Tab>
+      </Tabs>
+    </>,
+  );
+
+test("names the tab list with `aria-label`", async () => {
+  renderTabs({ "aria-label": "Server settings" });
+
+  await expect
+    .element(page.getByRole("tablist", { name: "Server settings" }))
+    .toBeInTheDocument();
+});
+
+test("names the tab list with `aria-labelledby`", async () => {
+  renderTabs({
+    "aria-labelledby": "tabs-heading",
+    before: <Heading id="tabs-heading">Server settings</Heading>,
+  });
+
+  await expect
+    .element(page.getByRole("tablist", { name: "Server settings" }))
+    .toBeInTheDocument();
+});

--- a/packages/components/src/components/Tabs/Tabs.tsx
+++ b/packages/components/src/components/Tabs/Tabs.tsx
@@ -16,6 +16,14 @@ export interface TabsProps
     PropsWithChildren,
     FlowComponentProps {
   /**
+   * An accessible name for the tab list. `Tabs` has no `Label` slot, so this is
+   * how the group is named when the surrounding heading does not already do
+   * it.
+   */
+  "aria-label"?: string;
+  /** The id of an element that names the tab list. */
+  "aria-labelledby"?: string;
+  /**
    * The view rendered when the selected tab does not exist. Defaults to a
    * built-in IllustratedMessage.
    */
@@ -33,6 +41,8 @@ export const Tabs = flowComponent("Tabs", (props) => {
     ref,
     onSelectionChange,
     tabNotFoundView,
+    "aria-label": ariaLabel,
+    "aria-labelledby": ariaLabelledby,
     ...rest
   } = props;
 
@@ -63,6 +73,8 @@ export const Tabs = flowComponent("Tabs", (props) => {
         ref={ref}
       >
         <TabList
+          aria-label={ariaLabel}
+          aria-labelledby={ariaLabelledby}
           selection={selectedKey}
           onContextMenuSelectionChange={(key) => {
             setSelectedKeyState(key);

--- a/packages/components/src/components/Tabs/components/TabList/TabList.tsx
+++ b/packages/components/src/components/Tabs/components/TabList/TabList.tsx
@@ -16,10 +16,18 @@ interface Props {
   selection: Aria.Key | undefined;
   onContextMenuSelectionChange: (key: Aria.Key) => void;
   disabledKeys?: Iterable<Aria.Key>;
+  "aria-label"?: string;
+  "aria-labelledby"?: string;
 }
 
 export const TabList: FC<Props> = (props) => {
-  const { selection, disabledKeys, onContextMenuSelectionChange } = props;
+  const {
+    selection,
+    disabledKeys,
+    onContextMenuSelectionChange,
+    "aria-label": ariaLabel,
+    "aria-labelledby": ariaLabelledby,
+  } = props;
 
   const titleCollapsedElementId = useId();
   const overflowObserver = useObserveOverflow();
@@ -37,7 +45,12 @@ export const TabList: FC<Props> = (props) => {
   };
 
   const regularTabTitles = (
-    <Aria.TabList className={styles.titles} ref={setTitlesRef}>
+    <Aria.TabList
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledby}
+      className={styles.titles}
+      ref={setTitlesRef}
+    >
       <UiComponentTunnelExit id="Titles" component="Tabs" />
     </Aria.TabList>
   );

--- a/packages/components/src/components/Tabs/stories/Default.stories.tsx
+++ b/packages/components/src/components/Tabs/stories/Default.stories.tsx
@@ -20,6 +20,9 @@ const meta: Meta<typeof Tabs> = {
   parameters: {
     controls: { disable: true },
   },
+  args: {
+    "aria-label": "Mailbox settings",
+  },
   render: (props) => {
     return (
       <Tabs {...props} disabledKeys={["spam"]}>


### PR DESCRIPTION
`Tabs` accepted `aria-label` and dropped it on an element that has no role. The
tab list — the thing that needs a name — never saw it.

`TabsProps extends Omit<Aria.TabsProps, "children">`, and `AriaTabListProps`
carries `AriaLabelingProps`, so the prop type-checked and even showed up in the
generated properties table. `Aria.Tabs` runs `filterDOMProps(props, {global:
true})` and puts the result on its wrapper `<div>`; `useTabList` reads labelling
only from `Aria.TabList`'s own props. Result: `<Tabs aria-label="…">` rendered
the attribute on a role-less div and left `role="tablist"` unnamed.

Both `aria-label` and `aria-labelledby` now travel to `TabList` and onto
`Aria.TabList`. `aria-describedby` and `aria-details` stay on the wrapper, where
react-aria puts them — they describe, they don't name.

## Why it matters here

`Tabs` has no `Label` slot; the tab list names itself through its tab titles. So
when the surrounding heading doesn't already name the group, `aria-label` is the
only way — and it was the one that didn't work. This is the gap a
`SegmentedControl` → `Tabs` migration walks into: the `<Label>` of a
`SegmentedControl` has nowhere to go (see mittwald/flow#3042).

## What's in the change

- `Tabs.tsx` / `TabList.tsx` — forward both labelling props to `Aria.TabList`
- `TabsProps` — both declared explicitly with JSDoc. They were already listed in
  the properties table with react-aria's generic wording; now the table says
  what they name and that there is no `Label` slot
- `Tabs.browser.test.tsx` — new. `aria-label` and `aria-labelledby` each name
  the `tablist`. Verified red before the fix (4/4 failing across webkit and
  firefox), green after
- Docs: a **Beschriftung** section on the Tabs page, and `aria-label` in the
  Storybook meta args so every story ships a named tab list

## Verification

- `test:browser` components (webkit) — Tabs 4/4 pass; the same two tests fail
  4/4 with the forwarding removed
- `test:compile` components clean, `test:unit` components 253/253, `pnpm lint`
  exit 0
- `build:remote-components` produced no diff — `aria-label` and
  `aria-labelledby` are already remote properties of `flr-tabs`, so the remote
  path works without a protocol change
- No usage in this repo passed `aria-label` to `Tabs`, so nothing loses the
  attribute on the wrapper. No visual output changes; no visual scenario passes
  the prop, so no cross-version divergence

## Follow-up

Once this and mittwald/flow#3042 are both in, the `segmented-control-deprecated`
entry can name a third option for the group `Label` — today it says the label
moves to the surrounding `Heading` or goes away. Left out here to keep the two
PRs conflict-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
