### PR TITLE
fix(ci): stop publishing on paths that cannot reach a consumer

### DIFF
--- a/.github/scripts/release-relevance-guard.mjs
+++ b/.github/scripts/release-relevance-guard.mjs
@@ -6,19 +6,26 @@
  * Reads the changed-file list on stdin (one repository-relative path per line)
  * and writes `publish=true|false` to $GITHUB_OUTPUT.
  *
- * `ROOT_MANIFEST_BEFORE_FILE` / `ROOT_MANIFEST_AFTER_FILE` optionally point at
- * the two versions of the root `package.json`. They let the classifier judge
- * that manifest by its key diff instead of its path (#2970); without them the
- * root manifest stays relevant, as before.
+ * `MANIFEST_SNAPSHOT_DIR` optionally points at a directory holding both
+ * versions of every changed `package.json` the workflow fetched, as
+ * `<dir>/before/<slug>.json` and `<dir>/after/<slug>.json` with the path's `/`
+ * replaced by `__`. They let the classifier judge a manifest by its key diff
+ * instead of its path (#2970, #3023); a missing snapshot leaves that manifest
+ * relevant, as before.
  *
  * It never fails the run. The decision is a routing choice, not a policy
  * violation: an empty or unreadable input yields `publish=true`, which is the
  * behaviour before #2931.
  */
 import { appendFileSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import {
   classifyChangedFiles,
-  classifyRootManifestChange,
+  classifyManifestChange,
+  packageRootMarkdown,
+  shipsRootMarkdown,
+  classifyPath,
+  isPublishRelevant,
 } from "./release-relevance-lib.mjs";
 
 /** Read all of stdin; an unreadable stdin is an empty list (fail-safe). */
@@ -36,34 +43,77 @@ const files = readStdin()
   .filter((line) => line !== "");
 
 /**
- * The root manifest's two versions, if the workflow fetched them.
+ * One fetched side of one manifest, or `undefined` when it is not there.
  *
- * A missing or unreadable file is `undefined`, which
- * `classifyRootManifestChange` reports as relevant — the behaviour before this
- * refinement.
+ * A missing or unreadable file makes `classifyManifestChange` report the
+ * manifest as relevant — the behaviour before this refinement. A manifest that
+ * was ADDED or DELETED has only one side, and that is exactly the case where
+ * the fail-safe default is what we want.
  *
- * @param {string} variable
+ * @param {string} dir
+ * @param {"before" | "after"} side
+ * @param {string} path
  */
-function readManifest(variable) {
-  const path = process.env[variable];
-  if (!path) return undefined;
+function readManifestSide(dir, side, path) {
+  const file = join(dir, side, `${path.replaceAll("/", "__")}.json`);
   try {
-    return readFileSync(path, "utf8");
+    return readFileSync(file, "utf8");
   } catch {
-    console.log(`::warning::Could not read ${variable} (${path}).`);
     return undefined;
   }
 }
 
-/** @type {{ rootManifestRelevant?: boolean }} */
-const options = {};
-if (files.includes("package.json")) {
-  const manifest = classifyRootManifestChange(
-    readManifest("ROOT_MANIFEST_BEFORE_FILE"),
-    readManifest("ROOT_MANIFEST_AFTER_FILE"),
+/**
+ * Judge every changed `package.json` by its key diff, not by its path.
+ *
+ * The root manifest and each `packages/*` manifest go through the same
+ * function; only the reason names which one.
+ *
+ * @type {{ manifestRelevance: Record<string, boolean> }}
+ */
+const options = { manifestRelevance: {} };
+const snapshotDir = process.env.MANIFEST_SNAPSHOT_DIR;
+const manifests = files.filter(
+  (path) =>
+    (path === "package.json" || path.endsWith("/package.json")) &&
+    // An `apps/*` manifest is already irrelevant by path — refining it would
+    // only log a fail-safe line about a snapshot the workflow never fetches.
+    isPublishRelevant(path),
+);
+
+for (const path of manifests) {
+  const manifest = classifyManifestChange(
+    snapshotDir ? readManifestSide(snapshotDir, "before", path) : undefined,
+    snapshotDir ? readManifestSide(snapshotDir, "after", path) : undefined,
+    path,
   );
-  options.rootManifestRelevant = manifest.relevant;
-  console.log(`Root manifest: ${manifest.reason}.`);
+  options.manifestRelevance[path] = manifest.relevant;
+  console.log(`Manifest: ${manifest.reason}.`);
+}
+
+/**
+ * The `files` of every package whose ROOT Markdown changed.
+ *
+ * Read from the checkout, not fetched: only the CURRENT `files` matters, and
+ * the job already has the tree. An unreadable manifest leaves the entry
+ * undefined, which the classifier reads as "shipped" — fail safe.
+ */
+for (const path of files) {
+  const markdown = packageRootMarkdown(path);
+  if (!markdown || markdown.dir in (options.packageFiles ?? {})) continue;
+  options.packageFiles ??= {};
+  try {
+    const manifest = JSON.parse(
+      readFileSync(join(markdown.dir, "package.json"), "utf8"),
+    );
+    options.packageFiles[markdown.dir] = manifest.files;
+    console.log(
+      `Package files: ${markdown.dir} publishes ${JSON.stringify(manifest.files)}.`,
+    );
+  } catch {
+    console.log(`::warning::Could not read ${markdown.dir}/package.json.`);
+    options.packageFiles[markdown.dir] = undefined;
+  }
 }
 
 const { publish, reason, relevant, total } = classifyChangedFiles(
@@ -93,8 +143,21 @@ if (publish) {
       "This push produces no npm publish, no version bump commit, no tag and " +
       "no GitHub Release. Dispatch this workflow manually to publish anyway.",
   );
-  console.log(`Changed files (${total}):`);
-  for (const path of files.slice(0, SAMPLE)) console.log(`  ${path}`);
+  console.log(`Changed files (${total}), with the rule that cleared each:`);
+  for (const path of files.slice(0, SAMPLE)) {
+    const markdown = packageRootMarkdown(path);
+    const rule =
+      options.manifestRelevance[path] === false
+        ? `manifest key diff "${path}"`
+        : markdown &&
+            !shipsRootMarkdown(
+              markdown.file,
+              options.packageFiles?.[markdown.dir],
+            )
+          ? `package Markdown outside "files"`
+          : classifyPath(path).rule;
+    console.log(`  ${path} — ${rule}`);
+  }
   if (files.length > SAMPLE) {
     console.log(`  … and ${files.length - SAMPLE} more`);
   }

--- a/.github/scripts/release-relevance-lib.mjs
+++ b/.github/scripts/release-relevance-lib.mjs
@@ -2,19 +2,28 @@
 /**
  * Release-relevance classification — pure functions, no git / no IO.
  *
- * Answers one question: can this set of changed files reach a PUBLISHED
- * package's tarball? Docs- and CI-only merges cannot, and must not produce a
+ * Answers one question: can this set of changed files reach a CONSUMER of a
+ * published package? Docs- and CI-only merges cannot, and must not produce a
  * release — no npm publish, no `chore(release):` bump, no tag, no GitHub
  * Release (#2931).
  *
  * The rule is a DENYLIST, and that direction is deliberate. Every published
- * package ships `dist` (plus three `.md` for flow-react-components), so "what
- * ends up in a tarball" spans nearly all of `packages/**` — source, locales,
- * SCSS, tsconfigs, vite configs, generated code. An ALLOWLIST that forgets one
- * of those paths silently swallows a real release. A DENYLIST that forgets a
- * new docs directory merely publishes one needless version — exactly what
- * happens today. So unknown paths are RELEVANT, and only paths that provably
- * cannot reach a tarball are listed below.
+ * package ships `dist` (plus a few top-level `.md`), so "what a consumer gets"
+ * spans nearly all of `packages/**` — source, locales, SCSS, tsconfigs, vite
+ * configs, generated code, build generators. An ALLOWLIST that forgets one of
+ * those paths silently swallows a real release. A DENYLIST that forgets a new
+ * docs directory merely publishes one needless version. So unknown paths are
+ * RELEVANT, and only paths that provably cannot reach a consumer are listed
+ * below.
+ *
+ * The criterion is CONSUMER EFFECT, not tarball membership. A tarball carries
+ * `scripts` and a `.d.ts` per story and test file; no consumer installs,
+ * imports or runs any of them.
+ *
+ * Relevance is decided by PATH, never by commit TYPE: `chore(deps):` and
+ * `refactor:` routinely change what consumers resolve, so a type gate would
+ * swallow real releases (#2931, #3023). What the changelog SAYS about those
+ * releases is a separate axis — `lerna.json`'s `changelogPreset`.
  */
 
 /**
@@ -48,7 +57,7 @@ const IRRELEVANT_PREFIXES = [
  * `package.json` and `pnpm-lock.yaml` are relevant only CONDITIONALLY, because
  * for those two the path alone says nothing (#2970, #2959). `isPublishRelevant`
  * still reports both as relevant — the refinement lives in
- * `classifyChangedFiles`, which sees the whole changed set and the root
+ * `classifyChangedFiles`, which sees the whole changed set and every changed
  * manifest's key diff.
  */
 const IRRELEVANT_ROOT_FILES = new Set([
@@ -62,29 +71,141 @@ const IRRELEVANT_ROOT_FILES = new Set([
 ]);
 
 /**
- * Can a change to `path` reach a published package's tarball?
+ * Package-local directories whose contents cannot affect a consumer (#3023).
  *
- * Note that `packages/**` is relevant WHOLESALE, Markdown included:
+ * Matched under `packages/<name>/`, segment-exact — `e2e-helpers/` is not
+ * `e2e/`. Every published package ships `dist` plus a few top-level `.md` (the
+ * `every published package ships …` test guards that), and none of these
+ * directories is reachable from a build entry:
+ *
+ * - `.storybook/` — Storybook's own config. #3010 changed only
+ *   `.storybook/preview.tsx` and cut 1.0.14.
+ * - `e2e/` — the remote-test-server and cross-version harnesses.
+ * - `src/tests/` — cross-package test sources, incl. the visual suite and its
+ *   screenshot baselines.
+ * - `dev/cross-version/`, `dev/vitest/` — the cross-version runner and the vitest
+ *   setup files. #3006 changed `dev/cross-version/**`, `src/tests/visual/**`, a
+ *   `CONTRIBUTE.md` and two npm scripts, and cut 1.0.12.
+ *
+ * `packages/*\/dev/` is deliberately NOT here wholesale, although #3023
+ * proposed it: in `components` and `codemods` that directory IS the build.
+ * `dev/vite/*` holds the PostCSS/rollup plugins `vite.build.config.ts` imports,
+ * `dev/createDocPropertiesJson.ts` writes the shipped
+ * `dist/assets/doc-properties.json`, `dev/remote-components-generator/**`
+ * generates `view.ts` and `src/auto-generated/**`, and `codemods`' whole build
+ * script is `tsx dev/generateCli.ts && …`. Denylisting `dev/` would swallow
+ * those releases — the one failure mode this direction exists to prevent.
+ */
+const IRRELEVANT_PACKAGE_LOCAL_DIRS = [
+  ".storybook",
+  "e2e",
+  "src/tests",
+  "dev/cross-version",
+  "dev/vitest",
+];
+
+/**
+ * Package-local files that cannot affect a consumer.
+ *
+ * `CONTRIBUTE.md` is contributor documentation and no package lists it in
+ * `files`; npm force-includes only `README`, `LICENSE` and `package.json`. The
+ * shipped Markdown (`AGENTS.md`, `MIGRATION.md`, `USAGE.md`, `README.md`) stays
+ * relevant — it really is part of the tarball.
+ */
+const IRRELEVANT_PACKAGE_LOCAL_FILES = new Set([
+  "CONTRIBUTE.md",
+  // The Storybook preview image, built by CI from `dev/` and `.github/`. #3008
+  // pushed both of these and nothing else under `packages/`.
+  "Dockerfile",
+  ".dockerignore",
+]);
+
+/**
+ * Filenames that cannot affect a consumer, wherever they sit.
+ *
+ * Stories and tests are never reachable from a build entry — the component
+ * bundle is built from the explicit entry list in `vite.build.config.ts` with
+ * `preserveModules`. `unplugin-dts` does emit a `.d.ts` for every file under
+ * `src`, stories and tests included, so these DO land in the tarball; no
+ * `exports` path reaches them, so no consumer can. Same argument as for
+ * `scripts` in a manifest: no consumer effect, not "not in the tarball".
+ *
+ * `.test.` is not always the last extension — the remote e2e specs are
+ * `*.browser.test.remote.tsx`.
+ */
+const IRRELEVANT_FILENAME_PATTERNS = [
+  { label: "*.stories.tsx", pattern: /\.stories\.tsx$/ },
+  { label: "*.test.*", pattern: /\.test\.[^/]+$/ },
+];
+
+/** The path below `packages/<name>/`, or `undefined` outside a package. */
+function packageLocalPath(path) {
+  const match = /^packages\/[^/]+\/(.+)$/.exec(path);
+  return match?.[1];
+}
+
+/**
+ * Can a change to `path` reach a consumer — and which rule decided?
+ *
+ * The `rule` is what the run's `::notice::` prints, so a skipped release says
+ * WHY without anyone re-deriving it from the file list (#3023).
+ *
+ * Note that package-local Markdown is relevant unless listed above:
  * `@mittwald/flow-react-components` ships `AGENTS.md`, `MIGRATION.md` and
- * `USAGE.md` next to `dist`, so a package-local `.md` really can be part of the
- * published artifact. Only Markdown OUTSIDE `packages/` (root `README.md`,
- * `AGENTS.md`, `CHANGELOG.md`, …) is irrelevant.
+ * `USAGE.md` next to `dist`, so it really can be part of the published
+ * artifact. Markdown OUTSIDE `packages/` (root `README.md`, `AGENTS.md`,
+ * `CHANGELOG.md`, …) is irrelevant.
+ *
+ * @param {string} path Repository-relative, forward-slash separated.
+ * @returns {{ relevant: boolean; rule: string }}
+ */
+export function classifyPath(path) {
+  const p = path.trim();
+  if (p === "") return { relevant: false, rule: "empty path" };
+
+  const prefix = IRRELEVANT_PREFIXES.find((candidate) =>
+    p.startsWith(candidate),
+  );
+  if (prefix) return { relevant: false, rule: `top-level "${prefix}"` };
+
+  const filename = IRRELEVANT_FILENAME_PATTERNS.find(({ pattern }) =>
+    pattern.test(p),
+  );
+  if (filename)
+    return { relevant: false, rule: `filename "${filename.label}"` };
+
+  if (!p.includes("/")) {
+    if (IRRELEVANT_ROOT_FILES.has(p)) {
+      return { relevant: false, rule: `root file "${p}"` };
+    }
+    if (p.endsWith(".md")) return { relevant: false, rule: "root Markdown" };
+    return { relevant: true, rule: "not provably non-shipping" };
+  }
+
+  const local = packageLocalPath(p);
+  if (local !== undefined) {
+    const dir = IRRELEVANT_PACKAGE_LOCAL_DIRS.find((candidate) =>
+      local.startsWith(`${candidate}/`),
+    );
+    if (dir) {
+      return { relevant: false, rule: `package-local "packages/*/${dir}/"` };
+    }
+    if (IRRELEVANT_PACKAGE_LOCAL_FILES.has(local)) {
+      return { relevant: false, rule: `package-local "packages/*/${local}"` };
+    }
+  }
+
+  return { relevant: true, rule: "not provably non-shipping" };
+}
+
+/**
+ * Can a change to `path` reach a consumer?
  *
  * @param {string} path Repository-relative, forward-slash separated.
  * @returns {boolean}
  */
 export function isPublishRelevant(path) {
-  const p = path.trim();
-  if (p === "") return false;
-
-  if (IRRELEVANT_PREFIXES.some((prefix) => p.startsWith(prefix))) return false;
-
-  const isRootFile = !p.includes("/");
-  if (isRootFile && (IRRELEVANT_ROOT_FILES.has(p) || p.endsWith(".md"))) {
-    return false;
-  }
-
-  return true;
+  return classifyPath(path).relevant;
 }
 
 /**
@@ -105,33 +226,50 @@ function looksLikePath(line) {
 }
 
 /**
- * Root-`package.json` keys whose change cannot reach any tarball.
+ * Manifest keys whose change cannot reach a consumer.
  *
  * Both are provably local: `scripts` is task wiring run by CI and by
  * developers, `simple-git-hooks` configures the local git hooks. Every other
  * key — the dependency blocks, `resolutions`, `packageManager`, `workspaces`,
- * `type`, `engines`, `version` — can move a built artifact or the toolchain
- * that produces it, and an UNKNOWN key is relevant like an unknown path is.
+ * `files`, `exports`, `type`, `engines`, `version` — can move a built artifact,
+ * the toolchain that produces it, or what a consumer resolves; an UNKNOWN key
+ * is relevant like an unknown path is.
+ *
+ * A published tarball DOES contain `scripts` — npm strips nothing but a few
+ * lifecycle-adjacent fields. The argument is "no consumer effect", not "not in
+ * the tarball": nothing a consumer installs, imports or runs reads a Flow
+ * package's `test:unit` or `build` script. Same reasoning as for the story and
+ * test `.d.ts` files above.
  */
-const IRRELEVANT_ROOT_MANIFEST_KEYS = new Set(["scripts", "simple-git-hooks"]);
+const IRRELEVANT_MANIFEST_KEYS = new Set(["scripts", "simple-git-hooks"]);
 
 /**
- * Can a change to the root `package.json` reach a published tarball?
+ * Can a change to a `package.json` reach a consumer?
  *
+ * Applies to the ROOT manifest and to every `packages/*\/package.json` (#3023).
  * The root manifest is private and never published, so nothing in it ships
  * directly — but its dependency and wiring keys shape what every package
- * builds. Only the key DIFF can tell the two apart, which is why the path-level
- * `isPublishRelevant` cannot: `scripts` churn (#2970 added `test:links` to two
- * scripts and cut 1.0.9) looks exactly like a `devDependencies` bump.
+ * builds. A package manifest ships whole. Either way only the key DIFF can tell
+ * the two cases apart, which is why the path-level `classifyPath` cannot:
+ * `scripts` churn (#2970 added `test:links` to two root scripts and cut 1.0.9;
+ * #3006 changed one package's `test:unit` and cut 1.0.12) looks exactly like a
+ * dependency bump.
  *
  * Fails SAFE in both directions: unreadable or unparsable content is relevant,
  * and so is any key not on the denylist above.
  *
  * @param {string | null | undefined} beforeText
  * @param {string | null | undefined} afterText
+ * @param {string} [path] The manifest's repository-relative path, for the
+ *   reason.
  * @returns {{ relevant: boolean; reason: string }}
  */
-export function classifyRootManifestChange(beforeText, afterText) {
+export function classifyManifestChange(
+  beforeText,
+  afterText,
+  path = "package.json",
+) {
+  const label = path === "package.json" ? "the root package.json" : path;
   /** @param {string | null | undefined} text */
   const parse = (text) => {
     if (typeof text !== "string") return undefined;
@@ -149,7 +287,7 @@ export function classifyRootManifestChange(beforeText, afterText) {
   if (!before || !after) {
     return {
       relevant: true,
-      reason: "the root package.json could not be read (fail-safe default)",
+      reason: `${label} could not be read (fail-safe default)`,
     };
   }
 
@@ -159,24 +297,65 @@ export function classifyRootManifestChange(beforeText, afterText) {
   );
 
   if (changed.length === 0) {
-    return { relevant: false, reason: "the root package.json did not change" };
+    return { relevant: false, reason: `${label} did not change` };
   }
 
   const relevantKeys = changed.filter(
-    (key) => !IRRELEVANT_ROOT_MANIFEST_KEYS.has(key),
+    (key) => !IRRELEVANT_MANIFEST_KEYS.has(key),
   );
 
   if (relevantKeys.length === 0) {
     return {
       relevant: false,
-      reason: `the root package.json only changed ${changed.join(", ")}`,
+      reason: `${label} only changed ${changed.join(", ")}`,
     };
   }
 
   return {
     relevant: true,
-    reason: `the root package.json changed ${relevantKeys.join(", ")}`,
+    reason: `${label} changed ${relevantKeys.join(", ")}`,
   };
+}
+
+/**
+ * The package directory and filename of a package-root Markdown file.
+ *
+ * Only the root level: `packages/codemods/src/migrations/x/entry.md` is a
+ * generator INPUT, not documentation, so it must keep its path-level
+ * relevance.
+ *
+ * @param {string} path
+ * @returns {{ dir: string; file: string } | undefined}
+ */
+export function packageRootMarkdown(path) {
+  const match = /^(packages\/[^/]+)\/([^/]+\.md)$/.exec(path);
+  return match ? { dir: match[1], file: match[2] } : undefined;
+}
+
+/**
+ * Does a package's `files` list ship this root Markdown file?
+ *
+ * `files` is the whole truth for a root-level `.md`: nothing builds one, so it
+ * reaches a consumer exactly if it is published. `flow-react-components` lists
+ * `AGENTS.md`, `MIGRATION.md` and `USAGE.md`; `remote-react-components` lists
+ * only `USAGE.md`, so ITS `AGENTS.md` reaches nobody.
+ *
+ * Fails SAFE: an unknown `files` (the caller could not read the manifest)
+ * counts as shipped.
+ *
+ * @param {string} file
+ * @param {string[] | undefined} files
+ * @returns {boolean}
+ */
+export function shipsRootMarkdown(file, files) {
+  if (!Array.isArray(files)) return true;
+  return files.some((entry) => {
+    const normalized = entry.replace(/^\.\//, "");
+    if (normalized === file) return true;
+    // npm honours a `*.md`-style glob at the root of `files`.
+    if (normalized.startsWith("*.")) return file.endsWith(normalized.slice(1));
+    return false;
+  });
 }
 
 /** Does `path` name a package manifest? */
@@ -191,24 +370,32 @@ function isManifest(path) {
  * (unreachable `before` sha, a force push, a compare response we could not
  * read), and the answer is then "publish" — the behaviour before #2931.
  *
- * Two paths are refined beyond `isPublishRelevant`, because for them the path
- * alone carries no information (#2970, #2959):
+ * Two kinds of path are refined beyond `classifyPath`, because for them the
+ * path alone carries no information (#2970, #2959, #3023):
  *
- * - **`package.json`** (root) — relevant only per `options.rootManifestRelevant`,
- *   which the caller derives from the key diff via
- *   `classifyRootManifestChange`. Unknown (`undefined`) stays relevant.
+ * - **every `package.json`** — the root one and each `packages/*\/package.json` —
+ *   relevant only per `options.manifestRelevance[path]`, which the caller
+ *   derives from the key diff via `classifyManifestChange`. Unknown
+ *   (`undefined`) stays relevant.
  * - **`pnpm-lock.yaml`** — a DERIVED file: it is relevant when the manifest that
  *   moved it is. So it follows the manifests in the same push, and drops out
  *   only when at least one manifest changed and none of them is relevant. A
  *   lockfile that changed with NO manifest (a dedupe, a resolution refresh)
  *   stays relevant — nothing in the path list explains it.
  *
+ * `rules` lists, deduplicated and sorted, which rule decided each irrelevant
+ * file. The guard prints it, so a skipped release names the rule that fired.
+ *
  * @param {string[]} paths Changed files, repository-relative.
- * @param {{ rootManifestRelevant?: boolean }} [options]
+ * @param {{
+ *   manifestRelevance?: Record<string, boolean | undefined>;
+ *   packageFiles?: Record<string, string[] | undefined>;
+ * }} [options]
  * @returns {{
  *   publish: boolean;
  *   reason: string;
  *   relevant: string[];
+ *   rules: string[];
  *   total: number;
  * }}
  */
@@ -221,6 +408,7 @@ export function classifyChangedFiles(paths, options = {}) {
       reason:
         "the changed-file list is not a list of paths (fail-safe default)",
       relevant: [],
+      rules: [],
       total: files.length,
     };
   }
@@ -230,29 +418,60 @@ export function classifyChangedFiles(paths, options = {}) {
       publish: true,
       reason: "no changed files could be determined (fail-safe default)",
       relevant: [],
+      rules: [],
       total: 0,
     };
   }
 
-  let relevant = files.filter(isPublishRelevant);
+  const manifestRelevance = options.manifestRelevance ?? {};
+  const rules = new Set();
 
-  // The root manifest first: the lockfile rule below reads the REFINED
-  // relevance of the manifests, not the path-level one.
-  if (options.rootManifestRelevant === false) {
-    relevant = relevant.filter((path) => path !== "package.json");
-  }
+  let relevant = files.filter((path) => {
+    const { relevant: isRelevant, rule } = classifyPath(path);
+    if (!isRelevant) rules.add(rule);
+    return isRelevant;
+  });
+
+  // A package-root Markdown file reaches a consumer exactly if that package
+  // publishes it, which only its `files` can say (#3023).
+  const packageFiles = options.packageFiles ?? {};
+  relevant = relevant.filter((path) => {
+    const markdown = packageRootMarkdown(path);
+    if (!markdown) return true;
+    if (shipsRootMarkdown(markdown.file, packageFiles[markdown.dir])) {
+      return true;
+    }
+    rules.add(`package Markdown outside "files"`);
+    return false;
+  });
+
+  // The manifests next: the lockfile rule below reads their REFINED relevance,
+  // not the path-level one.
+  relevant = relevant.filter((path) => {
+    if (!isManifest(path) || manifestRelevance[path] !== false) return true;
+    rules.add(`manifest key diff "${path}"`);
+    return false;
+  });
 
   const manifests = files.filter(isManifest);
   const relevantManifests = manifests.filter((path) => relevant.includes(path));
   if (manifests.length > 0 && relevantManifests.length === 0) {
+    if (relevant.includes("pnpm-lock.yaml")) {
+      rules.add("derived lockfile follows its manifests");
+    }
     relevant = relevant.filter((path) => path !== "pnpm-lock.yaml");
   }
+
+  const firedRules = [...rules].sort();
 
   if (relevant.length === 0) {
     return {
       publish: false,
-      reason: `all ${files.length} changed file(s) are docs/CI/tooling only — nothing reaches a published package`,
+      reason:
+        `all ${files.length} changed file(s) are non-shipping — ` +
+        `rules: ${firedRules.join("; ")}`,
       relevant,
+      rules: firedRules,
       total: files.length,
     };
   }
@@ -261,6 +480,7 @@ export function classifyChangedFiles(paths, options = {}) {
     publish: true,
     reason: `${relevant.length} of ${files.length} changed file(s) affect published packages`,
     relevant,
+    rules: firedRules,
     total: files.length,
   };
 }

--- a/.github/scripts/release-relevance-lib.test.mjs
+++ b/.github/scripts/release-relevance-lib.test.mjs
@@ -1,10 +1,14 @@
 // @ts-check
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
 import {
   isPublishRelevant,
+  shipsRootMarkdown,
+  packageRootMarkdown,
   classifyChangedFiles,
-  classifyRootManifestChange,
+  classifyManifestChange,
 } from "./release-relevance-lib.mjs";
 
 test("isPublishRelevant: docs, CI and tooling paths are irrelevant", () => {
@@ -82,6 +86,81 @@ test("isPublishRelevant: unknown paths are relevant (fail-safe denylist)", () =>
   assert.equal(isPublishRelevant("some-new-root-file.ts"), true);
 });
 
+test("packageRootMarkdown: only the root level of a package", () => {
+  assert.deepEqual(packageRootMarkdown("packages/components/AGENTS.md"), {
+    dir: "packages/components",
+    file: "AGENTS.md",
+  });
+  // A generator input, not documentation.
+  assert.equal(
+    packageRootMarkdown("packages/codemods/src/migrations/x/entry.md"),
+    undefined,
+  );
+  assert.equal(packageRootMarkdown("AGENTS.md"), undefined);
+  assert.equal(packageRootMarkdown("apps/docs/README.md"), undefined);
+});
+
+test("shipsRootMarkdown: `files` is the whole truth for a root Markdown", () => {
+  const components = ["AGENTS.md", "MIGRATION.md", "USAGE.md", "dist"];
+  assert.equal(shipsRootMarkdown("AGENTS.md", components), true);
+  assert.equal(shipsRootMarkdown("CONTRIBUTE.md", components), false);
+  // remote-react-components publishes only USAGE.md, so its AGENTS.md does not.
+  assert.equal(shipsRootMarkdown("AGENTS.md", ["USAGE.md", "dist"]), false);
+  assert.equal(shipsRootMarkdown("README.md", ["*.md", "dist"]), true);
+  // Fail safe: an unknown `files` counts as shipped.
+  assert.equal(shipsRootMarkdown("AGENTS.md", undefined), true);
+});
+
+test("classifyChangedFiles: package Markdown follows that package's `files`", () => {
+  // #3009 changed remote-react-components' AGENTS.md and CONTRIBUTE.md, which
+  // it does not publish, and nothing else that reaches a consumer.
+  const result = classifyChangedFiles(
+    [
+      "packages/remote-react-components/AGENTS.md",
+      "packages/remote-react-components/CONTRIBUTE.md",
+    ],
+    {
+      packageFiles: {
+        "packages/remote-react-components": ["USAGE.md", "dist"],
+      },
+    },
+  );
+  assert.equal(result.publish, false);
+
+  // components DOES publish AGENTS.md — #2954 released through it.
+  assert.equal(
+    classifyChangedFiles(["packages/components/AGENTS.md"], {
+      packageFiles: {
+        "packages/components": [
+          "AGENTS.md",
+          "MIGRATION.md",
+          "USAGE.md",
+          "dist",
+        ],
+      },
+    }).publish,
+    true,
+  );
+
+  // Without the `files` of that package, it stays relevant.
+  assert.equal(
+    classifyChangedFiles(["packages/remote-react-components/AGENTS.md"])
+      .publish,
+    true,
+  );
+});
+
+test("classifyChangedFiles: the Storybook image does not publish", () => {
+  // #3008 pushed exactly these under packages/, and cut 1.0.15 with them.
+  assert.equal(
+    classifyChangedFiles([
+      "packages/components/Dockerfile",
+      "packages/components/.dockerignore",
+    ]).publish,
+    false,
+  );
+});
+
 test("classifyChangedFiles: an undeterminable file list publishes", () => {
   assert.equal(classifyChangedFiles([]).publish, true);
   assert.equal(classifyChangedFiles(["", "  "]).publish, true);
@@ -136,13 +215,35 @@ test("classifyChangedFiles: a promotion merge publishes", () => {
 test("classifyChangedFiles: the reason names the counts", () => {
   assert.match(
     classifyChangedFiles(["apps/docs/a.mdx", "docs/b.md"]).reason,
-    /all 2 changed file\(s\) are docs\/CI\/tooling only/,
+    /all 2 changed file\(s\) are non-shipping/,
   );
   assert.match(
     classifyChangedFiles(["apps/docs/a.mdx", "packages/components/src/a.ts"])
       .reason,
     /1 of 2 changed file\(s\) affect published packages/,
   );
+});
+
+test("classifyChangedFiles: a skip names the rules that fired", () => {
+  // The AC asks for a `::notice::` that says WHICH rule skipped the release,
+  // so the rule labels are part of the classifier's output, not log prose.
+  const result = classifyChangedFiles(
+    [
+      "apps/docs/a.mdx",
+      "packages/components/.storybook/preview.tsx",
+      "packages/components/src/components/Button/stories/Default.stories.tsx",
+      "packages/components/package.json",
+    ],
+    { manifestRelevance: { "packages/components/package.json": false } },
+  );
+  assert.equal(result.publish, false);
+  assert.deepEqual(result.rules, [
+    'filename "*.stories.tsx"',
+    'manifest key diff "packages/components/package.json"',
+    'package-local "packages/*/.storybook/"',
+    'top-level "apps/"',
+  ]);
+  for (const rule of result.rules) assert.ok(result.reason.includes(rule));
 });
 
 test("classifyChangedFiles: a non-path input publishes instead of being classified", () => {
@@ -167,7 +268,7 @@ test("classifyChangedFiles: square brackets are legitimate path characters", () 
   );
 });
 
-test("classifyRootManifestChange: a scripts-only change is irrelevant", () => {
+test("classifyManifestChange: a scripts-only change is irrelevant", () => {
   // #2970 "test(docs): check the documentation's internal links in CI" → 1.0.9
   const before = JSON.stringify({
     name: "root",
@@ -181,10 +282,10 @@ test("classifyRootManifestChange: a scripts-only change is irrelevant", () => {
     },
     devDependencies: { vite: "7.0.0" },
   });
-  assert.equal(classifyRootManifestChange(before, after).relevant, false);
+  assert.equal(classifyManifestChange(before, after).relevant, false);
 });
 
-test("classifyRootManifestChange: dependency and wiring keys stay relevant", () => {
+test("classifyManifestChange: dependency and wiring keys stay relevant", () => {
   const base = { scripts: { test: "a" }, devDependencies: { vite: "7.0.0" } };
   for (const [key, value] of [
     ["devDependencies", { vite: "7.1.0" }],
@@ -199,17 +300,17 @@ test("classifyRootManifestChange: dependency and wiring keys stay relevant", () 
   ]) {
     const after = JSON.stringify({ ...base, [key]: value });
     assert.equal(
-      classifyRootManifestChange(JSON.stringify(base), after).relevant,
+      classifyManifestChange(JSON.stringify(base), after).relevant,
       true,
       key,
     );
   }
 });
 
-test("classifyRootManifestChange: unparsable or unknown content is relevant", () => {
-  assert.equal(classifyRootManifestChange("{ not json", "{}").relevant, true);
-  assert.equal(classifyRootManifestChange(null, "{}").relevant, true);
-  assert.equal(classifyRootManifestChange("{}", undefined).relevant, true);
+test("classifyManifestChange: unparsable or unknown content is relevant", () => {
+  assert.equal(classifyManifestChange("{ not json", "{}").relevant, true);
+  assert.equal(classifyManifestChange(null, "{}").relevant, true);
+  assert.equal(classifyManifestChange("{}", undefined).relevant, true);
 });
 
 test("classifyChangedFiles: a scripts-only root manifest does not publish", () => {
@@ -221,14 +322,19 @@ test("classifyChangedFiles: a scripts-only root manifest does not publish", () =
       ".github/workflows/test.yml",
       "package.json",
     ],
-    { rootManifestRelevant: false },
+    { manifestRelevance: { "package.json": false } },
   );
   assert.equal(result.publish, false);
   assert.deepEqual(result.relevant, []);
 });
 
 test("classifyChangedFiles: an unclassified root manifest still publishes", () => {
-  for (const options of [undefined, {}, { rootManifestRelevant: true }]) {
+  for (const options of [
+    undefined,
+    {},
+    { manifestRelevance: {} },
+    { manifestRelevance: { "package.json": true } },
+  ]) {
     assert.equal(
       classifyChangedFiles(["apps/docs/a.mdx", "package.json"], options)
         .publish,
@@ -253,15 +359,24 @@ test("classifyChangedFiles: a lockfile follows the manifests that moved it", () 
   // The root manifest counts as a manifest — and only when it is relevant.
   assert.equal(
     classifyChangedFiles(["package.json", "pnpm-lock.yaml"], {
-      rootManifestRelevant: false,
+      manifestRelevance: { "package.json": false },
     }).publish,
     false,
   );
   assert.equal(
     classifyChangedFiles(["package.json", "pnpm-lock.yaml"], {
-      rootManifestRelevant: true,
+      manifestRelevance: { "package.json": true },
     }).publish,
     true,
+  );
+  // Same for a PACKAGE manifest: a scripts-only diff cannot have moved the
+  // lockfile, so the lock churn has nothing relevant left to follow.
+  assert.equal(
+    classifyChangedFiles(
+      ["packages/components/package.json", "pnpm-lock.yaml"],
+      { manifestRelevance: { "packages/components/package.json": false } },
+    ).publish,
+    false,
   );
 });
 
@@ -277,4 +392,218 @@ test("classifyChangedFiles: unexplained lock churn publishes (fail-safe)", () =>
     classifyChangedFiles(["patches/foo@1.0.0.patch", "pnpm-lock.yaml"]).publish,
     true,
   );
+});
+
+test("isPublishRelevant: package-local non-shipping directories are irrelevant", () => {
+  for (const path of [
+    // #3010 → 1.0.14. The Storybook config is never built into `dist`.
+    "packages/components/.storybook/preview.tsx",
+    "packages/components/.storybook/main.ts",
+    "packages/remote-react-components/e2e/remote-test-server/vitest.config.ts",
+    "packages/remote-react-components/src/tests/visual/lib/scenarios.ts",
+    "packages/remote-react-components/src/tests/visual/__screenshots__/a.png",
+    "packages/components/src/tests/layered/thirdParty.ts",
+    // #3006 → 1.0.12. The cross-version harness and the vitest setup files run
+    // only under vitest.
+    "packages/remote-react-components/dev/cross-version/run.ts",
+    "packages/components/dev/vitest/setupBrowser.ts",
+  ]) {
+    assert.equal(isPublishRelevant(path), false, path);
+  }
+});
+
+test("isPublishRelevant: stories and tests are irrelevant wherever they sit", () => {
+  for (const path of [
+    "packages/components/src/components/Button/stories/Default.stories.tsx",
+    "packages/components/src/lib/react/dynamic.test.ts",
+    "packages/components/src/components/Button/Button.browser.test.tsx",
+    "packages/components/dev/vite/layerOrderPlugin.test.ts",
+    // `.test.` is not always the last extension.
+    "packages/remote-react-components/e2e/tests/Button.browser.test.remote.tsx",
+  ]) {
+    assert.equal(isPublishRelevant(path), false, path);
+  }
+});
+
+test("isPublishRelevant: package-local build tooling in dev/ stays relevant", () => {
+  // `packages/*/dev/**` is NOT irrelevant wholesale: in `components` and
+  // `codemods` that directory IS the build. Only the test-harness subtrees are
+  // denylisted, so these four keep publishing.
+  for (const path of [
+    // Imported by vite.build.config.ts — changes the emitted CSS.
+    "packages/components/dev/vite/layerOrderPlugin.ts",
+    // Generates the shipped dist/assets/doc-properties.json.
+    "packages/components/dev/createDocPropertiesJson.ts",
+    // Generates view.ts / src/auto-generated/**.
+    "packages/components/dev/remote-components-generator/lib/propClassifiers.ts",
+    // `codemods`' build script is `tsx dev/generateCli.ts && …`.
+    "packages/codemods/dev/generateCli.ts",
+  ]) {
+    assert.equal(isPublishRelevant(path), true, path);
+  }
+});
+
+test("isPublishRelevant: a package's CONTRIBUTE.md never ships", () => {
+  // No package lists it in `files`, and npm force-includes only README and
+  // LICENSE — guarded by "every published package ships …" below.
+  assert.equal(
+    isPublishRelevant("packages/remote-react-components/CONTRIBUTE.md"),
+    false,
+  );
+});
+
+test("isPublishRelevant: the package-local rules need a full path segment", () => {
+  for (const path of [
+    // A prefix, not a segment.
+    "packages/components/src/testsWithoutSlash.ts",
+    "packages/components/e2e-helpers/serve.ts",
+    "packages/components/development/thing.ts",
+    // `dev/` other than the two harness subtrees.
+    "packages/components/dev/icons/generate.ts",
+    "packages/components/dev/scss-types/generateScssTypes.ts",
+    // The rules are package-local: the same names OUTSIDE packages/ are
+    // unknown paths, and unknown means relevant.
+    "src/tests/a.ts",
+    "e2e/a.ts",
+    ".storybook/main.ts",
+  ]) {
+    assert.equal(isPublishRelevant(path), true, path);
+  }
+});
+
+test("classifyChangedFiles: 1.0.14 — a Storybook-only push does not publish", () => {
+  // #3010 "build(components): silence the Storybook a11y addon".
+  const result = classifyChangedFiles([
+    "packages/components/.storybook/preview.tsx",
+  ]);
+  assert.equal(result.publish, false);
+  assert.deepEqual(result.relevant, []);
+});
+
+test("classifyChangedFiles: 1.0.12 — a package-local tooling push does not publish", () => {
+  // #3006 "ci(remote-react-components): select both unit projects": a
+  // scripts-only package manifest, a package-local CONTRIBUTE.md, the
+  // cross-version harness and the visual-test sources.
+  const result = classifyChangedFiles(
+    [
+      "packages/remote-react-components/package.json",
+      "packages/remote-react-components/CONTRIBUTE.md",
+      "packages/remote-react-components/dev/cross-version/crossVersionRunner.ts",
+      "packages/remote-react-components/src/tests/visual/lib/scenarios.ts",
+    ],
+    {
+      manifestRelevance: {
+        "packages/remote-react-components/package.json": false,
+      },
+    },
+  );
+  assert.equal(result.publish, false);
+  assert.deepEqual(result.relevant, []);
+});
+
+test("classifyChangedFiles: a mixed package-local push publishes", () => {
+  // One source file among the non-shipping ones is enough — the mixed case must
+  // never be swallowed.
+  const result = classifyChangedFiles(
+    [
+      "packages/components/.storybook/preview.tsx",
+      "packages/components/src/components/Button/stories/Default.stories.tsx",
+      "packages/components/src/tests/layered/thirdParty.ts",
+      "packages/remote-react-components/package.json",
+      "packages/components/src/components/Button/Button.tsx",
+    ],
+    {
+      manifestRelevance: {
+        "packages/remote-react-components/package.json": false,
+      },
+    },
+  );
+  assert.equal(result.publish, true);
+  assert.deepEqual(result.relevant, [
+    "packages/components/src/components/Button/Button.tsx",
+  ]);
+});
+
+test("classifyChangedFiles: a package manifest dependency bump publishes", () => {
+  for (const options of [
+    undefined,
+    { manifestRelevance: { "packages/components/package.json": true } },
+  ]) {
+    assert.equal(
+      classifyChangedFiles(["packages/components/package.json"], options)
+        .publish,
+      true,
+    );
+  }
+});
+
+test("classifyManifestChange: a package manifest is judged the same way", () => {
+  // #3006 changed only `test:unit` in remote-react-components' manifest.
+  const path = "packages/remote-react-components/package.json";
+  const before = JSON.stringify({
+    name: "@mittwald/flow-remote-react-components",
+    scripts: { "test:unit": "vitest run --project=unit" },
+    dependencies: { "@quilted/threads": "3.0.0" },
+  });
+  const scriptsOnly = JSON.stringify({
+    name: "@mittwald/flow-remote-react-components",
+    scripts: { "test:unit": "vitest run --project=unit*" },
+    dependencies: { "@quilted/threads": "3.0.0" },
+  });
+  const dependencyBump = JSON.stringify({
+    name: "@mittwald/flow-remote-react-components",
+    scripts: { "test:unit": "vitest run --project=unit" },
+    dependencies: { "@quilted/threads": "3.1.0" },
+  });
+
+  assert.equal(
+    classifyManifestChange(before, scriptsOnly, path).relevant,
+    false,
+  );
+  assert.equal(
+    classifyManifestChange(before, dependencyBump, path).relevant,
+    true,
+  );
+  // The reason names the manifest, so a run with several of them stays readable.
+  assert.match(
+    classifyManifestChange(before, scriptsOnly, path).reason,
+    /packages\/remote-react-components\/package\.json/,
+  );
+  assert.match(
+    classifyManifestChange(before, before).reason,
+    /root package\.json/,
+  );
+});
+
+test("every published package ships only dist and shipped Markdown", () => {
+  // The invariant the package-local denylist rests on. If a package ever starts
+  // shipping `src`, `.storybook`, `e2e` or CONTRIBUTE.md, this fails and the
+  // denylist has to be revisited — the classifier itself cannot notice.
+  const packagesDir = join(import.meta.dirname, "..", "..", "packages");
+  const neverShipped = new Set(["CONTRIBUTE.md"]);
+  let checked = 0;
+
+  for (const name of readdirSync(packagesDir)) {
+    let manifest;
+    try {
+      manifest = JSON.parse(
+        readFileSync(join(packagesDir, name, "package.json"), "utf8"),
+      );
+    } catch {
+      continue;
+    }
+    // Private packages are never published, so their `files` says nothing about
+    // tarballs (`core` and `icons-base` legitimately ship `src`).
+    if (manifest.private) continue;
+    checked += 1;
+
+    for (const entry of manifest.files ?? []) {
+      assert.ok(
+        entry === "dist" || (entry.endsWith(".md") && !neverShipped.has(entry)),
+        `${name} ships ${entry}`,
+      );
+    }
+  }
+
+  assert.ok(checked > 5, `only ${checked} published packages found`);
 });

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -133,25 +133,33 @@ jobs:
             files=""
           fi
 
-          # The root `package.json` is judged by its KEY DIFF, not its path: a
-          # `scripts` edit cannot reach a tarball, a `devDependencies` bump can,
-          # and the path cannot tell them apart (#2970). Fetch both versions so
-          # the classifier can compare them. A failed fetch leaves the file
-          # missing, which the guard reads as "relevant" — the behaviour before.
-          if printf '%s\n' "$files" | grep -qx 'package.json'; then
-            for side in BEFORE AFTER; do
-              if [ "$side" = AFTER ]; then ref="${AFTER}"; else ref="${BEFORE}"; fi
-              target="${RUNNER_TEMP}/root-package.${side}.json"
-              if gh api "repos/${REPO}/contents/package.json?ref=${ref}" \
+          # Every `package.json` is judged by its KEY DIFF, not its path: a
+          # `scripts` edit cannot reach a consumer, a dependency bump can, and
+          # the path cannot tell them apart (#2970 for the root manifest, #3023
+          # for the package ones). Fetch both versions of each so the classifier
+          # can compare them; only the root and `packages/*` manifests, because
+          # an `apps/*` manifest is already irrelevant by path.
+          #
+          # A failed fetch leaves the snapshot missing, which the guard reads as
+          # "relevant" — the behaviour before. That also covers an ADDED or
+          # DELETED manifest, which has only one side.
+          export MANIFEST_SNAPSHOT_DIR="${RUNNER_TEMP}/manifests"
+          mkdir -p "${MANIFEST_SNAPSHOT_DIR}/before" "${MANIFEST_SNAPSHOT_DIR}/after"
+          while IFS= read -r manifest; do
+            [ -n "$manifest" ] || continue
+            slug="$(printf '%s' "$manifest" | sed 's|/|__|g')"
+            for side in before after; do
+              if [ "$side" = after ]; then ref="${AFTER}"; else ref="${BEFORE}"; fi
+              target="${MANIFEST_SNAPSHOT_DIR}/${side}/${slug}.json"
+              if ! gh api "repos/${REPO}/contents/${manifest}?ref=${ref}" \
                 --header 'Accept: application/vnd.github.raw+json' \
                 > "$target"; then
-                export "ROOT_MANIFEST_${side}_FILE=${target}"
-              else
-                echo "::warning::Could not fetch the root package.json at ${ref}."
+                echo "::warning::Could not fetch ${manifest} at ${ref}."
                 rm -f "$target"
               fi
             done
-          fi
+          done <<< "$(printf '%s\n' "$files" \
+            | grep -E '^(package\.json|packages/[^/]+/package\.json)$' || true)"
 
           printf '%s\n' "$files" \
             | node .github/scripts/release-relevance-guard.mjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,9 +157,12 @@ and commit the results.
 - **Conventional Commits** with component/package scope — `fix(Button): …`,
   `feat(components): …`. Releases and changelogs are generated from them.
 - Merged PRs trigger the publish workflow (lerna-lite, fixed versioning across
-  packages) — **unless the merge is docs-, CI- or tooling-only**, which
+  packages) — **unless nothing in the merge can reach a consumer**, which
   publishes nothing at all (no npm release, no version bump commit, no tag, no
-  GitHub Release). The rule lives in
+  GitHub Release). That covers docs, CI and repo tooling, and inside `packages/`
+  also `.storybook/**`, `e2e/**`, `src/tests/**`,
+  `dev/{cross-version,vitest}/**`, `CONTRIBUTE.md`, `*.stories.tsx`, `*.test.*`
+  and a `scripts`-only manifest diff. The rule lives in
   `.github/scripts/release-relevance-lib.mjs`; see
   [docs/release-workflow.md](docs/release-workflow.md).
 - **Maintain the nx wiring for scripts.** Every package script that nx

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -44,10 +44,7 @@ flowchart LR
   promoted to `main` in curated bundles.
 - **The major line** — an on-demand branch (e.g. `2.x`) spun up only when a rare
   breaking change appears. Breaking changes are rare _by policy_: **deprecate,
-  don't break** — keep the old path and warn via `useWarnDeprecation`. Opening
-  the line is not a branch creation: the guards, both cascades, the drift check
-  and `publish.yml` are all hardcoded to the two standing lines. See the
-  [major-line runbook](major-line-runbook.md).
+  don't break** — keep the old path and warn via `useWarnDeprecation`.
 
 ## How changes flow (the mechanics)
 
@@ -70,33 +67,48 @@ flowchart LR
   guard that Lerna-Lite 5's changelog config trips over (it recompiles the
   preset's template itself), and the guard then aborts `lerna version`. Re-check
   on the next Lerna-Lite major.
-- **Not every merge releases.** A push to a release line only publishes when it
-  carries a change that can reach a **published package**. Docs-, CI- and
-  repo-tooling-only merges (`apps/**`, `docs/**`, `.github/**`, `dev/**`, root
-  Markdown and editor config) are skipped whole: no npm publish, no
-  `chore(release):` version bump commit, no tag, no GitHub Release (#2931). The
-  decision is made by the `decide` job in `publish.yml`, which classifies the
-  pushed file set with `.github/scripts/release-relevance-lib.mjs`. Two
-  properties matter when you touch that list:
-  - It is a **denylist** — anything not provably docs/CI/tooling counts as
+- **Not every merge releases.** A push to a release line publishes only when it
+  carries a change that can reach a **consumer**. Everything else is skipped
+  whole: no npm publish, no `chore(release):` version bump commit, no tag, no
+  GitHub Release (#2931). The `decide` job in `publish.yml` classifies the
+  pushed file set with `.github/scripts/release-relevance-lib.mjs`, and a
+  **`workflow_dispatch` run always publishes** — the escape hatch when a
+  docs-only change has to go out anyway. Four properties of that classifier:
+  - It is a **denylist**: anything not provably non-shipping counts as
     publishable. Forgetting a docs path costs one needless version; forgetting a
-    source path would silently swallow a real release. So `packages/**` is
-    relevant wholesale, Markdown included: `@mittwald/flow-react-components`
-    ships `AGENTS.md`, `MIGRATION.md` and `USAGE.md` next to `dist`.
-  - **Two files are judged by content, not by path**, because for them the path
-    carries no information:
-    - Root **`package.json`** — a `scripts` or `simple-git-hooks` edit cannot
-      reach a tarball, a `devDependencies` bump can. The `decide` job fetches
-      both versions and compares the top-level keys; an unknown key is relevant
-      like an unknown path is. #2970 added `test:links` to two scripts and cut
-      1.0.9.
-    - **`pnpm-lock.yaml`** — a derived file, relevant when the manifest that
-      moved it is. It follows the manifests in the same push and drops out only
-      when at least one changed and none of them is publish-relevant. Lock churn
-      with NO manifest change (a dedupe, a resolution refresh) stays relevant.
-      #2959 bumped an `apps/docs` dependency and cut 1.0.4.
-  - A **`workflow_dispatch` run always publishes.** That is the escape hatch
-    when a docs-only change has to go out as a release anyway.
+    source path would swallow a real release. Package-local Markdown therefore
+    stays relevant — `@mittwald/flow-react-components` ships `AGENTS.md`,
+    `MIGRATION.md` and `USAGE.md` next to `dist`.
+  - Outside `packages/**`: `apps/**`, `docs/**`, `.github/**`, `dev/**`, root
+    Markdown and editor config are irrelevant.
+  - Inside `packages/**` these are irrelevant too, segment-exact under
+    `packages/<name>/`: `.storybook/**`, `e2e/**`, `src/tests/**`,
+    `dev/cross-version/**`, `dev/vitest/**`, the package's `CONTRIBUTE.md`,
+    `Dockerfile` and `.dockerignore`, and `*.stories.tsx` / `*.test.*` anywhere.
+    The criterion is **no consumer effect**, not "not in the tarball".
+  - A package's **root-level Markdown is judged against that package's `files`**
+    — nothing builds one, so it reaches a consumer exactly if it is published.
+    `flow-react-components` lists `AGENTS.md`, `MIGRATION.md` and `USAGE.md`;
+    `remote-react-components` lists only `USAGE.md`, so ITS `AGENTS.md` reaches
+    nobody. The `files` are read from the checkout, not fetched — only the
+    current state matters. A Markdown file DEEPER in a package keeps its
+    path-level relevance: `codemods/src/migrations/*/entry.md` is a generator
+    input, not documentation.
+    - `packages/*/dev/**` is **not** irrelevant wholesale. In `components` and
+      `codemods` that directory is the build: `dev/vite/*` holds the plugins
+      `vite.build.config.ts` imports, `dev/createDocPropertiesJson.ts` writes
+      the shipped `dist/assets/doc-properties.json`,
+      `dev/remote-components-generator/**` generates `view.ts` and
+      `src/auto-generated/**`, and `codemods`' build script is
+      `tsx dev/generateCli.ts && …`.
+  - **Every `package.json` and `pnpm-lock.yaml` are judged by content**, because
+    their paths carry no information. A `scripts` or `simple-git-hooks` edit
+    cannot reach a consumer, a dependency bump can — the job fetches both sides
+    of each manifest and compares the top-level keys, and an unknown key is
+    relevant like an unknown path is. The lockfile follows the manifests that
+    moved it and stays relevant when none of them changed. #2970 cut 1.0.9 from
+    two root scripts, #3006 cut 1.0.12 from one package's `test:unit`, #2959 cut
+    1.0.4 from an `apps/docs` dependency.
 - **Tests and stories stay out of `dist/types`.** Every release build shares
   `publishedDtsOptions` from `packages/core`, whose `exclude` keeps
   `*.stories.*`, `*.test.*`, `src/tests/**` and `e2e/**` out of the declaration
@@ -197,8 +209,6 @@ an existing codemod is not a justification for breaking consumers.
   contributor-facing summary of where your PR lands.
 - **[ADR 0004](adr/0004-forward-merge-main-into-next.md)** — the forward-merge
   mechanics: merge strategy, merge drivers, sync PRs, concurrency.
-- **[The major-line runbook](major-line-runbook.md)** — what has to be
-  configured, verified and later retired when a `2.x` line is opened.
 - **[ADR 0005](adr/0005-semver-contract.md)** — the semver contract: exactly
   what is guaranteed versus best-effort at 1.0.0.
 - **[RFC #2711](https://github.com/mittwald/flow/issues/2711)** — the


### PR DESCRIPTION
The release denylist knew only repo-**root** prefixes, matched with `startsWith`, so everything under `packages/**` counted as publish-relevant wholesale:

| Version | Trigger | Reaches a consumer? |
| --- | --- | --- |
| 1.0.14 | #3010 — `packages/components/.storybook/preview.tsx` alone | No |
| 1.0.12 | #3006 — a `scripts`-only package manifest, a package-local `CONTRIBUTE.md`, `dev/cross-version/**`, `src/tests/visual/**` | No |

**Package-local denylist entries**, segment-exact under `packages/<name>/` — `e2e-helpers/` is not `e2e/`:

- `.storybook/**`, `e2e/**`, `src/tests/**`, `dev/cross-version/**`, `dev/vitest/**`
- the package's `CONTRIBUTE.md` (no package lists it in `files`)
- `Dockerfile` and `.dockerignore` — the Storybook preview image, built by CI from `dev/` and `.github/`. #3008 pushed both and nothing else under `packages/`
- `*.stories.tsx` and `*.test.*` anywhere — `.test.` is not always the last extension (`*.browser.test.remote.tsx`)

A package's **root-level Markdown is judged against that package's `files`**, not by path — nothing builds one, so it reaches a consumer exactly if it is published. `flow-react-components` lists `AGENTS.md`, `MIGRATION.md` and `USAGE.md`; `remote-react-components` lists only `USAGE.md`, so ITS `AGENTS.md` reaches nobody. Markdown *deeper* in a package keeps its path-level relevance: `codemods/src/migrations/*/entry.md` is a generator input, not documentation.

`packages/*/dev/**` is deliberately **not** denylisted wholesale: in `components` and `codemods` that directory *is* the build — `dev/vite/*` holds the plugins `vite.build.config.ts` imports, `dev/createDocPropertiesJson.ts` writes the shipped `dist/assets/doc-properties.json`, `dev/remote-components-generator/**` generates `view.ts` and `src/auto-generated/**`, and `codemods`' build script is `tsx dev/generateCli.ts && …`.

The criterion is **no consumer effect**, not "not in the tarball": a tarball carries the package's `scripts`, yet nothing a consumer installs reads them.

**The key-diff refinement applies to every `packages/*/package.json`**, not just the root one — a `scripts`-only diff cannot reach a consumer. `publish.yml` therefore snapshots each changed manifest into `MANIFEST_SNAPSHOT_DIR` instead of the two `ROOT_MANIFEST_*` files. A failed fetch leaves the snapshot missing, which the classifier still reads as "relevant" — the behaviour before, and what an added or deleted manifest gets.

`isPublishRelevant` is now a wrapper around `classifyPath`, which also returns the **rule** that decided — that is what the skip notice prints.

## Verified

- 35 classifier tests, run by the `decide` job before it classifies.
- Replayed every non-release commit on `main` since #2933 through the changed classifier: #3010 and #3008 flip to no-publish, and no commit that produced a legitimate release flips with them.
- `next` stays symmetric — docs-only `chore(sync):` merges produce no `-next.N` bump.

`docs/release-workflow.md` is cut back to the mechanics: what the classifier excludes and what it judges by content.

## Split out of this PR

This PR was three changes; each now has its own line, all rebased onto current `main`.

- **#3103** (merged) — keeping tests and stories out of `dist/types`. Changes what the packages publish, not when.
- **the changelog half** — `changelogPreset` rendering every commit type. Relevance is decided by path, the changelog by type; two axes, two PRs.
- **the commit-mixture guard** — reviewed as #3102 and merged into *this branch* rather than into `main`. It is now standalone, and it **depends on this PR**: without the package-Markdown and `Dockerfile` rules above it would fire on #3009 and #3008, which reach nobody, and its `MANIFEST_SNAPSHOT_DIR` wiring needs the classifier below. Merge this one first.

A title-driven variant of the release gate (`[release]` / `[no-release]` tags in the PR title) was built and withdrawn — the tag puts the decision in a hand-written token while the paths answer the question directly. The branch name still carries that withdrawn approach; the PR number is kept for its review history.

Part of #3023 — the path half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
