### PR TITLE
fix(ci): no release for merges that cannot reach a consumer (fixes #3023)

### DIFF
--- a/.github/scripts/release-relevance-guard.mjs
+++ b/.github/scripts/release-relevance-guard.mjs
@@ -6,10 +6,11 @@
  * Reads the changed-file list on stdin (one repository-relative path per line)
  * and writes `publish=true|false` to $GITHUB_OUTPUT.
  *
- * `ROOT_MANIFEST_BEFORE_FILE` / `ROOT_MANIFEST_AFTER_FILE` optionally point at
- * the two versions of the root `package.json`. They let the classifier judge
- * that manifest by its key diff instead of its path (#2970); without them the
- * root manifest stays relevant, as before.
+ * `MANIFEST_DIR` optionally points at a directory holding the two versions of
+ * every changed `package.json`, as `<path with / replaced by __>.before.json`
+ * and `.after.json`. They let the classifier judge each manifest by its key
+ * diff instead of its path (#2970, #3023); a manifest whose pair is missing
+ * stays relevant, as before.
  *
  * It never fails the run. The decision is a routing choice, not a policy
  * violation: an empty or unreadable input yields `publish=true`, which is the
@@ -18,6 +19,7 @@
 import { appendFileSync, readFileSync } from "node:fs";
 import {
   classifyChangedFiles,
+  classifyPackageManifestChange,
   classifyRootManifestChange,
 } from "./release-relevance-lib.mjs";
 
@@ -36,34 +38,43 @@ const files = readStdin()
   .filter((line) => line !== "");
 
 /**
- * The root manifest's two versions, if the workflow fetched them.
+ * One side of a manifest the workflow fetched, if it is there.
  *
- * A missing or unreadable file is `undefined`, which
- * `classifyRootManifestChange` reports as relevant — the behaviour before this
- * refinement.
+ * A missing or unreadable file is `undefined`, which the classifiers report as
+ * relevant — the behaviour before this refinement.
  *
- * @param {string} variable
+ * @param {string} path
  */
-function readManifest(variable) {
-  const path = process.env[variable];
-  if (!path) return undefined;
+function readManifest(path) {
   try {
     return readFileSync(path, "utf8");
   } catch {
-    console.log(`::warning::Could not read ${variable} (${path}).`);
     return undefined;
   }
 }
 
-/** @type {{ rootManifestRelevant?: boolean }} */
-const options = {};
-if (files.includes("package.json")) {
-  const manifest = classifyRootManifestChange(
-    readManifest("ROOT_MANIFEST_BEFORE_FILE"),
-    readManifest("ROOT_MANIFEST_AFTER_FILE"),
-  );
-  options.rootManifestRelevant = manifest.relevant;
-  console.log(`Root manifest: ${manifest.reason}.`);
+/** @type {{ manifestRelevance: Record<string, boolean> }} */
+const options = { manifestRelevance: {} };
+const manifestDir = process.env.MANIFEST_DIR;
+
+for (const path of files.filter(
+  (file) => file === "package.json" || file.endsWith("/package.json"),
+)) {
+  const slug = path.replaceAll("/", "__");
+  const before = manifestDir
+    ? readManifest(`${manifestDir}/${slug}.before.json`)
+    : undefined;
+  const after = manifestDir
+    ? readManifest(`${manifestDir}/${slug}.after.json`)
+    : undefined;
+
+  const { relevant, reason } =
+    path === "package.json"
+      ? classifyRootManifestChange(before, after)
+      : classifyPackageManifestChange(before, after, path);
+
+  options.manifestRelevance[path] = relevant;
+  console.log(`Manifest: ${reason}.`);
 }
 
 const { publish, reason, relevant, total } = classifyChangedFiles(

--- a/.github/scripts/release-relevance-lib.mjs
+++ b/.github/scripts/release-relevance-lib.mjs
@@ -2,10 +2,20 @@
 /**
  * Release-relevance classification — pure functions, no git / no IO.
  *
- * Answers one question: can this set of changed files reach a PUBLISHED
- * package's tarball? Docs- and CI-only merges cannot, and must not produce a
- * release — no npm publish, no `chore(release):` bump, no tag, no GitHub
- * Release (#2931).
+ * Answers one question: can this set of changed files change what a CONSUMER of
+ * a published package gets? Docs- and CI-only merges cannot, and must not
+ * produce a release — no npm publish, no `chore(release):` bump, no tag, no
+ * GitHub Release (#2931).
+ *
+ * "Consumer effect", not "inside the tarball" — the two are not the same, and
+ * the difference decides two whole classes (#3023). A published tarball carries
+ * the package's `scripts`, yet only the install lifecycle ones ever run on a
+ * consumer's machine. And `dist/types` is emitted from all of `src`, which used
+ * to drag test and story declarations along — 196 of `flow-remote-react-`
+ * `components@1.1.10`'s 799 entries were `dist/types/tests/**`, dead files no
+ * `exports` path can reach. The build excludes them now, but the criterion has
+ * to be consumer effect either way: nothing stops the next generator from
+ * emitting something similar.
  *
  * The rule is a DENYLIST, and that direction is deliberate. Every published
  * package ships `dist` (plus three `.md` for flow-react-components), so "what
@@ -62,13 +72,59 @@ const IRRELEVANT_ROOT_FILES = new Set([
 ]);
 
 /**
- * Can a change to `path` reach a published package's tarball?
+ * Package-local paths with no consumer effect.
+ *
+ * `packages/**` is relevant WHOLESALE for a reason (see `isPublishRelevant`),
+ * so this list holds only what provably cannot change what a consumer gets:
+ *
+ * - `.storybook/` — the component dev environment (`nx dev components`). No build
+ *   or generator reads it; the only mentions elsewhere are comments.
+ * - `Dockerfile` / `.dockerignore` — the Storybook preview image, which CI builds
+ *   from `dev/` and `.github/`.
+ * - `e2e/` and `src/tests/` — test suites. They are not build entries, and the
+ *   declarations `dist/types` used to emit for them are excluded now.
+ * - `*.stories.*` and `*.test.*` anywhere in a package — same argument, for the
+ *   files that sit next to the code they exercise. No production module imports
+ *   a story or a test.
+ *
+ * Deliberately NOT here, though #3023 proposed it: a package's own `dev/`
+ * directory. It is a BUILD INPUT, not tooling. `components/dev/vite/*` is
+ * imported by `vite.build.config.ts` and shapes the emitted CSS layers,
+ * `dev/component-index` and `dev/status-registry` generate shipped `dist`
+ * assets, and `codemods/dev/generate` writes `MIGRATION.md` — which
+ * `flow-react-components` publishes. Skipping it would swallow real releases.
+ *
+ * Nor is a `stories/` or `testData/` DIRECTORY skipped, only the story and test
+ * files themselves. `components/dev/createDocPropertiesJson.ts` parses every
+ * `.tsx` under `src/` and ignores only `*.stories.tsx`, so the helper beside a
+ * story — `components/Button/stories/lib.tsx` — contributes five entries to the
+ * published `dist/assets/doc-properties.json`. `packages/core`'s
+ * `publishedDtsOptions` draws the same line for the declaration emit; keep the
+ * two in step.
+ *
+ * Also not here: a package's non-shipped Markdown (`CONTRIBUTE.md` and
+ * friends). Each package's `files` differs — `flow-react-components` publishes
+ * three `.md` — so that decision needs the manifest, not the path.
+ */
+const IRRELEVANT_PACKAGE_PATTERNS = [
+  /^packages\/[^/]+\/\.storybook\//,
+  /^packages\/[^/]+\/Dockerfile$/,
+  /^packages\/[^/]+\/\.dockerignore$/,
+  /^packages\/[^/]+\/e2e\//,
+  /^packages\/[^/]+\/src\/tests\//,
+  /^packages\/.*\.stories\.[^/]+$/,
+  /^packages\/.*\.test\.[^/]+$/,
+];
+
+/**
+ * Can a change to `path` change what a consumer gets?
  *
  * Note that `packages/**` is relevant WHOLESALE, Markdown included:
  * `@mittwald/flow-react-components` ships `AGENTS.md`, `MIGRATION.md` and
  * `USAGE.md` next to `dist`, so a package-local `.md` really can be part of the
  * published artifact. Only Markdown OUTSIDE `packages/` (root `README.md`,
- * `AGENTS.md`, `CHANGELOG.md`, …) is irrelevant.
+ * `AGENTS.md`, `CHANGELOG.md`, …) is irrelevant. The only carve-outs are the
+ * narrow, provable ones in `IRRELEVANT_PACKAGE_PATTERNS` above.
  *
  * @param {string} path Repository-relative, forward-slash separated.
  * @returns {boolean}
@@ -78,6 +134,7 @@ export function isPublishRelevant(path) {
   if (p === "") return false;
 
   if (IRRELEVANT_PREFIXES.some((prefix) => p.startsWith(prefix))) return false;
+  if (IRRELEVANT_PACKAGE_PATTERNS.some((re) => re.test(p))) return false;
 
   const isRootFile = !p.includes("/");
   if (isRootFile && (IRRELEVANT_ROOT_FILES.has(p) || p.endsWith(".md"))) {
@@ -105,7 +162,7 @@ function looksLikePath(line) {
 }
 
 /**
- * Root-`package.json` keys whose change cannot reach any tarball.
+ * Root-`package.json` keys whose change cannot reach a consumer.
  *
  * Both are provably local: `scripts` is task wiring run by CI and by
  * developers, `simple-git-hooks` configures the local git hooks. Every other
@@ -116,22 +173,64 @@ function looksLikePath(line) {
 const IRRELEVANT_ROOT_MANIFEST_KEYS = new Set(["scripts", "simple-git-hooks"]);
 
 /**
- * Can a change to the root `package.json` reach a published tarball?
+ * A published package's manifest keys whose change cannot reach a consumer.
  *
- * The root manifest is private and never published, so nothing in it ships
- * directly — but its dependency and wiring keys shape what every package
- * builds. Only the key DIFF can tell the two apart, which is why the path-level
- * `isPublishRelevant` cannot: `scripts` churn (#2970 added `test:links` to two
- * scripts and cut 1.0.9) looks exactly like a `devDependencies` bump.
+ * Only `scripts` — and only conditionally. The tarball DOES carry it, but a
+ * consumer never runs `build` or `test` from a dependency; the install
+ * lifecycle is the exception, and `SCRIPTS_A_CONSUMER_RUNS` guards it. No Flow
+ * package defines one of those today, which is exactly why the guard has to be
+ * in the code rather than in someone's memory.
+ *
+ * Everything else stays relevant: the dependency blocks and `peerDependencies`
+ * decide what a consumer resolves, `exports` / `main` / `types` / `files` /
+ * `sideEffects` / `bin` / `type` decide what they can import, and `version` is
+ * the release itself.
+ */
+const IRRELEVANT_PACKAGE_MANIFEST_KEYS = new Set(["scripts"]);
+
+/** Script names npm runs when a consumer installs the package. */
+const SCRIPTS_A_CONSUMER_RUNS = [
+  "preinstall",
+  "install",
+  "postinstall",
+  "prepare",
+];
+
+/**
+ * Did the `scripts` diff touch anything a consumer's install would run?
+ *
+ * @param {Record<string, unknown>} before
+ * @param {Record<string, unknown>} after
+ * @returns {boolean}
+ */
+function scriptsReachAConsumer(before, after) {
+  const b = /** @type {Record<string, unknown>} */ (before.scripts ?? {});
+  const a = /** @type {Record<string, unknown>} */ (after.scripts ?? {});
+  return SCRIPTS_A_CONSUMER_RUNS.some((name) => b[name] !== a[name]);
+}
+
+/**
+ * Judge a manifest by its KEY DIFF instead of its path.
  *
  * Fails SAFE in both directions: unreadable or unparsable content is relevant,
- * and so is any key not on the denylist above.
+ * and so is any key not on the given denylist.
  *
  * @param {string | null | undefined} beforeText
  * @param {string | null | undefined} afterText
+ * @param {{
+ *   label: string;
+ *   irrelevantKeys: Set<string>;
+ *   stillRelevant?: (
+ *     key: string,
+ *     before: Record<string, unknown>,
+ *     after: Record<string, unknown>,
+ *   ) => boolean;
+ * }} options
  * @returns {{ relevant: boolean; reason: string }}
  */
-export function classifyRootManifestChange(beforeText, afterText) {
+function classifyManifestChange(beforeText, afterText, options) {
+  const { label, irrelevantKeys, stillRelevant } = options;
+
   /** @param {string | null | undefined} text */
   const parse = (text) => {
     if (typeof text !== "string") return undefined;
@@ -149,7 +248,7 @@ export function classifyRootManifestChange(beforeText, afterText) {
   if (!before || !after) {
     return {
       relevant: true,
-      reason: "the root package.json could not be read (fail-safe default)",
+      reason: `${label} could not be read (fail-safe default)`,
     };
   }
 
@@ -159,24 +258,71 @@ export function classifyRootManifestChange(beforeText, afterText) {
   );
 
   if (changed.length === 0) {
-    return { relevant: false, reason: "the root package.json did not change" };
+    return { relevant: false, reason: `${label} did not change` };
   }
 
   const relevantKeys = changed.filter(
-    (key) => !IRRELEVANT_ROOT_MANIFEST_KEYS.has(key),
+    (key) =>
+      !irrelevantKeys.has(key) ||
+      (stillRelevant?.(key, before, after) ?? false),
   );
 
   if (relevantKeys.length === 0) {
     return {
       relevant: false,
-      reason: `the root package.json only changed ${changed.join(", ")}`,
+      reason: `${label} only changed ${changed.join(", ")}`,
     };
   }
 
   return {
     relevant: true,
-    reason: `the root package.json changed ${relevantKeys.join(", ")}`,
+    reason: `${label} changed ${relevantKeys.join(", ")}`,
   };
+}
+
+/**
+ * Can a change to the root `package.json` reach a consumer?
+ *
+ * The root manifest is private and never published, so nothing in it ships
+ * directly — but its dependency and wiring keys shape what every package
+ * builds. Only the key DIFF can tell the two apart, which is why the path-level
+ * `isPublishRelevant` cannot: `scripts` churn (#2970 added `test:links` to two
+ * scripts and cut 1.0.9) looks exactly like a `devDependencies` bump.
+ *
+ * @param {string | null | undefined} beforeText
+ * @param {string | null | undefined} afterText
+ * @returns {{ relevant: boolean; reason: string }}
+ */
+export function classifyRootManifestChange(beforeText, afterText) {
+  return classifyManifestChange(beforeText, afterText, {
+    label: "the root package.json",
+    irrelevantKeys: IRRELEVANT_ROOT_MANIFEST_KEYS,
+  });
+}
+
+/**
+ * Can a change to a PACKAGE's `package.json` reach a consumer?
+ *
+ * Same reasoning as the root manifest, one level down (#3023): #3006 edited
+ * `remote-react-components`' `scripts` (a `--project=unit` glob) and cut 1.0.12
+ * with an empty changelog.
+ *
+ * @param {string | null | undefined} beforeText
+ * @param {string | null | undefined} afterText
+ * @param {string} [path] Named in the reason, so a run says WHICH manifest.
+ * @returns {{ relevant: boolean; reason: string }}
+ */
+export function classifyPackageManifestChange(
+  beforeText,
+  afterText,
+  path = "a package.json",
+) {
+  return classifyManifestChange(beforeText, afterText, {
+    label: path,
+    irrelevantKeys: IRRELEVANT_PACKAGE_MANIFEST_KEYS,
+    stillRelevant: (key, before, after) =>
+      key === "scripts" && scriptsReachAConsumer(before, after),
+  });
 }
 
 /** Does `path` name a package manifest? */
@@ -191,12 +337,13 @@ function isManifest(path) {
  * (unreachable `before` sha, a force push, a compare response we could not
  * read), and the answer is then "publish" — the behaviour before #2931.
  *
- * Two paths are refined beyond `isPublishRelevant`, because for them the path
- * alone carries no information (#2970, #2959):
+ * Two kinds of path are refined beyond `isPublishRelevant`, because for them
+ * the path alone carries no information (#2970, #2959, #3023):
  *
- * - **`package.json`** (root) — relevant only per `options.rootManifestRelevant`,
- *   which the caller derives from the key diff via
- *   `classifyRootManifestChange`. Unknown (`undefined`) stays relevant.
+ * - **every `package.json`** — relevant per `options.manifestRelevance[path]`,
+ *   which the caller derives from that manifest's key diff via
+ *   `classifyRootManifestChange` / `classifyPackageManifestChange`. Unknown
+ *   (missing or `undefined`) stays relevant.
  * - **`pnpm-lock.yaml`** — a DERIVED file: it is relevant when the manifest that
  *   moved it is. So it follows the manifests in the same push, and drops out
  *   only when at least one manifest changed and none of them is relevant. A
@@ -204,7 +351,7 @@ function isManifest(path) {
  *   stays relevant — nothing in the path list explains it.
  *
  * @param {string[]} paths Changed files, repository-relative.
- * @param {{ rootManifestRelevant?: boolean }} [options]
+ * @param {{ manifestRelevance?: Record<string, boolean | undefined> }} [options]
  * @returns {{
  *   publish: boolean;
  *   reason: string;
@@ -236,11 +383,12 @@ export function classifyChangedFiles(paths, options = {}) {
 
   let relevant = files.filter(isPublishRelevant);
 
-  // The root manifest first: the lockfile rule below reads the REFINED
-  // relevance of the manifests, not the path-level one.
-  if (options.rootManifestRelevant === false) {
-    relevant = relevant.filter((path) => path !== "package.json");
-  }
+  // The manifests first: the lockfile rule below reads their REFINED relevance,
+  // not the path-level one.
+  const manifestRelevance = options.manifestRelevance ?? {};
+  relevant = relevant.filter(
+    (path) => !isManifest(path) || manifestRelevance[path] !== false,
+  );
 
   const manifests = files.filter(isManifest);
   const relevantManifests = manifests.filter((path) => relevant.includes(path));

--- a/.github/scripts/release-relevance-lib.test.mjs
+++ b/.github/scripts/release-relevance-lib.test.mjs
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import {
   isPublishRelevant,
   classifyChangedFiles,
+  classifyPackageManifestChange,
   classifyRootManifestChange,
 } from "./release-relevance-lib.mjs";
 
@@ -61,6 +62,35 @@ test("isPublishRelevant: Markdown INSIDE packages is relevant", () => {
   assert.equal(isPublishRelevant("packages/components/MIGRATION.md"), true);
 });
 
+test("isPublishRelevant: package-local paths without consumer effect", () => {
+  for (const path of [
+    "packages/components/.storybook/main.ts",
+    "packages/components/.storybook/preview.tsx",
+    "packages/components/Dockerfile",
+    "packages/components/.dockerignore",
+    "packages/remote-react-components/e2e/cross-version/vitest.config.ts",
+    "packages/remote-react-components/src/tests/visual/Accordion.browser.test.tsx",
+    "packages/components/src/components/List/stories/Default.stories.tsx",
+    "packages/components/src/components/Button/Button.browser.test.tsx",
+    "packages/codemods/src/tests/install.test.ts",
+  ]) {
+    assert.equal(isPublishRelevant(path), false, path);
+  }
+});
+
+test("isPublishRelevant: a package's own dev/ IS a build input", () => {
+  // #3023 proposed skipping `packages/*/dev/**`. It cannot be skipped: these
+  // shape `dist` — vite plugins in the build config, generators writing shipped
+  // assets, and the one that writes the published MIGRATION.md.
+  for (const path of [
+    "packages/components/dev/vite/flowComponentsLayerPlugin.ts",
+    "packages/components/dev/component-index/buildComponentIndex.ts",
+    "packages/codemods/dev/generate/migrationGuide.ts",
+  ]) {
+    assert.equal(isPublishRelevant(path), true, path);
+  }
+});
+
 test("isPublishRelevant: build wiring and dependencies stay relevant", () => {
   for (const path of [
     "package.json",
@@ -104,6 +134,42 @@ test("classifyChangedFiles: docs-only and CI-only pushes do not publish", () => 
   );
   // #2873 "chore(docs): correct lint git hook to pre-push" → 0.2.0-alpha.1049
   assert.equal(classifyChangedFiles(["AGENTS.md"]).publish, false);
+});
+
+test("classifyChangedFiles: Storybook- and image-only pushes do not publish", () => {
+  // #3010 "build(components): use the next-themes client entry in Storybook"
+  // → 1.0.14
+  assert.equal(
+    classifyChangedFiles(["packages/components/.storybook/preview.tsx"])
+      .publish,
+    false,
+  );
+  // #3008 "ci: build the preview apps in CI and let the image only package
+  // them" → its packages/ half was the Storybook image alone
+  assert.equal(
+    classifyChangedFiles([
+      ".github/workflows/build-previews.yml",
+      "apps/docs/Dockerfile",
+      "packages/components/Dockerfile",
+      "packages/components/.dockerignore",
+    ]).publish,
+    false,
+  );
+});
+
+test("classifyChangedFiles: a docs-only dependency patch still publishes", () => {
+  // #3020 patched `@mfalkenberg/react-live-ssr`, an apps/docs dependency, and
+  // cut 1.1.5. Ruling that out needs the lockfile's importer graph, so the
+  // path-level fail-safe stands — asserted so the gap stays deliberate.
+  assert.equal(
+    classifyChangedFiles([
+      "apps/docs/src/components/LiveExample.tsx",
+      "patches/@mfalkenberg__react-live-ssr@4.1.7.patch",
+      "pnpm-workspace.yaml",
+      "pnpm-lock.yaml",
+    ]).publish,
+    true,
+  );
 });
 
 test("classifyChangedFiles: a mixed push publishes", () => {
@@ -221,20 +287,119 @@ test("classifyChangedFiles: a scripts-only root manifest does not publish", () =
       ".github/workflows/test.yml",
       "package.json",
     ],
-    { rootManifestRelevant: false },
+    { manifestRelevance: { "package.json": false } },
   );
   assert.equal(result.publish, false);
   assert.deepEqual(result.relevant, []);
 });
 
 test("classifyChangedFiles: an unclassified root manifest still publishes", () => {
-  for (const options of [undefined, {}, { rootManifestRelevant: true }]) {
+  for (const options of [
+    undefined,
+    {},
+    { manifestRelevance: { "package.json": true } },
+  ]) {
     assert.equal(
       classifyChangedFiles(["apps/docs/a.mdx", "package.json"], options)
         .publish,
       true,
     );
   }
+});
+
+test("classifyPackageManifestChange: a scripts-only change is irrelevant", () => {
+  // #3006 edited remote-react-components' `--project=unit` glob and cut 1.0.12.
+  const before = JSON.stringify({
+    name: "@mittwald/flow-remote-react-components",
+    scripts: { "test:unit": "vitest run --project=unit" },
+  });
+  const after = JSON.stringify({
+    name: "@mittwald/flow-remote-react-components",
+    scripts: { "test:unit": "vitest run --project=unit*" },
+  });
+  const result = classifyPackageManifestChange(
+    before,
+    after,
+    "packages/remote-react-components/package.json",
+  );
+  assert.equal(result.relevant, false);
+  assert.match(result.reason, /packages\/remote-react-components/);
+});
+
+test("classifyPackageManifestChange: install scripts DO reach a consumer", () => {
+  // The tarball carries `scripts`; only the install lifecycle runs on a
+  // consumer's machine. No Flow package has one today — the guard is for the
+  // day one appears.
+  for (const name of ["preinstall", "install", "postinstall", "prepare"]) {
+    const result = classifyPackageManifestChange(
+      JSON.stringify({ scripts: { build: "vite build" } }),
+      JSON.stringify({ scripts: { build: "vite build", [name]: "node x.js" } }),
+      "packages/components/package.json",
+    );
+    assert.equal(result.relevant, true, name);
+    assert.match(result.reason, /scripts/);
+  }
+});
+
+test("classifyPackageManifestChange: everything else stays relevant", () => {
+  const base = { name: "@mittwald/flow-react-components", version: "1.1.0" };
+  for (const change of [
+    { dependencies: { react: "^19" } },
+    { peerDependencies: { react: "^19" } },
+    { devDependencies: { vite: "^8" } },
+    { exports: { ".": "./dist/js/default.mjs" } },
+    { files: ["dist"] },
+    { version: "1.1.1" },
+    { sideEffects: false },
+    { somethingBrandNew: true },
+  ]) {
+    const result = classifyPackageManifestChange(
+      JSON.stringify(base),
+      JSON.stringify({ ...base, ...change }),
+      "packages/components/package.json",
+    );
+    assert.equal(result.relevant, true, Object.keys(change)[0]);
+  }
+  // Unreadable content fails safe, like the root manifest.
+  assert.equal(
+    classifyPackageManifestChange("not json", "{}", "packages/x/package.json")
+      .relevant,
+    true,
+  );
+});
+
+test("classifyChangedFiles: a scripts-only package manifest does not publish", () => {
+  // #3006 → 1.0.12: a CI change whose packages/ half was a scripts edit, a
+  // non-shipped Markdown file, dev/ tooling and the visual suite.
+  const result = classifyChangedFiles(
+    [
+      ".github/workflows/test.yml",
+      "packages/remote-react-components/package.json",
+      "packages/remote-react-components/e2e/cross-version/harness.ts",
+      "packages/remote-react-components/src/tests/visual/Accordion.browser.test.tsx",
+    ],
+    {
+      manifestRelevance: {
+        "packages/remote-react-components/package.json": false,
+      },
+    },
+  );
+  assert.equal(result.publish, false);
+  assert.deepEqual(result.relevant, []);
+});
+
+test("classifyChangedFiles: a mixed push with a skipped manifest publishes", () => {
+  const result = classifyChangedFiles(
+    [
+      "packages/components/package.json",
+      "packages/components/src/components/Button/Button.tsx",
+    ],
+    { manifestRelevance: { "packages/components/package.json": false } },
+  );
+  assert.equal(result.publish, true);
+  assert.deepEqual(result.relevant, [
+    "packages/components/src/components/Button/Button.tsx",
+  ]);
 });
 
 test("classifyChangedFiles: a lockfile follows the manifests that moved it", () => {
@@ -253,13 +418,13 @@ test("classifyChangedFiles: a lockfile follows the manifests that moved it", () 
   // The root manifest counts as a manifest — and only when it is relevant.
   assert.equal(
     classifyChangedFiles(["package.json", "pnpm-lock.yaml"], {
-      rootManifestRelevant: false,
+      manifestRelevance: { "package.json": false },
     }).publish,
     false,
   );
   assert.equal(
     classifyChangedFiles(["package.json", "pnpm-lock.yaml"], {
-      rootManifestRelevant: true,
+      manifestRelevance: { "package.json": true },
     }).publish,
     true,
   );

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -133,25 +133,33 @@ jobs:
             files=""
           fi
 
-          # The root `package.json` is judged by its KEY DIFF, not its path: a
-          # `scripts` edit cannot reach a tarball, a `devDependencies` bump can,
-          # and the path cannot tell them apart (#2970). Fetch both versions so
-          # the classifier can compare them. A failed fetch leaves the file
+          # EVERY changed `package.json` is judged by its KEY DIFF, not its
+          # path: a `scripts` edit cannot reach a consumer, a dependency bump
+          # can, and the path cannot tell them apart (#2970 for the root
+          # manifest, #3023 for the package ones). Fetch both versions of each
+          # so the classifier can compare them. A failed fetch leaves the file
           # missing, which the guard reads as "relevant" — the behaviour before.
-          if printf '%s\n' "$files" | grep -qx 'package.json'; then
-            for side in BEFORE AFTER; do
-              if [ "$side" = AFTER ]; then ref="${AFTER}"; else ref="${BEFORE}"; fi
-              target="${RUNNER_TEMP}/root-package.${side}.json"
-              if gh api "repos/${REPO}/contents/package.json?ref=${ref}" \
+          #
+          # The pair is named after the path with `/` replaced by `__`, the
+          # layout `release-relevance-guard.mjs` expects under MANIFEST_DIR.
+          manifest_dir="${RUNNER_TEMP}/manifests"
+          mkdir -p "$manifest_dir"
+
+          for manifest in $(printf '%s\n' "$files" \
+            | grep -E '(^|/)package\.json$' || true); do
+            slug="${manifest//\//__}"
+            for side in before after; do
+              if [ "$side" = after ]; then ref="${AFTER}"; else ref="${BEFORE}"; fi
+              target="${manifest_dir}/${slug}.${side}.json"
+              if ! gh api "repos/${REPO}/contents/${manifest}?ref=${ref}" \
                 --header 'Accept: application/vnd.github.raw+json' \
                 > "$target"; then
-                export "ROOT_MANIFEST_${side}_FILE=${target}"
-              else
-                echo "::warning::Could not fetch the root package.json at ${ref}."
+                echo "::warning::Could not fetch ${manifest} at ${ref}."
                 rm -f "$target"
               fi
             done
-          fi
+          done
+          export MANIFEST_DIR="$manifest_dir"
 
           printf '%s\n' "$files" \
             | node .github/scripts/release-relevance-guard.mjs

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -68,32 +68,67 @@ flowchart LR
   preset's template itself), and the guard then aborts `lerna version`. Re-check
   on the next Lerna-Lite major.
 - **Not every merge releases.** A push to a release line only publishes when it
-  carries a change that can reach a **published package**. Docs-, CI- and
-  repo-tooling-only merges (`apps/**`, `docs/**`, `.github/**`, `dev/**`, root
-  Markdown and editor config) are skipped whole: no npm publish, no
-  `chore(release):` version bump commit, no tag, no GitHub Release (#2931). The
-  decision is made by the `decide` job in `publish.yml`, which classifies the
-  pushed file set with `.github/scripts/release-relevance-lib.mjs`. Two
-  properties matter when you touch that list:
-  - It is a **denylist** — anything not provably docs/CI/tooling counts as
-    publishable. Forgetting a docs path costs one needless version; forgetting a
-    source path would silently swallow a real release. So `packages/**` is
-    relevant wholesale, Markdown included: `@mittwald/flow-react-components`
-    ships `AGENTS.md`, `MIGRATION.md` and `USAGE.md` next to `dist`.
-  - **Two files are judged by content, not by path**, because for them the path
-    carries no information:
+  carries a change that can reach a **consumer** of a published package. Docs-,
+  CI- and repo-tooling-only merges (`apps/**`, `docs/**`, `.github/**`,
+  `dev/**`, root Markdown and editor config) are skipped whole: no npm publish,
+  no `chore(release):` version bump commit, no tag, no GitHub Release (#2931).
+  The decision is made by the `decide` job in `publish.yml`, which classifies
+  the pushed file set with `.github/scripts/release-relevance-lib.mjs`. What
+  matters when you touch that list:
+  - It is a **denylist** — anything not provably without consumer effect counts
+    as publishable. Forgetting a docs path costs one needless version;
+    forgetting a source path would silently swallow a real release. So
+    `packages/**` is relevant wholesale, Markdown included:
+    `@mittwald/flow-react-components` ships `AGENTS.md`, `MIGRATION.md` and
+    `USAGE.md` next to `dist`.
+  - The criterion is **consumer effect, not tarball membership** (#3023). The
+    two diverge in both directions, and only the first one decides: a tarball
+    carries the package's `scripts`, yet nothing but the install lifecycle runs
+    on a consumer's machine.
+  - **Every `package.json` is judged by content, not by path**, and so is the
+    lockfile — for them the path carries no information:
     - Root **`package.json`** — a `scripts` or `simple-git-hooks` edit cannot
-      reach a tarball, a `devDependencies` bump can. The `decide` job fetches
+      reach a consumer, a `devDependencies` bump can. The `decide` job fetches
       both versions and compares the top-level keys; an unknown key is relevant
       like an unknown path is. #2970 added `test:links` to two scripts and cut
       1.0.9.
+    - A **package's `package.json`** — same rule one level down, with `scripts`
+      as the only irrelevant key, and only while the diff leaves
+      `preinstall`/`install`/`postinstall`/`prepare` alone. #3006 edited
+      `remote-react-components`' `--project=unit` glob and cut 1.0.12.
     - **`pnpm-lock.yaml`** — a derived file, relevant when the manifest that
       moved it is. It follows the manifests in the same push and drops out only
       when at least one changed and none of them is publish-relevant. Lock churn
       with NO manifest change (a dedupe, a resolution refresh) stays relevant.
       #2959 bumped an `apps/docs` dependency and cut 1.0.4.
+  - **Package-local paths without consumer effect are carved out** of the
+    wholesale `packages/**` rule: `.storybook/**`, the Storybook image's
+    `Dockerfile` / `.dockerignore`, `e2e/**`, `src/tests/**`, and any
+    `*.stories.*` or `*.test.*`. #3010 cut 1.0.14 through the Storybook config,
+    #3008 pushed the image.
+  - A package's own **`dev/` directory is NOT carved out**, although #3023
+    proposed it. It is a build input: `components/dev/vite/*` is imported by
+    `vite.build.config.ts` and shapes the emitted CSS layers,
+    `dev/component-index` and `dev/status-registry` generate shipped `dist`
+    assets, and `codemods/dev/generate` writes the published `MIGRATION.md`.
+    Skipping it would swallow real releases.
+  - **One gap is knowingly left open:** a `patches/**` entry (with its
+    `pnpm-workspace.yaml` line) for a dependency that only a private workspace
+    project imports still publishes. #3020 patched
+    `@mfalkenberg/react-live-ssr`, an `apps/docs` dependency, and cut 1.1.5.
+    Ruling that out needs the lockfile's importer graph including transitive
+    edges, where a wrong answer swallows a real release — so the path-level
+    fail-safe stands and the occasional needless version is the cheaper error.
   - A **`workflow_dispatch` run always publishes.** That is the escape hatch
     when a docs-only change has to go out as a release anyway.
+- **Tests and stories stay out of `dist/types`.** `unplugin-dts` emits
+  declarations for everything its `include` matches, so `include: ["src"]` used
+  to drag `*.stories.d.ts` and whole test suites into the tarball — 196 of
+  `@mittwald/flow-remote-react-components@1.1.10`'s 799 entries. Every release
+  build now shares `publishedDtsOptions` from `packages/core`, whose `exclude`
+  drops them. The globs cannot live in the shared tsconfig preset instead: its
+  `exclude` also governs `tsc --noEmit`, and that would stop type-checking the
+  tests.
 - **The build runs after the version bump.** Both publish workflows version
   first, then `pnpm build`, then publish. Some bundles bake their own version in
   at build time (vite `define` over `package.json` — `remote-react-components`'

--- a/packages/components/vite.build.config.ts
+++ b/packages/components/vite.build.config.ts
@@ -5,7 +5,7 @@ import { defineConfig, mergeConfig } from "vite";
 import { flowComponentsLayerPlugin } from "./dev/vite/flowComponentsLayerPlugin.ts";
 import { layerOrderPlugin } from "./dev/vite/layerOrderPlugin.ts";
 import { stylesheetVariantsPlugin } from "./dev/vite/stylesheetVariantsPlugin.ts";
-import { preserveUseClientBanner } from "../core";
+import { preserveUseClientBanner, publishedDtsOptions } from "../core";
 
 export default mergeConfig(
   baseConfig,
@@ -65,10 +65,7 @@ export default mergeConfig(
       externalizeDeps({
         except: ["@mittwald/flow-design-tokens/**/*", "@mittwald/flow-core"],
       }),
-      dts({
-        include: ["src"],
-        outDirs: "dist/types",
-      }),
+      dts(publishedDtsOptions),
     ],
   }),
 );

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./preserveUseClientBanner";
+export * from "./publishedDtsOptions";
 export * from "./vitestBrowserTestConfig";

--- a/packages/core/src/publishedDtsOptions.ts
+++ b/packages/core/src/publishedDtsOptions.ts
@@ -1,0 +1,37 @@
+/**
+ * The `unplugin-dts` options every package's release build shares.
+ *
+ * `include: ["src"]` alone emits declarations for ALL of `src` — stories and
+ * tests with it. Those are dead files: no `exports` path reaches them, nothing
+ * imports them, and they made up 196 of the 799 entries in
+ * `@mittwald/flow-remote-react-components@1.1.10` (#3023). `exclude` keeps them
+ * out, which also lets the release-relevance guard skip a test-only change
+ * honestly instead of arguing about tarball membership
+ * (`.github/scripts/release-relevance-lib.mjs`).
+ *
+ * The globs match story and test FILES, not the directories around them. A
+ * helper beside a story stays: `dev/createDocPropertiesJson.ts` parses every
+ * `.tsx` under `src/` and ignores only `*.stories.tsx`, so
+ * `components/Button/stories/lib.tsx` really does contribute to the published
+ * `dist/assets/doc-properties.json` — five of its entries. Keep this list and
+ * the guard's denylist in step; they answer the same question.
+ *
+ * The globs cannot move into the shared tsconfig preset instead: its `exclude`
+ * governs `tsc --noEmit` too, and dropping tests from `test:compile` would stop
+ * type-checking the largest surface in the repository.
+ *
+ * `exclude` REPLACES the tsconfig's own list rather than extending it, so
+ * `node_modules` and `dist` are repeated here.
+ */
+export const publishedDtsOptions = {
+  include: ["src"],
+  exclude: [
+    "node_modules/**",
+    "dist/**",
+    "**/tests/**",
+    "**/e2e/**",
+    "**/*.stories.*",
+    "**/*.test.*",
+  ],
+  outDirs: "dist/types",
+};

--- a/packages/ext-bridge/package.json
+++ b/packages/ext-bridge/package.json
@@ -47,6 +47,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@mittwald/flow-core": "workspace:*",
     "@mittwald/typescript-config": "workspace:*",
     "@types/node": "^25.9.3",
     "@types/react": "^19.2",

--- a/packages/ext-bridge/vite.build.config.ts
+++ b/packages/ext-bridge/vite.build.config.ts
@@ -3,6 +3,7 @@ import { defineConfig, mergeConfig } from "vite";
 import dts from "unplugin-dts/vite";
 import { externalizeDeps } from "vite-plugin-externalize-deps";
 import baseConfig from "./vite.config";
+import { publishedDtsOptions } from "../core";
 
 export default mergeConfig(
   baseConfig,
@@ -10,10 +11,7 @@ export default mergeConfig(
     plugins: [
       preserveDirectives(),
       externalizeDeps(),
-      dts({
-        include: ["src"],
-        outDirs: "dist/types",
-      }),
+      dts(publishedDtsOptions),
     ],
     build: {
       minify: false,

--- a/packages/mstudio-ext-react-components/vite.build.config.ts
+++ b/packages/mstudio-ext-react-components/vite.build.config.ts
@@ -1,7 +1,7 @@
 import preserveDirectives from "rollup-preserve-directives";
 import { defineConfig, mergeConfig } from "vite";
 import dts from "unplugin-dts/vite";
-import { preserveUseClientBanner } from "../core";
+import { preserveUseClientBanner, publishedDtsOptions } from "../core";
 import { externalizeDeps } from "vite-plugin-externalize-deps";
 import baseConfig from "./vite.config";
 
@@ -32,10 +32,7 @@ export default mergeConfig(
     plugins: [
       preserveDirectives(),
       externalizeDeps(),
-      dts({
-        include: ["src"],
-        outDirs: "dist/types",
-      }),
+      dts(publishedDtsOptions),
     ],
   }),
 );

--- a/packages/react-tunnel/vite.build.config.ts
+++ b/packages/react-tunnel/vite.build.config.ts
@@ -1,18 +1,12 @@
 import { defineConfig, mergeConfig } from "vite";
-import { preserveUseClientBanner } from "../core";
+import { preserveUseClientBanner, publishedDtsOptions } from "../core";
 import dts from "unplugin-dts/vite";
 import baseConfig from "./vite.config";
 import { externalizeDeps } from "vite-plugin-externalize-deps";
 
 export default defineConfig(
   mergeConfig(baseConfig, {
-    plugins: [
-      externalizeDeps(),
-      dts({
-        include: ["src"],
-        outDirs: "dist/types",
-      }),
-    ],
+    plugins: [externalizeDeps(), dts(publishedDtsOptions)],
     build: {
       emptyOutDir: false,
       lib: {

--- a/packages/remote-core/package.json
+++ b/packages/remote-core/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "@mittwald/ext-bridge": "workspace:*",
+    "@mittwald/flow-core": "workspace:*",
     "@mittwald/flow-react-components": "workspace:*",
     "@mittwald/typescript-config": "workspace:*",
     "@types/node": "^25.9.3",

--- a/packages/remote-core/vite.build.config.ts
+++ b/packages/remote-core/vite.build.config.ts
@@ -3,6 +3,7 @@ import { defineConfig, mergeConfig } from "vite";
 import dts from "unplugin-dts/vite";
 import { externalizeDeps } from "vite-plugin-externalize-deps";
 import baseConfig from "./vite.config";
+import { publishedDtsOptions } from "../core";
 
 export default mergeConfig(
   baseConfig,
@@ -12,10 +13,7 @@ export default mergeConfig(
       externalizeDeps({
         except: ["@quilted/threads"],
       }),
-      dts({
-        include: ["src"],
-        outDirs: "dist/types",
-      }),
+      dts(publishedDtsOptions),
     ],
 
     build: {

--- a/packages/remote-elements/package.json
+++ b/packages/remote-elements/package.json
@@ -32,6 +32,7 @@
     "type-fest": "^5.7.0"
   },
   "devDependencies": {
+    "@mittwald/flow-core": "workspace:*",
     "@mittwald/flow-react-components": "workspace:*",
     "@mittwald/typescript-config": "workspace:*",
     "@types/node": "^25.9.3",

--- a/packages/remote-elements/vite.build.config.ts
+++ b/packages/remote-elements/vite.build.config.ts
@@ -3,6 +3,7 @@ import { defineConfig, mergeConfig } from "vite";
 import dts from "unplugin-dts/vite";
 import { externalizeDeps } from "vite-plugin-externalize-deps";
 import baseConfig from "./vite.config";
+import { publishedDtsOptions } from "../core";
 
 export default mergeConfig(
   baseConfig,
@@ -10,10 +11,7 @@ export default mergeConfig(
     plugins: [
       preserveDirectives(),
       externalizeDeps(),
-      dts({
-        include: ["src"],
-        outDirs: "dist/types",
-      }),
+      dts(publishedDtsOptions),
     ],
     build: {
       minify: false,

--- a/packages/remote-react-components/vite.build.config.ts
+++ b/packages/remote-react-components/vite.build.config.ts
@@ -1,6 +1,6 @@
 import preserveDirectives from "rollup-preserve-directives";
 import { mergeConfig } from "vite";
-import { preserveUseClientBanner } from "../core";
+import { preserveUseClientBanner, publishedDtsOptions } from "../core";
 import dts from "unplugin-dts/vite";
 import { externalizeDeps } from "vite-plugin-externalize-deps";
 import baseConfig from "./vite.config";
@@ -29,12 +29,5 @@ export default mergeConfig(baseConfig, {
       },
     },
   },
-  plugins: [
-    preserveDirectives(),
-    externalizeDeps(),
-    dts({
-      include: ["src"],
-      outDirs: "dist/types",
-    }),
-  ],
+  plugins: [preserveDirectives(), externalizeDeps(), dts(publishedDtsOptions)],
 });

--- a/packages/remote-react-renderer/vite.build.config.ts
+++ b/packages/remote-react-renderer/vite.build.config.ts
@@ -1,6 +1,6 @@
 import preserveDirectives from "rollup-preserve-directives";
 import { defineConfig, mergeConfig } from "vite";
-import { preserveUseClientBanner } from "../core";
+import { preserveUseClientBanner, publishedDtsOptions } from "../core";
 import dts from "unplugin-dts/vite";
 import { externalizeDeps } from "vite-plugin-externalize-deps";
 import baseConfig from "./vite.config";
@@ -13,10 +13,7 @@ export default mergeConfig(
       externalizeDeps({
         except: [/^@mittwald\/remote-dom-react(?:\/.+)?$/],
       }),
-      dts({
-        include: ["src"],
-        outDirs: "dist/types",
-      }),
+      dts(publishedDtsOptions),
     ],
     build: {
       minify: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -852,6 +852,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@mittwald/flow-core':
+        specifier: workspace:*
+        version: link:../core
       '@mittwald/typescript-config':
         specifier: workspace:*
         version: link:../typescript-config
@@ -1100,6 +1103,9 @@ importers:
       '@mittwald/ext-bridge':
         specifier: workspace:*
         version: link:../ext-bridge
+      '@mittwald/flow-core':
+        specifier: workspace:*
+        version: link:../core
       '@mittwald/flow-react-components':
         specifier: workspace:*
         version: link:../components
@@ -1146,6 +1152,9 @@ importers:
         specifier: ^5.7.0
         version: 5.8.0
     devDependencies:
+      '@mittwald/flow-core':
+        specifier: workspace:*
+        version: link:../core
       '@mittwald/flow-react-components':
         specifier: workspace:*
         version: link:../components


### PR DESCRIPTION
Relevance was decided by repo-**root** paths, so everything under `packages/**` counted as publish-relevant wholesale. Two of the empty-changelog releases in #3023 came from that, and one class the issue does not list came later.

## What no longer publishes

Per PUSH, since that is what the `decide` job classifies:

| Push | What it carried | Version it cut |
| --- | --- | --- |
| #3010 | only `packages/components/.storybook/preview.tsx` | 1.0.14 — would not be cut now |
| #3008 | the Storybook image's `Dockerfile` / `.dockerignore` | folded into 1.0.15, which also carried #3013 (a real change) and would still be cut |

Two cases from #3023's evidence table are **not** closed, and that is deliberate — see "Not in scope":

| Push | Why it still publishes |
| --- | --- |
| #3006 (cut 1.0.12) | its `package.json` `scripts` diff and `src/tests/visual/**` drop out, but `remote-react-components/CONTRIBUTE.md` and `dev/cross-version/crossVersionRunner.ts` stay relevant |
| #3020 (cut 1.1.5) | `patches/` for `@mfalkenberg/react-live-ssr`, a dependency only `apps/docs` imports |

## The change

**The criterion is consumer effect, not tarball membership.** The two differ in both directions, and only the first decides: a tarball carries the package's `scripts`, yet nothing but the install lifecycle runs on a consumer's machine.

- **Package-local denylist:** `.storybook/**`, the Storybook image's `Dockerfile`/`.dockerignore`, `e2e/**`, `src/tests/**`, `*.stories.*`, `*.test.*`.
- **Every `package.json` is judged by its key diff**, not only the root one. `scripts` is irrelevant unless the diff touches `preinstall`, `install`, `postinstall` or `prepare`. No Flow package defines one today — which is exactly why the guard belongs in code and not in someone's memory. The `decide` job now fetches before/after for every changed manifest.
- **`packages/*/dev/**` stays relevant**, although #3023 proposed skipping it. It is a build input: `components/dev/vite/*` is imported by `vite.build.config.ts` and shapes the emitted CSS layers, `dev/component-index` and `dev/status-registry` write shipped `dist/assets/*.json`, and `codemods/dev/generate` writes the published `MIGRATION.md`.
- **A `stories/` directory stays relevant too** — only the story files are skipped. `createDocPropertiesJson.ts` parses every `.tsx` under `src/` and ignores only `*.stories.tsx`, so `components/Button/stories/lib.tsx` contributes five entries to the published `doc-properties.json`.
- **One gap stays open by choice:** a `patches/` entry for a dependency only a private project imports (1.1.5). Ruling it out needs the lockfile's importer graph including transitive edges, where a wrong answer swallows a real release. A test pins the current behaviour so the gap stays deliberate.

**Tests and stories leave `dist/types`.** `unplugin-dts` emitted declarations for all of `src`:

| 1.1.10 | tarball entries | of those stories/tests |
| --- | --- | --- |
| `flow-react-components` | 4160 | 126 `*.stories.d.ts` + 126 maps |
| `flow-remote-react-components` | 799 | 196 under `dist/types/tests/**` |

All eight release builds now share `publishedDtsOptions` from `packages/core`. **No consumer loses a type:** no package's `exports` has a wildcard subpath, so those declarations were unreachable. The globs cannot move into the shared tsconfig preset instead — its `exclude` governs `tsc --noEmit`, and that would stop type-checking the tests.

`@mittwald/flow-core` is now a declared devDependency of `ext-bridge`, `remote-core` and `remote-elements`, which newly import it. That is also the nx graph edge their build cache needs in order to invalidate on a `core` change.

## Verification

- Replayed **every** non-release commit on `main` since #2933 through the changed classifier: #3010 and #3008 flip to no-publish, and no commit that produced a legitimate release flips with them.
- `next` is symmetric — docs-only `chore(sync):` merges produce no `-next.N` bump (#3067, #3064, #3056, #3054 among others).
- 28 classifier tests, `build` and `test:compile` green for all eight touched packages; after the build, story/test declarations in `dist/types` drop from 252+6 to 18 in `components` and from 196 to 2 in `remote-react-components`. The remainder are real source modules the doc-properties generator sees, matching the denylist exactly.
- The `decide` job's shell loop was exercised locally against the no-match case (`set -euo pipefail` plus `grep || true`).

## Not in scope

Tracked in #3083:

- **The type-based half of #3023** — real releases whose changelog reads "Version bump only", because relevance is path-based while the changelog is type-based. Since #3023 was filed, 1.1.5, 1.1.7, 1.1.8 and 1.1.11 joined that list. Needs a `changelogPreset` decision, and an explanation for why 1.1.6 appears in the components changelog while 1.1.1 does not.
- **The relevance residue** — package-local non-shipped Markdown (judged against that package's `files`) and the test-only subdirectories of `dev/`. Those two are why #3006 and #3003 still publish.

Fixes #3023.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
