### PR TITLE
fix(List): let items follow the state they are rendered from

### DIFF
--- a/packages/components/src/components/List/List.browser.test.tsx
+++ b/packages/components/src/components/List/List.browser.test.tsx
@@ -9,7 +9,7 @@ import {
   ListStaticData,
 } from "@/components/List";
 import type { AsyncDataLoader } from "@/components/List/model/loading/types";
-import { use, type ReactNode } from "react";
+import { use, useState, type ReactNode } from "react";
 import { test } from "vitest";
 import { page, userEvent } from "vitest/browser";
 import {
@@ -518,8 +518,9 @@ describe("Infinite scroll", () => {
     await (await page.getByText("Item: 2").element()).scrollIntoView();
     await expect.element(page.getByText("Item: 5")).toBeInTheDocument();
 
-    // Appending items must not re-run the render of the existing ones — their
-    // memoized item components bail out on the unchanged (id, data).
+    // Appending items must not re-run the render of the existing ones — the
+    // list model is rebuilt, but the render functions it carries come from the
+    // unchanged JSX above, so the memoized item components bail out.
     expect(renderCounts[0]).toBe(before0);
     expect(renderCounts[1]).toBe(before1);
   });
@@ -604,4 +605,50 @@ describe("Loading view", () => {
       await expect.element(page.getByText("Loading item")).toBeInTheDocument();
     },
   );
+});
+
+describe("Item rendering", () => {
+  // Stable identity: the memoized item is only skipped while its data is
+  // unchanged, which is what a real loader returns between renders.
+  const selectableData: Data[] = [{ num: 42 }];
+
+  const SelectableList = () => {
+    const [selected, setSelected] = useState<number[]>([]);
+
+    return (
+      <List
+        aria-label="Test"
+        onAction={({ num }: Data) =>
+          setSelected((current) =>
+            current.includes(num)
+              ? current.filter((n) => n !== num)
+              : [...current, num],
+          )
+        }
+      >
+        <ListStaticData<Data> data={selectableData} />
+        <ListItem<Data> textValue={({ num }) => String(num)}>
+          {({ num }) => (
+            <span>
+              Item: {num} {selected.includes(num) ? "selected" : "unselected"}
+            </span>
+          )}
+        </ListItem>
+      </List>
+    );
+  };
+
+  test("items follow state the consumer renders them from", async () => {
+    await render(<SelectableList />);
+
+    await userEvent.click(page.getByText("Item: 42 unselected"));
+    await expect
+      .element(page.getByText("Item: 42 selected"))
+      .toBeInTheDocument();
+
+    await userEvent.click(page.getByText("Item: 42 selected"));
+    await expect
+      .element(page.getByText("Item: 42 unselected"))
+      .toBeInTheDocument();
+  });
 });

--- a/packages/components/src/components/List/components/Items/components/Item/Item.tsx
+++ b/packages/components/src/components/List/components/Items/components/Item/Item.tsx
@@ -52,13 +52,21 @@ const ItemImpl = (props: Props) => {
   );
 };
 
+// The list model is rebuilt on every render, so it cannot be compared by
+// identity — but everything an item renders from it can. Those closures come
+// from the consumer's own JSX and only change when the consumer re-renders,
+// so loading more still skips the re-render while parent state no longer
+// leaves an item frozen on the values it first saw.
 export const Item = memo(
   ItemImpl,
   (prev, next) =>
     prev.id === next.id &&
     prev.data === next.data &&
     prev.triggerRef === next.triggerRef &&
-    prev.isTile === next.isTile,
+    prev.isTile === next.isTile &&
+    prev.list.onAction === next.list.onAction &&
+    prev.list.accordion === next.list.accordion &&
+    !!prev.list.itemView?.rendersSameAs(next.list.itemView),
 );
 Item.displayName = "Item";
 

--- a/packages/components/src/components/List/model/item/ItemView.ts
+++ b/packages/components/src/components/List/model/item/ItemView.ts
@@ -57,6 +57,21 @@ export class ItemView<T> {
   private static fallbackRenderItemFn: RenderItemFn<never> = (item) =>
     createElement("pre", undefined, JSON.stringify(item));
 
+  /**
+   * Whether `other` would render this item identically — i.e. all render
+   * functions taken from the consumer's `ListItem` element are still the same.
+   */
+  public rendersSameAs(other?: ItemView<T>): boolean {
+    return (
+      !!other &&
+      this.renderFn === other.renderFn &&
+      this.textValue === other.textValue &&
+      this.href === other.href &&
+      this.target === other.target &&
+      this.defaultExpanded === other.defaultExpanded
+    );
+  }
+
   public render(data: T): ReactNode {
     const renderFn = (this.renderFn ??
       ItemView.fallbackRenderItemFn) as RenderItemFn<T>;


### PR DESCRIPTION
## Problem

`Item` is memoized on `(id, data, triggerRef, isTile)` and ignores the `list` prop. The list model is rebuilt on every render, so it *cannot* be compared by identity — but the render functions it carries can, and dropping them means an item keeps the closures it saw on its first render, forever.

Anything a consumer renders from its own state is frozen:

- a selection checkbox never ticks, because `isSelected` is evaluated in the stale closure
- worse, a handler asking "is this already selected?" against that stale closure takes the *add* branch every time — so each click appends a duplicate instead of toggling

The second one is the damaging half. In mStudio's mail archive order the duplicates reach the order overview, and the customer is quoted 12× the price for 12 clicks on the same address.

Regression from #2677.

## Fix

Compare the render functions and `onAction` the list carries. They come from the consumer's own `ListItem` JSX, so they only change when the consumer re-renders — loading more does not, so it still bails out and #2677's optimization is untouched.

## Tests

New browser test `items follow state the consumer renders them from`. Verified it fails on the unfixed code (`Cannot find element with locator: getByText('Item: 42 selected')`) and passes with the fix — its data is a hoisted const, because an inline array gets a fresh identity each render and defeats the memo on its own.

The existing #2677 guard `Already-loaded items are not re-rendered when the next batch loads` still passes; its comment claimed the bail-out was on `(id, data)` and is corrected.

44/44 List browser tests green in webkit and firefox, `pnpm lint` clean, `pnpm affected:test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)