### PR TITLE
docs(components): give the stories and examples accessible names (part of #3015)

### DIFF
--- a/apps/docs/src/content/components/content/avatar/examples/status-example.tsx
+++ b/apps/docs/src/content/components/content/avatar/examples/status-example.tsx
@@ -29,7 +29,7 @@ export default () => {
           Avatar verwendet werden.
         </Text>
 
-        <NotificationList.List aria-label="Benachrichtigungen">
+        <NotificationList.List>
           <NotificationList.StaticData
             data={[
               {
@@ -64,7 +64,7 @@ export default () => {
           werden, der Status Avatar kann daher nicht
           verwendet werden.
         </Text>
-        <EmailList.List aria-label="E-Mail-Adressen">
+        <EmailList.List>
           <EmailList.StaticData
             data={[
               {

--- a/apps/docs/src/content/components/content/avatar/examples/status-example.tsx
+++ b/apps/docs/src/content/components/content/avatar/examples/status-example.tsx
@@ -29,7 +29,7 @@ export default () => {
           Avatar verwendet werden.
         </Text>
 
-        <NotificationList.List>
+        <NotificationList.List aria-label="Benachrichtigungen">
           <NotificationList.StaticData
             data={[
               {
@@ -64,7 +64,7 @@ export default () => {
           werden, der Status Avatar kann daher nicht
           verwendet werden.
         </Text>
-        <EmailList.List>
+        <EmailList.List aria-label="E-Mail-Adressen">
           <EmailList.StaticData
             data={[
               {

--- a/apps/docs/src/content/components/data-visualisation/donut-chart/index.mdx
+++ b/apps/docs/src/content/components/data-visualisation/donut-chart/index.mdx
@@ -9,6 +9,8 @@ description: Das DonutChart stellt Verteilungen und Anteile als Ring dar.
 
 # Best Practices
 
+- Gib dem DonutChart über `aria-label` einen zugänglichen Namen. Sonst liest ein
+  Screenreader den Wert vor, ohne zu sagen, worauf er sich bezieht.
 - Kombiniere die Status-Farben gezielt, um Zustände hervorzuheben. Wechsle etwa
   bei hoher Speicherplatzauslastung auf Warning oder Danger.
 - Mach jede Segmentfarbe eindeutig unterscheidbar. Nutze dafür die

--- a/apps/docs/src/content/components/status/progress-bar/examples/status.tsx
+++ b/apps/docs/src/content/components/status/progress-bar/examples/status.tsx
@@ -1,16 +1,19 @@
-import { ProgressBar } from "@mittwald/flow-react-components";
+import {
+  Label,
+  ProgressBar,
+} from "@mittwald/flow-react-components";
 
 <>
   <ProgressBar value={100} status="success">
-    Success
+    <Label>Success</Label>
   </ProgressBar>
   <ProgressBar value={50} status="info">
-    Info
+    <Label>Info</Label>
   </ProgressBar>
   <ProgressBar value={70} status="warning">
-    Warning
+    <Label>Warning</Label>
   </ProgressBar>
   <ProgressBar value={90} status="danger">
-    Danger
+    <Label>Danger</Label>
   </ProgressBar>
 </>;

--- a/apps/docs/src/content/components/structure/list/index.mdx
+++ b/apps/docs/src/content/components/structure/list/index.mdx
@@ -26,6 +26,8 @@ description:
   erhält sie ein `aria-label`; hat sie eine eigene
   [Heading](/components/content/heading), wird diese über `aria-labelledby`
   zugeordnet.
+- Gib jedem Item über `textValue` seinen Text mit. Erst damit findet der User
+  ein Item über die Tastatur, indem er dessen Anfang tippt.
 
 ---
 

--- a/apps/docs/src/content/patterns/patterns/anlegeprozess/examples/app-illustrated-message.tsx
+++ b/apps/docs/src/content/patterns/patterns/anlegeprozess/examples/app-illustrated-message.tsx
@@ -37,7 +37,10 @@ export default () => {
             <Modal offCanvas>
               <Heading>App anlegen</Heading>
               <Content>
-                <AppList.List defaultViewMode="tiles">
+                <AppList.List
+                  aria-label="Apps"
+                  defaultViewMode="tiles"
+                >
                   <AppList.Search />
                   <AppList.StaticData
                     data={[
@@ -46,7 +49,11 @@ export default () => {
                       { id: "1", name: "WordPress" },
                     ]}
                   />
-                  <AppList.Item showTiles showList={false}>
+                  <AppList.Item
+                    showTiles
+                    showList={false}
+                    textValue={(app) => app.name}
+                  >
                     {(app) => (
                       <ListItemView>
                         <Avatar>

--- a/apps/docs/src/content/patterns/patterns/anlegeprozess/examples/create-container.tsx
+++ b/apps/docs/src/content/patterns/patterns/anlegeprozess/examples/create-container.tsx
@@ -80,6 +80,7 @@ export default () => {
               auf die Dateien zuzugreifen.
             </Text>
             <VolumeList.List
+              aria-label="Volumes"
               hidePagination
               getItemId={(volume) => volume.id}
             >
@@ -98,7 +99,9 @@ export default () => {
                   },
                 ]}
               />
-              <VolumeList.Item>
+              <VolumeList.Item
+                textValue={(volume) => volume.name}
+              >
                 {(volume) => (
                   <ListItemView>
                     <Heading>{volume.name}</Heading>

--- a/packages/components/src/components/DonutChart/stories/Default.stories.tsx
+++ b/packages/components/src/components/DonutChart/stories/Default.stories.tsx
@@ -22,7 +22,7 @@ const meta: Meta<typeof DonutChart> = {
   parameters: {
     controls: { exclude: ["segments"] },
   },
-  render: (props) => <DonutChart value={30} {...props} />,
+  render: (props) => <DonutChart aria-label="Storage" value={30} {...props} />,
 };
 
 export default meta;
@@ -73,7 +73,6 @@ export const WithSegments: Story = {
       exclude: ["segments", "status"],
     },
   },
-  render: (props) => <DonutChart aria-label="storage" {...props} />,
 };
 
 export const WithTextValue: Story = {
@@ -84,7 +83,7 @@ export const WithTextValue: Story = {
     const value = 300;
 
     return (
-      <DonutChart {...props} value={value} maxValue={600}>
+      <DonutChart aria-label="Storage" {...props} value={value} maxValue={600}>
         <strong>{value}</strong>
         <small>GB</small>
       </DonutChart>

--- a/packages/components/src/components/List/stories/Default.stories.tsx
+++ b/packages/components/src/components/List/stories/Default.stories.tsx
@@ -213,7 +213,7 @@ export const WithSummary: Story = {
               { id: "RG100002", date: "3.10.2024", amount: "4,00 €" },
             ]}
           />
-          <InvoiceList.Item>
+          <InvoiceList.Item textValue={(invoice) => invoice.id}>
             {(invoice) => (
               <ListItemView>
                 <Heading level={3}>{invoice.id}</Heading>
@@ -263,7 +263,7 @@ export const InfiniteScroll: Story = {
           <InvoiceList.LoaderAsync manualPagination>
             {loadInvoices}
           </InvoiceList.LoaderAsync>
-          <InvoiceList.Item>
+          <InvoiceList.Item textValue={(invoice) => invoice.id}>
             {(invoice) => (
               <ListItemView>
                 <Heading level={3}>{invoice.id}</Heading>
@@ -290,7 +290,10 @@ export const WithAccordion: Story = {
         <List.StaticData
           data={[{ id: "Tatooine" }, { id: "Hoth" }, { id: "Endor" }]}
         />
-        <List.Item defaultExpanded={(invoice) => invoice.id === "Tatooine"}>
+        <List.Item
+          textValue={(invoice) => invoice.id}
+          defaultExpanded={(invoice) => invoice.id === "Tatooine"}
+        >
           {(invoice) => (
             <ListItemView>
               <Heading>{invoice.id}</Heading>

--- a/packages/components/src/components/List/stories/EdgeCases.stories.tsx
+++ b/packages/components/src/components/List/stories/EdgeCases.stories.tsx
@@ -165,7 +165,7 @@ export const CustomSorting = () => {
         customSortingFn={domainTypeSortingFn}
       />
 
-      <DomainList.Item>
+      <DomainList.Item textValue={(domain) => domain.hostname}>
         {(domain) => (
           <DomainList.ItemView>
             <Avatar color={domain.type === "Domain" ? "blue" : "teal"}>

--- a/packages/components/src/components/List/stories/ListItem.stories.tsx
+++ b/packages/components/src/components/List/stories/ListItem.stories.tsx
@@ -30,7 +30,7 @@ export const WithContent: Story = {
     const List = typedList<{ mail: string }>();
 
     return (
-      <List.List>
+      <List.List aria-label="Mail addresses">
         <List.StaticData data={[{ mail: "luke.skywalker@rebellion.org" }]} />
         <List.Item showTiles textValue={(mail) => mail.mail}>
           {(mail) => (
@@ -63,7 +63,7 @@ export const WithActionGroup: Story = {
     const List = typedList<{ name: string }>();
 
     return (
-      <List.List>
+      <List.List aria-label="Users">
         <List.StaticData data={[{ name: "Han Solo" }]} />
         <List.Item showTiles textValue={(user) => user.name}>
           {(user) => (
@@ -96,7 +96,7 @@ export const WithCustomTileMaxWidth: Story = {
     const List = typedList<{ name: string }>();
 
     return (
-      <List.List defaultViewMode="tiles">
+      <List.List aria-label="Users" defaultViewMode="tiles">
         <List.StaticData data={[{ name: "Leia Organa" }]} />
         <List.Item tileMaxWidth={100} showTiles textValue={(user) => user.name}>
           {(user) => (
@@ -120,7 +120,7 @@ export const WithCheckbox: Story = {
     const List = typedList<{ mail: string }>();
 
     return (
-      <List.List>
+      <List.List aria-label="Mail addresses">
         <List.StaticData data={[{ mail: "leia.organa@rebellion.org" }]} />
         <List.Table>
           <List.TableHeader>
@@ -162,7 +162,7 @@ export const WithColumnLayout: Story = {
     const List = typedList<{ mail: string }>();
 
     return (
-      <List.List>
+      <List.List aria-label="Mail addresses">
         <List.StaticData
           data={[
             { mail: "han.solo@rebellion.org" },

--- a/packages/components/src/components/Modal/stories/Default.stories.tsx
+++ b/packages/components/src/components/Modal/stories/Default.stories.tsx
@@ -20,7 +20,7 @@ import { dummyText } from "@/lib/dev/dummyText";
 import { RadioButton, RadioGroup } from "@/components/RadioGroup";
 import { DatePicker } from "@/components/DatePicker";
 import { FieldDescription } from "@/components/FieldDescription";
-import { useState } from "react";
+import { useId, useState } from "react";
 import { useTimeout } from "usehooks-ts";
 import { useModalController } from "@/lib/controller";
 
@@ -279,73 +279,77 @@ export const WithSuspense: Story = {
 };
 
 export const LongContent: Story = {
-  render: (props) => (
-    <Modal {...props} isOpen>
-      <Heading>{dummyText.short}</Heading>
-      <Content>
-        <Section>
-          <Heading>Description</Heading>
-          <Text>
-            An SFTP user allows you to connect to your project, for example to
-            upload files.
-          </Text>
-          <ColumnLayout m={[1, 1]}>
+  render: (props) => {
+    const permissionsHeadingId = useId();
+
+    return (
+      <Modal {...props} isOpen>
+        <Heading>{dummyText.short}</Heading>
+        <Content>
+          <Section>
+            <Heading>Description</Heading>
+            <Text>
+              An SFTP user allows you to connect to your project, for example to
+              upload files.
+            </Text>
+            <ColumnLayout m={[1, 1]}>
+              <TextField isRequired>
+                <Label>Name</Label>
+              </TextField>
+              <DatePicker>
+                <Label>Expiration Date</Label>
+                <FieldDescription>
+                  After this date, the SFTP user will be deleted.
+                </FieldDescription>
+              </DatePicker>
+            </ColumnLayout>
+
+            <Heading id={permissionsHeadingId}>Permissions</Heading>
+            <Text>Select the permissions the SFTP user should have.</Text>
+            <RadioGroup
+              s={[1, 1]}
+              defaultValue="read&write"
+              aria-labelledby={permissionsHeadingId}
+            >
+              <RadioButton value="write">
+                <Text>Read Access</Text>
+                <Content>The SFTP user can view and download files.</Content>
+              </RadioButton>
+              <RadioButton value="read&write">
+                <Text>Read and Write Access</Text>
+                <Content>
+                  The SFTP user can view, edit, upload, and download files.
+                </Content>
+              </RadioButton>
+            </RadioGroup>
+
+            <Heading>Directory Selection</Heading>
+            <Text>
+              Specify the directory the SFTP user should have access to.
+            </Text>
             <TextField isRequired>
-              <Label>Name</Label>
+              <Label>Path</Label>
             </TextField>
-            <DatePicker>
-              <Label>Expiration Date</Label>
-              <FieldDescription>
-                After this date, the SFTP user will be deleted.
-              </FieldDescription>
-            </DatePicker>
-          </ColumnLayout>
 
-          <Heading>Permissions</Heading>
-          <Text>Select the permissions the SFTP user should have.</Text>
-          <RadioGroup
-            s={[1, 1]}
-            defaultValue="read&write"
-            aria-label="Permissions"
-          >
-            <RadioButton value="write">
-              <Text>Read Access</Text>
-              <Content>The SFTP user can view and download files.</Content>
-            </RadioButton>
-            <RadioButton value="read&write">
-              <Text>Read and Write Access</Text>
-              <Content>
-                The SFTP user can view, edit, upload, and download files.
-              </Content>
-            </RadioButton>
-          </RadioGroup>
-
-          <Heading>Directory Selection</Heading>
-          <Text>
-            Specify the directory the SFTP user should have access to.
-          </Text>
-          <TextField isRequired>
-            <Label>Path</Label>
-          </TextField>
-
-          <Heading>{dummyText.short}</Heading>
-          <Text>{dummyText.long}</Text>
-          <Heading>{dummyText.short}</Heading>
-          <Text>{dummyText.long}</Text>
-          <Heading>{dummyText.short}</Heading>
-          <Text>{dummyText.long}</Text>
-          <Heading>{dummyText.short}</Heading>
-          <Text>{dummyText.long}</Text>
-        </Section>
-      </Content>
-      <ActionGroup>
-        <Action closeModal>
-          <Button color="success">Create SFTP user</Button>
-          <Button variant="soft" color="secondary">
-            Abort
-          </Button>
-        </Action>
-      </ActionGroup>
-    </Modal>
-  ),
+            <Heading>{dummyText.short}</Heading>
+            <Text>{dummyText.long}</Text>
+            <Heading>{dummyText.short}</Heading>
+            <Text>{dummyText.long}</Text>
+            <Heading>{dummyText.short}</Heading>
+            <Text>{dummyText.long}</Text>
+            <Heading>{dummyText.short}</Heading>
+            <Text>{dummyText.long}</Text>
+          </Section>
+        </Content>
+        <ActionGroup>
+          <Action closeModal>
+            <Button color="success">Create SFTP user</Button>
+            <Button variant="soft" color="secondary">
+              Abort
+            </Button>
+          </Action>
+        </ActionGroup>
+      </Modal>
+    );
+  },
 };

--- a/packages/components/src/components/Modal/stories/Default.stories.tsx
+++ b/packages/components/src/components/Modal/stories/Default.stories.tsx
@@ -303,7 +303,11 @@ export const LongContent: Story = {
 
           <Heading>Permissions</Heading>
           <Text>Select the permissions the SFTP user should have.</Text>
-          <RadioGroup s={[1, 1]} defaultValue="read&write">
+          <RadioGroup
+            s={[1, 1]}
+            defaultValue="read&write"
+            aria-label="Permissions"
+          >
             <RadioButton value="write">
               <Text>Read Access</Text>
               <Content>The SFTP user can view and download files.</Content>

--- a/packages/components/src/components/Select/stories/Default.stories.tsx
+++ b/packages/components/src/components/Select/stories/Default.stories.tsx
@@ -108,6 +108,7 @@ export const WithNumbers: Story = {
 export const WithCountryOptions: Story = {
   render: (props) => (
     <Select {...props}>
+      <Label>Country</Label>
       <CountryOptions />
     </Select>
   ),
@@ -116,6 +117,7 @@ export const WithCountryOptions: Story = {
 export const WithCountryOptionsAndCustomSort: Story = {
   render: (props) => (
     <Select {...props}>
+      <Label>Country</Label>
       <CountryOptions sortBy={sortByDachFirst} />
     </Select>
   ),


### PR DESCRIPTION
Part of #3015. Split out of #3022, which now carries only the `react-tunnel` fix. Everything here is a caller passing a name that was always available — no component code, no locale file, no generated artifact.

| Warning | Reality |
| --- | --- |
| `DonutChart`, `Select` | `aria-label` is already public API (inherited from `Aria.ProgressBarProps`, already in the generated remote element). Three stories just never passed it |
| `Modal --long-content` | Came from the `RadioGroup` inside the story, not from `Modal` |
| `ProgressBar` docs | The `status` example passed its text as raw children, which renders but never becomes a label. Wrapped in `<Label>` |
| `GridListInner` needs a name | `List` already supports `aria-label`/`aria-labelledby`; five ListItem stories omitted it |
| `textValue` required | `List.Item` already has the prop; four stories omitted it |

`aria-hidden` on `DonutChart`'s inner `ProgressBar` was considered and rejected — it would hide `aria-valuenow`/`aria-valuetext`, which is the chart's actual content.

`textValue` was deliberately **not** made required or auto-derived: required would break the public API, and deriving text from an arbitrary `renderFn` is not reliable. The react-aria warning stays as the signal, now documented on the List page.

A code scan turned up the same two defects in four docs examples the issue had not listed (`content/avatar`, two `patterns/anlegeprozess` examples); those are fixed too.

## No new UI text

No locale file was touched — every accessible name comes from a caller. The only new prose is two German best-practice bullets on the DonutChart and List docs pages.

## Verified

- All story ids from the issue that this PR covers report 0 warnings (Playwright against Storybook, `console.warn` wrapped with a stack trace to name the react-aria frame).
- eslint + prettier clean on every changed file, rebased onto current `main` (1.1.4).

The three `Slider` stories from the issue are fixed by #3022, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
