### PR TITLE
docs(codemods): add migration entry for Tabs' navigation-usage move to TabNavigation

### DIFF
--- a/packages/codemods/src/migrations.generated.ts
+++ b/packages/codemods/src/migrations.generated.ts
@@ -88,6 +88,16 @@ export const migrations: Omit<MigrationEntry, "body">[] = [
       "Replace the import path `@mittwald/flow-react-components/password-tools` with `@mittwald/flow-react-components/mittwald-password-tools-js`.",
   },
   {
+    id: "tabs-navigation-usage-to-tab-navigation",
+    since: "0.2.0-alpha.977",
+    title: "Tabs restyled; navigation usage moves to TabNavigation",
+    kind: "migration",
+    action: "manual",
+    remotePackage: true,
+    apply:
+      "Tabs' rendering changed: the tab list now fills the available width with equal-size tabs and a shared, animated indicator that slides between them, replacing the previous fit-content tabs that each carried their own hover/pressed/selected background. Nothing else about `Tabs` changed, and a `Tabs` that switches content within a page needs no code change — the new look applies on upgrade. Where `Tabs` was used to fake real navigation instead — a `TabTitle` given an `href` (`Aria.Tab`'s routing props: `href`, `target`, `routerOptions`, …) so selecting it pushed a real route change — replace it with `TabNavigation`: plain `Link` children instead of `Tab`/`TabTitle`/panels, `aria-current=\"page\"` on the active `Link` instead of `selectedKey`/`defaultSelectedKey`/`onSelectionChange`. `TabNavigation` keeps the visual language the old `Tabs` used to have, because it now owns that use case.",
+  },
+  {
     id: "table-column-width-props",
     since: "0.2.0-alpha.956",
     title: "TableColumn: `maxWidth` removed, `width` and `minWidth` retyped",

--- a/packages/codemods/src/migrations/tabs-navigation-usage-to-tab-navigation/entry.md
+++ b/packages/codemods/src/migrations/tabs-navigation-usage-to-tab-navigation/entry.md
@@ -1,0 +1,83 @@
+---
+since: 0.2.0-alpha.977
+title: Tabs restyled; navigation usage moves to TabNavigation
+kind: migration
+action: manual
+remotePackage: true
+apply: >-
+  Tabs' rendering changed: the tab list now fills the available width with
+  equal-size tabs and a shared, animated indicator that slides between them,
+  replacing the previous fit-content tabs that each carried their own
+  hover/pressed/selected background. Nothing else about `Tabs` changed, and a
+  `Tabs` that switches content within a page needs no code change — the new look
+  applies on upgrade. Where `Tabs` was used to fake real navigation instead — a
+  `TabTitle` given an `href` (`Aria.Tab`'s routing props: `href`, `target`,
+  `routerOptions`, …) so selecting it pushed a real route change — replace it
+  with `TabNavigation`: plain `Link` children instead of
+  `Tab`/`TabTitle`/panels, `aria-current="page"` on the active `Link` instead of
+  `selectedKey`/`defaultSelectedKey`/`onSelectionChange`. `TabNavigation` keeps
+  the visual language the old `Tabs` used to have, because it now owns that use
+  case.
+---
+
+`Tabs` restyled: the tab list now fills the available width with equal-size tabs
+and a shared, animated indicator that slides between them, instead of the
+previous fit-content tabs that each carried their own hover/pressed/selected
+background. Nothing else about `Tabs` changed — same props, same panels, same
+collapsing behavior. If `Tabs` switches content within a page, there is nothing
+to do; the new look applies on upgrade.
+
+**Real navigation has a proper home now.** React Aria's `Tab` (which `TabTitle`
+extends) accepts the same routing props as a plain link — `href`, `target`,
+`routerOptions`, … — so a `Tabs` could always double as a navigation control:
+give a `TabTitle` an `href` and selecting it pushed a real route change while
+the row still looked and behaved like tabs otherwise. That usage only reached
+for `Tabs` because nothing else looked right for it. Now there is
+`TabNavigation`, introduced in the same version specifically for this case — and
+it keeps the visual language the old `Tabs` used to have.
+
+```diff
+- <Tabs selectedKey={pathname}>
+-   <Tab id="/apps">
+-     <TabTitle href="/apps">Apps</TabTitle>
+-   </Tab>
+-   <Tab id="/container">
+-     <TabTitle href="/container">Container</TabTitle>
+-   </Tab>
+- </Tabs>
++ <TabNavigation aria-label="Projekt-Navigation">
++   <Link href="/apps" aria-current={pathname === "/apps" ? "page" : undefined}>
++     Apps
++   </Link>
++   <Link
++     href="/container"
++     aria-current={pathname === "/container" ? "page" : undefined}
++   >
++     Container
++   </Link>
++ </TabNavigation>
+```
+
+#### What moves and what doesn't
+
+**The children.** `Tab` / `TabTitle` / the panel disappear; `TabNavigation`
+takes plain `Link` children directly. There is no panel, because the destination
+page's content lives on that route, not inside the component.
+
+**The active state.** `selectedKey` / `defaultSelectedKey` / `onSelectionChange`
+have no counterpart — `TabNavigation` does not track selection itself. Each
+`Link` marks itself current with `aria-current="page"`, which the app's router
+already knows how to derive (e.g. from the current pathname), the same way it
+would for any other navigation link.
+
+**Status icons.** An `AlertIcon` moves from inside `TabTitle` to inside the
+`Link`.
+
+**Collapsing.** Both components collapse the same way once space runs out — the
+hidden items move into a "More" button's context menu — so nothing changes
+there.
+
+There is no codemod: only the surrounding code knows whether a given `Tabs`
+usage was real navigation (an `href` on `TabTitle`, or a route push from
+`onSelectionChange`) or a genuine content switcher that merely looked similar
+before this change — the two are indistinguishable from the source alone.

