### PR TITLE
fix(components): prefix the CSS properties Safari needs prefixed

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -155,6 +155,7 @@
     "@vitest/browser": "^4.1.11",
     "@vitest/browser-playwright": "^4.1.11",
     "@vitest/coverage-v8": "~4.1.11",
+    "autoprefixer": "^10.5.4",
     "camelcase": "^9.0.0",
     "decamelize": "^6.0.1",
     "fs-jetpack": "^5.1.0",
@@ -210,5 +211,8 @@
     "react-hook-form": {
       "optional": true
     }
-  }
+  },
+  "browserslist": [
+    "baseline widely available"
+  ]
 }

--- a/packages/components/vite.config.ts
+++ b/packages/components/vite.config.ts
@@ -3,6 +3,7 @@ import path from "path";
 import { cssModuleClassNameGenerator } from "./dev/vite/cssModuleClassNameGenerator.ts";
 import { viteI18nPlugin } from "./dev/vite/viteI18nPlugin.ts";
 import { unlayeredMarkerPlugin } from "./dev/vite/unlayeredMarker.ts";
+import autoprefixer from "autoprefixer";
 import { lezer } from "@lezer/generator/rollup";
 import sassDts from "vite-plugin-sass-dts";
 
@@ -41,7 +42,11 @@ export default defineConfig({
      * lose to Flow's own unlayered rules – the opposite of its purpose.
      */
     postcss: {
-      plugins: [unlayeredMarkerPlugin()],
+      /*
+       * Autoprefixer sits here, not in the build config: that one merges on top
+       * and concatenates the plugin list, so both pipelines prefix alike.
+       */
+      plugins: [unlayeredMarkerPlugin(), autoprefixer()],
     },
     modules: {
       generateScopedName: cssModuleClassNameGenerator,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -688,6 +688,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ~4.1.11
         version: 4.1.11(@vitest/browser@4.1.11)(vitest@4.1.11)
+      autoprefixer:
+        specifier: ^10.5.4
+        version: 10.5.4(postcss@8.5.26)
       camelcase:
         specifier: ^9.0.0
         version: 9.0.0
@@ -5299,6 +5302,13 @@ packages:
     resolution: {integrity: sha512-KbWgR8wOYRAPekEmMXrYYdc7BRyhn2Ftk7KWfMUnQ43hFdojWEFRxhhRUm3/OFEdPa1r0KAvTTg9YQK57xTe0g==}
     engines: {node: '>=0.8'}
 
+  autoprefixer@10.5.4:
+    resolution: {integrity: sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA==}
+    engines: {node: ^10 || ^12 || >=14}
+    hasBin: true
+    peerDependencies:
+      postcss: ^8.1.0
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -6520,6 +6530,9 @@ packages:
   form-data@4.0.6:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
+
+  fraction.js@5.3.4:
+    resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
   framer-motion@12.43.0:
     resolution: {integrity: sha512-1eaL3RvR/kAlbG7UYcpMptEyzPoENO0c6w7ZnB3/hh2vSAz/6uGAFn6fdoqTBguNstf3MsFhJHsD/0DHiclG+g==}
@@ -14707,6 +14720,15 @@ snapshots:
 
   author-regex@1.0.0: {}
 
+  autoprefixer@10.5.4(postcss@8.5.26):
+    dependencies:
+      browserslist: 4.28.8
+      caniuse-lite: 1.0.30001810
+      fraction.js: 5.3.4
+      picocolors: 1.1.1
+      postcss: 8.5.26
+      postcss-value-parser: 4.2.0
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
@@ -16178,6 +16200,8 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.4
       mime-types: 2.1.35
+
+  fraction.js@5.3.4: {}
 
   framer-motion@12.43.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:


### PR DESCRIPTION
Safari honours `user-select` and `backdrop-filter` only behind `-webkit-`, and we ship the components' CSS through no autoprefixer. So the LightBox gallery item stayed selectable while swiping, and the overlay backdrop behind every Modal and LightBox did not blur below Safari 18.

This adds autoprefixer to the PostCSS pipeline. It goes into `vite.config.ts` rather than the build config, so dev, Storybook, the browser tests and the published CSS all carry the same prefixes.

The part worth a look is `browserslist`, which declares our supported range for the first time and is what decides which prefixes get written. It is a single `baseline widely available` query — Safari 17.2+, Chrome 121+, Edge, Firefox, Android Chrome and Firefox — so no version is pinned by hand. It sits in `packages/components/package.json` and not in the root because Next reads `browserslist` too, and a root entry would change the docs build along with it.

Costs 96 bytes: three declarations in `all.css`, nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)