### PR TITLE
fix(Heading): space tunneled content without :has()

### DIFF
--- a/packages/components/src/components/Heading/Heading.module.scss
+++ b/packages/components/src/components/Heading/Heading.module.scss
@@ -27,15 +27,12 @@
       display: inline-block;
       margin-inline-end: var(--heading--icon-to-text-spacing);
     }
-
-    &:not(:last-child):has(+ .headingContent:not(:empty)) {
-      margin-inline-end: var(--heading--icon-to-text-spacing);
-    }
   }
 
   .headingContent {
     vertical-align: bottom;
     display: inline-flex;
+    margin-inline-start: var(--heading--icon-to-text-spacing);
     min-height: var(--heading-line-height);
     align-items: center;
     gap: var(--heading--icon-to-text-spacing);


### PR DESCRIPTION
Badges reach a heading through the tunnel, so `.headingContent` fills after the heading was styled. Safari does not re-evaluate `.headingText:has(+ .headingContent:not(:empty))` on that change, and the badge stays glued to the text until a click forces a style recalc.

The spacing now sits on `.headingContent` itself, which is `display: none` while empty and therefore has no box to space. Rendering is unchanged — the visual baselines match without an update.

Verified in Safari with a minimal repro of both rules; the browser test covers the badge arriving after the initial render, which is the case that breaks.

fixes #3044