--- a/packages/codemods/src/migrations/tabs-navigation-usage-to-tab-navigation/entry.md
+++ b/packages/codemods/src/migrations/tabs-navigation-usage-to-tab-navigation/entry.md
@@ -73,9 +73,12 @@ would for any other navigation link.
 **Status icons.** An `AlertIcon` moves from inside `TabTitle` to inside the
 `Link`.
 
-**Collapsing.** Both components collapse the same way once space runs out — the
-hidden items move into a "More" button's context menu — so nothing changes
-there.
+**Collapsing.** The two do this differently. `Tabs` collapses all at once: as
+soon as any tab stops fitting, the whole tab list turns into a single button
+showing the active tab, which opens every tab in a context menu. `TabNavigation`
+collapses incrementally: links are hidden one by one as space runs out, and only
+those that no longer fit move into the "More" button's menu — the rest stay
+visible as ordinary links.
 
 There is no codemod: only the surrounding code knows whether a given `Tabs`
 usage was real navigation (an `href` on `TabTitle`, or a route push from

--- a/packages/codemods/src/tests/remoteScope.test.ts
+++ b/packages/codemods/src/tests/remoteScope.test.ts
@@ -61,6 +61,7 @@ const targets: Record<string, string[]> = {
     "RemoteButtonElementProps",
   ],
   "use-design-tokens-build-metadata-removed": ["useDesignTokens"],
+  "tabs-navigation-usage-to-tab-navigation": ["Tabs", "TabNavigation"],
   "imports-to-package-root": [],
   "renamed-css-export": [],
   "password-tools-subpath-renamed": [],

--- a/packages/components/MIGRATION.md
+++ b/packages/components/MIGRATION.md
@@ -417,6 +417,91 @@ npx @mittwald/flow-codemods@latest password-tools-subpath-renamed src
 
 ---
 
+<a id="tabs-navigation-usage-to-tab-navigation"></a>
+
+## Tabs restyled; navigation usage moves to TabNavigation
+
+**Since `0.2.0-alpha.977`** · migration · manual change · also applies to
+`@mittwald/flow-remote-react-components`
+
+`Tabs` restyled: the tab list now fills the available width with equal-size tabs
+and a shared, animated indicator that slides between them, instead of the
+previous fit-content tabs that each carried their own hover/pressed/selected
+background. Nothing else about `Tabs` changed — same props, same panels, same
+collapsing behavior. If `Tabs` switches content within a page, there is nothing
+to do; the new look applies on upgrade.
+
+**Real navigation has a proper home now.** React Aria's `Tab` (which `TabTitle`
+extends) accepts the same routing props as a plain link — `href`, `target`,
+`routerOptions`, … — so a `Tabs` could always double as a navigation control:
+give a `TabTitle` an `href` and selecting it pushed a real route change while
+the row still looked and behaved like tabs otherwise. That usage only reached
+for `Tabs` because nothing else looked right for it. Now there is
+`TabNavigation`, introduced in the same version specifically for this case — and
+it keeps the visual language the old `Tabs` used to have.
+
+```diff
+- <Tabs selectedKey={pathname}>
+-   <Tab id="/apps">
+-     <TabTitle href="/apps">Apps</TabTitle>
+-   </Tab>
+-   <Tab id="/container">
+-     <TabTitle href="/container">Container</TabTitle>
+-   </Tab>
+- </Tabs>
++ <TabNavigation aria-label="Projekt-Navigation">
++   <Link href="/apps" aria-current={pathname === "/apps" ? "page" : undefined}>
++     Apps
++   </Link>
++   <Link
++     href="/container"
++     aria-current={pathname === "/container" ? "page" : undefined}
++   >
++     Container
++   </Link>
++ </TabNavigation>
+```
+
+#### What moves and what doesn't
+
+**The children.** `Tab` / `TabTitle` / the panel disappear; `TabNavigation`
+takes plain `Link` children directly. There is no panel, because the destination
+page's content lives on that route, not inside the component.
+
+**The active state.** `selectedKey` / `defaultSelectedKey` / `onSelectionChange`
+have no counterpart — `TabNavigation` does not track selection itself. Each
+`Link` marks itself current with `aria-current="page"`, which the app's router
+already knows how to derive (e.g. from the current pathname), the same way it
+would for any other navigation link.
+
+**Status icons.** An `AlertIcon` moves from inside `TabTitle` to inside the
+`Link`.
+
+**Collapsing.** Both components collapse the same way once space runs out — the
+hidden items move into a "More" button's context menu — so nothing changes
+there.
+
+There is no codemod: only the surrounding code knows whether a given `Tabs`
+usage was real navigation (an `href` on `TabTitle`, or a route push from
+`onSelectionChange`) or a genuine content switcher that merely looked similar
+before this change — the two are indistinguishable from the source alone.
+
+**Apply:** Tabs' rendering changed: the tab list now fills the available width
+with equal-size tabs and a shared, animated indicator that slides between them,
+replacing the previous fit-content tabs that each carried their own
+hover/pressed/selected background. Nothing else about `Tabs` changed, and a
+`Tabs` that switches content within a page needs no code change — the new look
+applies on upgrade. Where `Tabs` was used to fake real navigation instead — a
+`TabTitle` given an `href` (`Aria.Tab`'s routing props: `href`, `target`,
+`routerOptions`, …) so selecting it pushed a real route change — replace it with
+`TabNavigation`: plain `Link` children instead of `Tab`/`TabTitle`/panels,
+`aria-current="page"` on the active `Link` instead of
+`selectedKey`/`defaultSelectedKey`/`onSelectionChange`. `TabNavigation` keeps
+the visual language the old `Tabs` used to have, because it now owns that use
+case.
+
+---
+
 <a id="table-column-width-props"></a>
 
 ## TableColumn: `maxWidth` removed, `width` and `minWidth` retyped

