### PR TITLE
docs: split Upgrades off the Versionierung page

### DIFF
--- a/apps/docs/src/app/releases/page.tsx
+++ b/apps/docs/src/app/releases/page.tsx
@@ -3,6 +3,7 @@ import {
   Flex,
   Heading,
   LayoutCard,
+  Link,
   Section,
   Text,
 } from "@mittwald/flow-react-components";
@@ -48,7 +49,12 @@ export default async function ReleasesPage() {
           </Heading>
           <Text>
             Alle veröffentlichten Flow-Releases mit ihren Highlights,
-            Migrationshinweisen und den enthaltenen Fixes.
+            Migrationshinweisen und den enthaltenen Fixes. Wie du ein Update
+            einspielst, beschreibt{" "}
+            <Link inline href="/get-started/upgrades">
+              Upgrades
+            </Link>
+            .
           </Text>
         </Section>
 

--- a/apps/docs/src/content/components/form-controls/segmented-control/index.mdx
+++ b/apps/docs/src/content/components/form-controls/segmented-control/index.mdx
@@ -29,7 +29,7 @@ es ersetzt, entscheidet die Aufgabe an der jeweiligen Stelle:
   [MIGRATION.md](https://github.com/mittwald/flow/blob/main/packages/components/MIGRATION.md).
 - SegmentedControl gibt zur Laufzeit eine Deprecation-Warnung aus und wird in
   einer zukünftigen Major-Version entfernt. Bis dahin bleibt der alte Pfad
-  abgesichert (siehe [Versionen & Upgrading](/get-started/versioning)).
+  abgesichert (siehe [Versionierung & Stabilität](/get-started/versioning)).
 
 ---
 

--- a/apps/docs/src/content/components/form-controls/segmented-control/index.mdx
+++ b/apps/docs/src/content/components/form-controls/segmented-control/index.mdx
@@ -29,7 +29,7 @@ es ersetzt, entscheidet die Aufgabe an der jeweiligen Stelle:
   [MIGRATION.md](https://github.com/mittwald/flow/blob/main/packages/components/MIGRATION.md).
 - SegmentedControl gibt zur Laufzeit eine Deprecation-Warnung aus und wird in
   einer zukünftigen Major-Version entfernt. Bis dahin bleibt der alte Pfad
-  abgesichert (siehe [Versionierung & Stabilität](/get-started/versioning)).
+  abgesichert (siehe [Versionen & Upgrading](/get-started/versioning)).
 
 ---
 

--- a/apps/docs/src/content/components/structure/align/index.mdx
+++ b/apps/docs/src/content/components/structure/align/index.mdx
@@ -18,7 +18,7 @@ deprecationNotice:
 - Für die Umbenennung gibt es einen Codemod – er passt benannte, umbenannte und
   Namespace-Imports an:
   `npx @mittwald/flow-codemods@latest align-to-combine src`. Siehe
-  [Versionierung & Stabilität](/get-started/versioning).
+  [Upgrades](/get-started/upgrades).
 - Align gibt zur Laufzeit eine Deprecation-Warnung aus und wird in einer
   zukünftigen Major-Version entfernt. Bis dahin bleibt der alte Pfad abgesichert
   (siehe [Versionierung & Stabilität](/get-started/versioning)).

--- a/apps/docs/src/content/components/structure/align/index.mdx
+++ b/apps/docs/src/content/components/structure/align/index.mdx
@@ -18,10 +18,10 @@ deprecationNotice:
 - Für die Umbenennung gibt es einen Codemod – er passt benannte, umbenannte und
   Namespace-Imports an:
   `npx @mittwald/flow-codemods@latest align-to-combine src`. Siehe
-  [Versionierung & Stabilität](/get-started/versioning).
+  [Versionen & Upgrading](/get-started/versioning).
 - Align gibt zur Laufzeit eine Deprecation-Warnung aus und wird in einer
   zukünftigen Major-Version entfernt. Bis dahin bleibt der alte Pfad abgesichert
-  (siehe [Versionierung & Stabilität](/get-started/versioning)).
+  (siehe [Versionen & Upgrading](/get-started/versioning)).
 
 ---
 

--- a/apps/docs/src/content/components/structure/align/index.mdx
+++ b/apps/docs/src/content/components/structure/align/index.mdx
@@ -18,10 +18,10 @@ deprecationNotice:
 - Für die Umbenennung gibt es einen Codemod – er passt benannte, umbenannte und
   Namespace-Imports an:
   `npx @mittwald/flow-codemods@latest align-to-combine src`. Siehe
-  [Versionen & Upgrading](/get-started/versioning).
+  [Versionierung & Stabilität](/get-started/versioning).
 - Align gibt zur Laufzeit eine Deprecation-Warnung aus und wird in einer
   zukünftigen Major-Version entfernt. Bis dahin bleibt der alte Pfad abgesichert
-  (siehe [Versionen & Upgrading](/get-started/versioning)).
+  (siehe [Versionierung & Stabilität](/get-started/versioning)).
 
 ---
 

--- a/apps/docs/src/content/get-started/installation/index.mdx
+++ b/apps/docs/src/content/get-started/installation/index.mdx
@@ -76,4 +76,4 @@ vorab und ohne etwas zu verändern zeigt es `list`.
 
 Welche Änderung ab welcher Version greift, was Flow dir innerhalb einer Linie
 zusichert und wie Deprecation-Warnungen den Vorlauf bilden, steht unter
-[Versionierung & Stabilität](/get-started/versioning).
+[Versionen & Upgrading](/get-started/versioning).

--- a/apps/docs/src/content/get-started/installation/index.mdx
+++ b/apps/docs/src/content/get-started/installation/index.mdx
@@ -74,6 +74,7 @@ Er ersetzt den Migrationsleitfaden nicht: die meisten Änderungen haben keinen
 Codemod. Was in deinem Bereich von Hand ansteht, listet der Befehl am Ende auf –
 vorab und ohne etwas zu verändern zeigt es `list`.
 
-Welche Änderung ab welcher Version greift, was Flow dir innerhalb einer Linie
-zusichert und wie Deprecation-Warnungen den Vorlauf bilden, steht unter
+Welche Änderung ab welcher Version greift und wie Deprecation-Warnungen den
+Vorlauf bilden, steht unter [Upgrades](/get-started/upgrades). Was Flow dir
+innerhalb einer Linie zusichert, steht unter
 [Versionierung & Stabilität](/get-started/versioning).

--- a/apps/docs/src/content/get-started/installation/index.mdx
+++ b/apps/docs/src/content/get-started/installation/index.mdx
@@ -76,4 +76,4 @@ vorab und ohne etwas zu verändern zeigt es `list`.
 
 Welche Änderung ab welcher Version greift, was Flow dir innerhalb einer Linie
 zusichert und wie Deprecation-Warnungen den Vorlauf bilden, steht unter
-[Versionen & Upgrading](/get-started/versioning).
+[Versionierung & Stabilität](/get-started/versioning).

--- a/apps/docs/src/content/get-started/upgrades/index.mdx
+++ b/apps/docs/src/content/get-started/upgrades/index.mdx
@@ -1,0 +1,111 @@
+---
+description:
+  Wie du eine neue Flow-Version einspielst – der Migrationsleitfaden für
+  Breaking Changes, die Codemod-CLI und was direkt nach einem Release zu
+  beachten ist.
+---
+
+---
+
+# Migration bei einer Breaking Change
+
+Jede Änderung, die eine Anpassung in deinem Code erfordert, steht mit
+Vorher-Nachher-Beispiel im Migrationsleitfaden des betroffenen Packages:
+
+- [Migrationsleitfaden `@mittwald/flow-react-components`](https://github.com/mittwald/flow/blob/main/packages/components/MIGRATION.md)
+  – deckt auch `@mittwald/flow-remote-react-components` ab
+- [Migrationsleitfaden `@mittwald/ext-bridge`](https://github.com/mittwald/flow/blob/main/packages/ext-bridge/MIGRATION.md)
+
+Die Einträge sind nach Version absteigend sortiert und nennen jeweils die
+Version, ab der die Änderung greift. Suche die Version, von der du kommst, und
+arbeite dich nach oben durch. Was dabei überhaupt als Breaking Change zählt und
+eine neue Major-Version erzwingt, beschreibt
+[Versionierung & Stabilität](/get-started/versioning).
+
+## Nutze die Codemod-CLI
+
+Ein Befehl hebt alle Flow-Abhängigkeiten auf die Zielversion, installiert und
+führt den Codemod jeder Migration bis zu dieser Version aus:
+
+```shell
+npx @mittwald/flow-codemods@latest upgrade
+```
+
+Ohne Argument geht es auf die nächste Minor innerhalb deiner Major.
+`upgrade patch` bleibt auf deiner Minor, `upgrade major` überquert eine
+Major-Grenze, und eine exakte Version oder ein Dist-Tag (`next`) gehen genau
+dorthin.
+
+Der Befehl ändert Dateien direkt und bricht auf einem unsauberen Git-Stand ab.
+
+Der Befehl kennt keine untere Grenze: er listet auch Migrationen, die vor deiner
+aktuellen Version erschienen sind. Nichts hält fest, welche davon dein Projekt
+schon durchgeführt hat – und ein zweiter Durchlauf eines Codemods ändert nichts.
+
+Er ersetzt den Migrationsleitfaden nicht: die meisten Einträge haben keinen
+Codemod. Welche das für deinen Bereich sind, listet der Befehl am Ende auf –
+oder vorab, ohne etwas zu verändern, mit `list` und derselben Revision:
+
+```shell
+npx @mittwald/flow-codemods@latest list minor
+```
+
+`list` ohne Argument zeigt den gesamten Katalog, offline. Mit einer Revision
+liest es dieselbe Version aus deinem `package.json` und zeigt genau den Bereich,
+den `upgrade` mit dieser Revision anfassen würde – ein echter Trockenlauf.
+
+Einen einzelnen Codemod führst du über seine ID aus:
+
+```shell
+npx @mittwald/flow-codemods@latest align-to-combine src
+```
+
+## Deprecation-Warnungen sind der Vorlauf
+
+Wird ein Pfad deprecated, bleibt er funktionsfähig und meldet sich zur Laufzeit
+per `console.warn`. Diese Warnungen sind die Vorwarnzeit vor der nächsten
+Major-Version – behandle sie als Aufgabenliste, nicht als Rauschen. Um sie
+zentral einzusammeln, etwa im Error-Tracking, umschließe deine Anwendung mit
+einem `DeprecationWarningProvider` und gib ihm einen `onWarning`-Handler:
+
+```tsx
+<DeprecationWarningProvider onWarning={(message) => reportToTracking(message)}>
+  <App />
+</DeprecationWarningProvider>
+```
+
+---
+
+# Direkt nach einem Release
+
+Ein Release veröffentlicht die Packages **nacheinander**, nicht gleichzeitig.
+Für einige Minuten liegt in der npm-Registry deshalb für die schon
+veröffentlichten Packages die neue Version, für die restlichen noch die alte.
+Beim Release `1.0.6` lagen zwischen dem ersten und dem letzten Package rund 25
+Minuten.
+
+Du triffst dieses Fenster leicht, denn ein Update betrifft immer mehrere
+Packages: alle `@mittwald/flow-*`-Packages teilen sich eine gemeinsame Version,
+und `@mittwald/flow-react-components` fordert `@mittwald/flow-icons-pro` als
+Peer-Dependency in exakt derselben Version. Ziehst du in diesem Fenster alle
+Flow-Abhängigkeiten auf die neue Version, schlägt die Installation für das
+Package fehl, das noch nicht dran war:
+
+```
+npm error code ETARGET
+npm error notarget No matching version found for @mittwald/flow-react-components@1.0.6
+```
+
+pnpm meldet dasselbe als `ERR_PNPM_NO_MATCHING_VERSION`.
+
+Das ist keine Lücke im Release: sobald der Release-Lauf durch ist, haben alle
+Packages dieselbe Version. Direkt nach einem Release ist dieser Fehler fast
+immer das Veröffentlichungsfenster und nichts anderes.
+
+<Alert>
+  <Heading>Warte ein paar Minuten und installiere erneut</Heading>
+  <Content>
+    Das Fenster schließt sich von selbst. Du brauchst keinen Workaround – pinne
+    nichts fest und mische keine Flow-Versionen, um den Fehler zu umgehen.
+  </Content>
+</Alert>

--- a/apps/docs/src/content/get-started/versioning/index.mdx
+++ b/apps/docs/src/content/get-started/versioning/index.mdx
@@ -26,7 +26,8 @@ geworden: Wir halten uns an [Semantic Versioning](https://semver.org) und gehen
 
 Entscheidend ist die Grenze: Welche Änderung erzwingt eine neue Major-Version,
 und welche darf in einem Minor oder Patch erscheinen? Die folgenden Abschnitte
-beschreiben diese Grenze aus Sicht der Entwickler.
+beschreiben diese Grenze aus Sicht der Entwickler. Wie du ein Update oder eine
+Migration konkret durchführst, beschreibt [Upgrades](/get-started/upgrades).
 
 ---
 
@@ -129,109 +130,6 @@ Update bewusst und kontrolliert erfolgt. Zu einem bewusst herbeigeführten
 Type-Breaking-Change gehört eine Migrationsnotiz in den Release Notes – so
 bekommst du einen konkreten Upgrade-Pfad, auch wenn die Änderung in einem Minor
 oder Patch erscheint.
-
----
-
-# Migration bei einer Breaking Change
-
-Jede Änderung, die eine Anpassung in deinem Code erfordert, steht mit
-Vorher-Nachher-Beispiel im Migrationsleitfaden des betroffenen Packages:
-
-- [Migrationsleitfaden `@mittwald/flow-react-components`](https://github.com/mittwald/flow/blob/main/packages/components/MIGRATION.md)
-  – deckt auch `@mittwald/flow-remote-react-components` ab
-- [Migrationsleitfaden `@mittwald/ext-bridge`](https://github.com/mittwald/flow/blob/main/packages/ext-bridge/MIGRATION.md)
-
-Die Einträge sind nach Version absteigend sortiert und nennen jeweils die
-Version, ab der die Änderung greift. Suche die Version, von der du kommst, und
-arbeite dich nach oben durch.
-
-## Nutze die Codemod-CLI
-
-Ein Befehl hebt alle Flow-Abhängigkeiten auf die Zielversion, installiert und
-führt den Codemod jeder Migration bis zu dieser Version aus:
-
-```shell
-npx @mittwald/flow-codemods@latest upgrade
-```
-
-Ohne Argument geht es auf die nächste Minor innerhalb deiner Major.
-`upgrade patch` bleibt auf deiner Minor, `upgrade major` überquert eine
-Major-Grenze, und eine exakte Version oder ein Dist-Tag (`next`) gehen genau
-dorthin.
-
-Der Befehl ändert Dateien direkt und bricht auf einem unsauberen Git-Stand ab.
-
-Der Befehl kennt keine untere Grenze: er listet auch Migrationen, die vor deiner
-aktuellen Version erschienen sind. Nichts hält fest, welche davon dein Projekt
-schon durchgeführt hat – und ein zweiter Durchlauf eines Codemods ändert nichts.
-
-Er ersetzt den Migrationsleitfaden nicht: die meisten Einträge haben keinen
-Codemod. Welche das für deinen Bereich sind, listet der Befehl am Ende auf –
-oder vorab, ohne etwas zu verändern, mit `list` und derselben Revision:
-
-```shell
-npx @mittwald/flow-codemods@latest list minor
-```
-
-`list` ohne Argument zeigt den gesamten Katalog, offline. Mit einer Revision
-liest es dieselbe Version aus deinem `package.json` und zeigt genau den Bereich,
-den `upgrade` mit dieser Revision anfassen würde – ein echter Trockenlauf.
-
-Einen einzelnen Codemod führst du über seine ID aus:
-
-```shell
-npx @mittwald/flow-codemods@latest align-to-combine src
-```
-
-## Deprecation-Warnungen sind der Vorlauf
-
-Wird ein Pfad deprecated, bleibt er funktionsfähig und meldet sich zur Laufzeit
-per `console.warn`. Diese Warnungen sind die Vorwarnzeit vor der nächsten
-Major-Version – behandle sie als Aufgabenliste, nicht als Rauschen. Um sie
-zentral einzusammeln, etwa im Error-Tracking, umschließe deine Anwendung mit
-einem `DeprecationWarningProvider` und gib ihm einen `onWarning`-Handler:
-
-```tsx
-<DeprecationWarningProvider onWarning={(message) => reportToTracking(message)}>
-  <App />
-</DeprecationWarningProvider>
-```
-
----
-
-# Direkt nach einem Release
-
-Ein Release veröffentlicht die Packages **nacheinander**, nicht gleichzeitig.
-Für einige Minuten liegt in der npm-Registry deshalb für die schon
-veröffentlichten Packages die neue Version, für die restlichen noch die alte.
-Beim Release `1.0.6` lagen zwischen dem ersten und dem letzten Package rund 25
-Minuten.
-
-Du triffst dieses Fenster leicht, denn ein Update betrifft immer mehrere
-Packages: alle `@mittwald/flow-*`-Packages teilen sich eine gemeinsame Version,
-und `@mittwald/flow-react-components` fordert `@mittwald/flow-icons-pro` als
-Peer-Dependency in exakt derselben Version. Ziehst du in diesem Fenster alle
-Flow-Abhängigkeiten auf die neue Version, schlägt die Installation für das
-Package fehl, das noch nicht dran war:
-
-```
-npm error code ETARGET
-npm error notarget No matching version found for @mittwald/flow-react-components@1.0.6
-```
-
-pnpm meldet dasselbe als `ERR_PNPM_NO_MATCHING_VERSION`.
-
-Das ist keine Lücke im Release: sobald der Release-Lauf durch ist, haben alle
-Packages dieselbe Version. Direkt nach einem Release ist dieser Fehler fast
-immer das Veröffentlichungsfenster und nichts anderes.
-
-<Alert>
-  <Heading>Warte ein paar Minuten und installiere erneut</Heading>
-  <Content>
-    Das Fenster schließt sich von selbst. Du brauchst keinen Workaround – pinne
-    nichts fest und mische keine Flow-Versionen, um den Fehler zu umgehen.
-  </Content>
-</Alert>
 
 ---
 

--- a/apps/docs/src/content/get-started/versioning/index.mdx
+++ b/apps/docs/src/content/get-started/versioning/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: Versionierung & Stabilität
-navTitle: Versionierung
+title: Versionen & Upgrading
+navTitle: Versionen & Upgrading
 description:
   Flow folgt Semantic Versioning. Diese Seite beschreibt, worauf du dich als
   Entwickler verlassen kannst, worauf nicht und wie du dich gegen ungewollte

--- a/apps/docs/src/content/get-started/versioning/index.mdx
+++ b/apps/docs/src/content/get-started/versioning/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: Versionen & Upgrading
-navTitle: Versionen & Upgrading
+title: Versionierung & Stabilität
+navTitle: Versionierung
 description:
   Flow folgt Semantic Versioning. Diese Seite beschreibt, worauf du dich als
   Entwickler verlassen kannst, worauf nicht und wie du dich gegen ungewollte

--- a/apps/docs/src/content/releases/index.mdx
+++ b/apps/docs/src/content/releases/index.mdx
@@ -8,4 +8,5 @@ description:
 # Releases
 
 Diese Seite bündelt die veröffentlichten Flow-Releases in einer Zeitleiste – mit
-Highlights, Migrationshinweisen und den enthaltenen Fixes je Patch-Version.
+Highlights, Migrationshinweisen und den enthaltenen Fixes je Patch-Version. Wie
+du ein Update einspielst, beschreibt [Upgrades](/get-started/upgrades).

--- a/apps/docs/src/lib/content/contentOrder.ts
+++ b/apps/docs/src/lib/content/contentOrder.ts
@@ -10,6 +10,10 @@
  */
 export const CONTENT_ORDER: readonly string[] = [
   "/get-started",
+  "/get-started/installation",
+  "/get-started/stylesheet",
+  "/get-started/versioning",
+  "/get-started/upgrades",
   "/releases",
   "/foundations",
   "/foundations/design",


### PR DESCRIPTION
## Summary
- Reverted the earlier rename — the page stays **Versionierung & Stabilität** / **Versionierung**.
- Split the upgrade-workflow content off into a new `/get-started/upgrades` page: the migration-guide pointer, the codemod CLI section, deprecation-warning guidance, and the post-release npm version-mismatch window. `Versionierung` keeps the semver contract itself (what's guaranteed, Node/React support, lifecycle status).
- Cross-linked the two pages, and updated the existing references in `installation`, `align`, and `segmented-control` to point at whichever of the two now actually covers that content.
- Links `Upgrades` from the `Releases` page's intro paragraph (both the rendered page and its shadow MDX used for search/`llms.txt`), so readers landing on release notes know where to find the upgrade how-to.

## Test plan
- [x] `pnpm nx test:links docs` — passes
- [x] `pnpm nx build docs` (full production build) — passes; verified `/get-started/upgrades` is generated, TypeScript compiles, and the split content lands on the right page in the built HTML
- [x] `prettier --check` on the touched files — passes