### PR TITLE
refactor(docs): remove two dead CSS rules

### DIFF
--- a/apps/docs/src/app/_components/layout/Header/Header.module.scss
+++ b/apps/docs/src/app/_components/layout/Header/Header.module.scss
@@ -55,12 +55,6 @@
     display: flex;
     padding-block: var(--size-px--m);
   }
-
-  .mobileNavigationOffCanvas {
-    h3 {
-      display: none;
-    }
-  }
 }
 
 @media (prefers-contrast: more), (prefers-reduced-transparency) {

--- a/apps/docs/src/app/_components/layout/MobileNavigation/MobileNavigation.tsx
+++ b/apps/docs/src/app/_components/layout/MobileNavigation/MobileNavigation.tsx
@@ -1,5 +1,4 @@
 import type { FC } from "react";
-import styles from "@/app/layout.module.scss";
 import MainNavigation from "@/app/_components/layout/MainNavigation";
 import {
   ActionGroup,
@@ -50,11 +49,7 @@ export const MobileNavigation: FC<Props> = (props) => {
         <Button variant="plain">
           <IconMenu />
         </Button>
-        <Modal
-          offCanvas
-          className={styles.mobileNavigationOffCanvas}
-          showCloseButton
-        >
+        <Modal offCanvas showCloseButton>
           <Heading>Menü</Heading>
           <Content>
             <Section>

--- a/apps/docs/src/app/layout.module.scss
+++ b/apps/docs/src/app/layout.module.scss
@@ -83,11 +83,6 @@
   display: flex;
   flex-direction: column;
   row-gap: var(--section--spacing);
-
-  > h3,
-  > h4 {
-    margin-top: var(--size-px--m);
-  }
 }
 
 /*


### PR DESCRIPTION
Deletes two `apps/docs` CSS rules that match nothing in the rendered DOM. No
rendering change — verified, see below.

Follow-up from the `selector-max-type` triage in #3091, where these three
warnings were disabled rather than changed, because switching them to a class
selector would have *activated* them.

## 1. `.mainContent > h3, > h4 { margin-top }` — obsolete

`apps/docs/src/app/layout.module.scss`

Live until #2573 wrapped the MDX output in `<div style="display: contents">`.
`display: contents` removes the box from layout but not from the DOM, so the
child combinator stopped matching and the extra spacing silently disappeared.

#2870 ("docs: fix heading spacing") fixed that at the heading instead:

```css
.anchorLinkHeading {
  &h3 { margin-top: var(--section--sub-heading-spacing-m); }
}
```

That is what puts 24px above every MDX `##` today. The layout rule has been
redundant since.

> [!NOTE]
> #3091's comment on this rule has the reasoning backwards — "the child
> combinator is load-bearing … only headings rendered directly here match".
> Because the MDX view wraps its output, *none* match.

## 2. `.mobileNavigationOffCanvas h3 { display: none }` — never applied

`apps/docs/src/app/_components/layout/Header/Header.module.scss`

A `styles` import/class mismatch, dead since the day it was written. #2338 put
the class in `Header.module.scss`, but its only consumer,
`MobileNavigation.tsx`, imports `@/app/layout.module.scss` — which has no such
key. `styles.mobileNavigationOffCanvas` was `undefined`, so React dropped the
`className`. Next types CSS modules as `{ [key: string]: string }`, so nothing
flagged it.

Also removed the dangling reference and the import that became unused with it.

**Activating the rule today would be a regression.** In the off-canvas menu the
two `h3`s are "Components" and "Integrations" — `Section` headings from
`MainNavigation`. Hiding them would drop the labels but keep the
expand-all/grouping buttons that sit on the "Components" header row, leaving two
unlabelled icon buttons. "Menü" is an `h2` and unaffected. No indication UX wants
this; the desktop navigation shows the same headings.

## Verification

Ran the docs app and inspected the live DOM (`pnpm nx dev docs`), plus the
prerendered output of `pnpm nx build docs`.

| Check | Result |
| --- | --- |
| `.mainContent > h3, > h4` matches | **0** — headings sit in the `display: contents` wrapper (11 `h3`/`h4` as grandchildren) |
| `h3` computed `margin-top` | 24px, before **and** after — from `.anchorLinkHeading&h3` |
| `.mobileNavigationOffCanvas` in the document | **absent** — off-canvas root is `div.flow--overlay.flow--modal--off-canvas` |
| Mobile menu at 900px, before vs. after | Identical |
| `stylelint` on both files | 3 `selector-max-type` warnings → 0 |
| `pnpm lint`, `pnpm nx build docs` | Pass |

No visual test snapshots are involved — this is docs layout, not
`packages/components`.

## For UX — not changed here

MDX `###` renders as a plain `Heading level={4}` with **no** top margin (only the
16px `row-gap`); 5 content files use it. The deleted rule wanted 16px there, but
#2870 deliberately moved h3 to the Flow scale, where the h4 counterpart is
`--section--sub-heading-spacing-s` (8px), not 16px. Picking a value is UX's call,
so this PR leaves it alone.

## Note for #3091

Once this lands, #3091 can drop both of its disable blocks — the warnings are
gone with the rules.

related #3091, #3021

🤖 Generated with [Claude Code](https://claude.com/claude-code)