--- a/packages/components/MIGRATION.md
+++ b/packages/components/MIGRATION.md
@@ -477,9 +477,12 @@ would for any other navigation link.
 **Status icons.** An `AlertIcon` moves from inside `TabTitle` to inside the
 `Link`.
 
-**Collapsing.** Both components collapse the same way once space runs out — the
-hidden items move into a "More" button's context menu — so nothing changes
-there.
+**Collapsing.** The two do this differently. `Tabs` collapses all at once: as
+soon as any tab stops fitting, the whole tab list turns into a single button
+showing the active tab, which opens every tab in a context menu. `TabNavigation`
+collapses incrementally: links are hidden one by one as space runs out, and only
+those that no longer fit move into the "More" button's menu — the rest stay
+visible as ordinary links.
 
 There is no codemod: only the surrounding code knows whether a given `Tabs`
 usage was real navigation (an `href` on `TabTitle`, or a route push from


### PR DESCRIPTION
## Summary

- Adds a migration catalogue entry documenting that `Tabs`' rendering changed in `0.2.0-alpha.977` (the same release that introduced `TabNavigation`): full-width equal tabs with a shared sliding indicator replaced the previous fit-content tabs with per-tab static hover/pressed/selected backgrounds.
- No code change is needed for `Tabs` used to switch content within a page.
- Consumers who used `Tabs`/`TabTitle`'s inherited React Aria routing props (`href`/`target`/`routerOptions`) to fake real navigation should move that usage to `TabNavigation`, which was built for exactly this and deliberately kept the old `Tabs` look and feel.
- No codemod: whether a given `Tabs` usage was real navigation or a genuine content switcher can't be derived from the source alone, same reasoning as the existing `SegmentedControl` deprecation entry.

## Files

- `packages/codemods/src/migrations/tabs-navigation-usage-to-tab-navigation/entry.md` (new catalogue entry)
- `packages/codemods/src/tests/remoteScope.test.ts` (registers the entry's remote-package targets)
- `packages/codemods/src/migrations.generated.ts`, `packages/components/MIGRATION.md` (regenerated via `pnpm nx build codemods`)

## Test plan

- [x] `pnpm nx build codemods` — regenerates `migrations.generated.ts` and `MIGRATION.md`
- [x] `pnpm nx test:unit codemods` — 308/308 tests pass, including the catalogue/remote-scope consistency checks
- [x] `prettier --check` on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)