### PR TITLE
docs(IllustratedMessage): broaden the component description

### DIFF
--- a/apps/docs/src/content/components/content/illustrated-message/index.mdx
+++ b/apps/docs/src/content/components/content/illustrated-message/index.mdx
@@ -1,8 +1,8 @@
 ---
 component: IllustratedMessage
 description:
-  Die IllustratedMessage dient als Platzhalter, wenn der eigentliche Inhalt
-  nicht angezeigt werden kann.
+  Die IllustratedMessage gibt großflächigen Bereichen mit wenig Inhalt eine
+  visuelle Struktur.
 ---
 
 <LiveCodeEditor />


### PR DESCRIPTION
## What

Updates the short description of the `IllustratedMessage` component.

**Before:**
> Die IllustratedMessage dient als Platzhalter, wenn der eigentliche Inhalt nicht angezeigt werden kann.

**After:**
> Die IllustratedMessage gibt großflächigen Bereichen mit wenig Inhalt eine visuelle Struktur.

## Why

The old wording constrained us too much: it focused primarily on the component being a placeholder for content that is shown later. But we have other use cases as well, so the description now says what the component does structurally rather than pinning it to that single scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)