### PR TITLE
ci: retry a hung visual shard on the PR run too

### DIFF
--- a/.github/actions/prepare-browser-tests/action.yml
+++ b/.github/actions/prepare-browser-tests/action.yml
@@ -1,12 +1,17 @@
 name: Prepare browser tests
 description:
   Answers whether a browser suite has anything to run in this PR, and installs
-  the browser only when it has.
+  the browser only when it has — unless the caller installs it itself.
 
 inputs:
   target:
     description: The nx target the calling job runs, e.g. `test:visual`.
     required: true
+  install:
+    description:
+      Whether to install the browser. Set to `false` to use this as a gate only,
+      when the job installs through another action — `run-visual-shard` does.
+    default: "true"
 
 outputs:
   run:
@@ -31,11 +36,12 @@ runs:
           echo "run=true" >> "$GITHUB_OUTPUT"
         fi
 
-    # Keyed apart from the visual workflows' cache on purpose. They install
-    # Firefox as well, and under one shared key whichever workflow saved first
-    # would decide what the other one finds.
+    # Keyed on the browser set, so this shares with every other WebKit-only
+    # install and stays apart from the full-set one the scheduled and label
+    # visual runs need. Under one shared key whichever saved first would decide
+    # what the others find, and a WebKit-only save leaves them without Firefox.
     - name: Cache the Playwright browser
-      if: steps.affected.outputs.run == 'true'
+      if: steps.affected.outputs.run == 'true' && inputs.install == 'true'
       uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
       with:
         path: ~/.cache/ms-playwright
@@ -45,6 +51,6 @@ runs:
           playwright-webkit-${{ runner.os }}-
 
     - name: Install the Playwright browser
-      if: steps.affected.outputs.run == 'true'
+      if: steps.affected.outputs.run == 'true' && inputs.install == 'true'
       shell: bash
       run: pnpm exec playwright install --with-deps webkit

--- a/.github/actions/run-visual-shard/action.yml
+++ b/.github/actions/run-visual-shard/action.yml
@@ -11,13 +11,13 @@ inputs:
     description: How many shards the suite is split into.
     required: true
   attempts:
-    description:
-      How often to run the shard before calling it failed. Firefox
+    description: How often to run the shard before calling it failed. Firefox
       intermittently hangs on a single file in headless CI — a hang vitest's
-      per-test `retry` cannot recover, only a fresh browser process can. WebKit
-      does not hang, but a contended runner starves it until every screenshot
-      misses its 5s stability budget, which fails a shard just as wrongly. A
-      real diff fails every attempt.
+      per-test `retry` cannot recover, only a fresh browser process can. A real
+      diff fails every attempt. It does not cover every red shard without a diff
+      behind it, though — the attempts share the runner, so a machine where
+      `toMatchScreenshot` never stabilizes fails all of them identically
+      (measured on #3104, 85 of 86 tests into the 5s budget three times over).
     default: "1"
   browser:
     description:

--- a/.github/actions/run-visual-shard/action.yml
+++ b/.github/actions/run-visual-shard/action.yml
@@ -14,27 +14,45 @@ inputs:
     description:
       How often to run the shard before calling it failed. Firefox
       intermittently hangs on a single file in headless CI — a hang vitest's
-      per-test `retry` cannot recover, only a fresh browser process can. A real
-      diff fails every attempt.
+      per-test `retry` cannot recover, only a fresh browser process can. WebKit
+      does not hang, but a contended runner starves it until every screenshot
+      misses its 5s stability budget, which fails a shard just as wrongly. A
+      real diff fails every attempt.
     default: "1"
+  browser:
+    description:
+      Which browser to render in. Empty means both, which is the full signal,
+      because the suite renders one theme in each (WebKit light, Firefox dark).
+      `test.yml` passes `webkit` and trades the dark theme for half the wall
+      clock on the PR path, where the scheduled run covers the rest.
+    default: ""
 
 runs:
   using: composite
   steps:
-    # Both browsers, because the suite renders one theme in each (WebKit light,
-    # Firefox dark) and a full run needs both. Keyed apart from test.yml's
-    # WebKit-only cache, which would otherwise decide what this one finds.
+    # Keyed on the browser set: under one shared key, whichever caller saved
+    # first would decide what the others find — a WebKit-only save would leave
+    # a both-browsers run without Firefox.
     - name: Cache the Playwright browsers
       uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
       with:
         path: ~/.cache/ms-playwright
-        key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+        key:
+          playwright-${{ inputs.browser || 'all' }}-${{ runner.os }}-${{
+          hashFiles('pnpm-lock.yaml') }}
         restore-keys: |
-          playwright-${{ runner.os }}-
+          playwright-${{ inputs.browser || 'all' }}-${{ runner.os }}-
 
+    # `test:browser:prepare` for the full set, so the browser list stays in the
+    # root package.json where the contributor docs point.
     - name: Install the Playwright browsers
       shell: bash
-      run: pnpm test:browser:prepare --only-shell
+      run: |
+        if [ -n "${{ inputs.browser }}" ]; then
+          pnpm exec playwright install --with-deps --only-shell "${{ inputs.browser }}"
+        else
+          pnpm test:browser:prepare --only-shell
+        fi
 
     # `test:visual` only declares `^build`; building the package itself is a
     # superset of that. Outside the retry loop below: a hung browser leaves the
@@ -48,22 +66,27 @@ runs:
     # most of them a pass they never ran.
     #
     # vitest shards by hashing the file paths, so the split is stable and each
-    # shard still runs its files one at a time, in both browsers, against the
+    # shard still runs its files one at a time, in its own browser, against the
     # committed baselines. Same suite, spread over runners.
     - name: Run visual tests (shard ${{ inputs.shard }}/${{ inputs.shards }})
       shell: bash
       run: |
         shard="${{ inputs.shard }}/${{ inputs.shards }}"
         attempts="${{ inputs.attempts }}"
+        browser="${{ inputs.browser }}"
+        args=(--shard="$shard")
+        if [ -n "$browser" ]; then
+          args+=(--browser.name="$browser")
+        fi
         for attempt in $(seq 1 "$attempts"); do
           echo "::group::Visual tests, shard $shard (attempt $attempt/$attempts)"
-          if pnpm --filter @mittwald/flow-remote-react-components test:visual --shard="$shard"; then
+          if pnpm --filter @mittwald/flow-remote-react-components test:visual "${args[@]}"; then
             echo "::endgroup::"
             exit 0
           fi
           echo "::endgroup::"
           if [ "$attempt" -lt "$attempts" ]; then
-            echo "::warning::Shard $shard failed on attempt $attempt/$attempts (likely a flaky firefox hang), retrying..."
+            echo "::warning::Shard $shard failed on attempt $attempt/$attempts (likely a flaky browser hang or a starved runner), retrying..."
           fi
         done
         echo "::error::Shard $shard failed."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -204,15 +204,19 @@ jobs:
           test:cross-version
 
   # Runs the shards through `run-visual-shard`, the same action the scheduled and
-  # label runs use — so the retry lives in one place and this path gets it too.
-  # It is the path every PR crosses, so it is the one that must not report a
-  # starved runner as a diff: run 33626981366 failed 85 of 86 tests with "Could
-  # not capture a stable screenshot within 5000ms", every file, trivial ones
-  # included, on a shard whose baselines nothing in the PR touched.
+  # label runs use, so the shard invocation and its retry live in one place
+  # instead of two.
+  #
+  # What the retry buys is a hung browser process. It does not buy the failure
+  # this path keeps hitting — every test in one shard reporting "Could not
+  # capture a stable screenshot within 5000ms", from the first one on, in both
+  # browsers, while the other shards pass. The attempts share the runner, so all
+  # three fail identically (measured on #3104; it hits roughly 4 of every 10 runs
+  # on main, a different shard each time). That one needs a fix at the root.
   #
   # `attempts` matches the other two; the timeout follows from it, because three
   # attempts of a shard have to fit inside the job. A shard is 3-6 minutes green
-  # and ~8 starved, plus ~3 for setup and the build.
+  # and ~8 when every screenshot times out, plus ~3 for setup and the build.
   visual:
     runs-on: ubuntu-latest
     timeout-minutes: 35

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -203,9 +203,19 @@ jobs:
           pnpm --filter @mittwald/flow-remote-react-components
           test:cross-version
 
+  # Runs the shards through `run-visual-shard`, the same action the scheduled and
+  # label runs use — so the retry lives in one place and this path gets it too.
+  # It is the path every PR crosses, so it is the one that must not report a
+  # starved runner as a diff: run 33626981366 failed 85 of 86 tests with "Could
+  # not capture a stable screenshot within 5000ms", every file, trivial ones
+  # included, on a shard whose baselines nothing in the PR touched.
+  #
+  # `attempts` matches the other two; the timeout follows from it, because three
+  # attempts of a shard have to fit inside the job. A shard is 3-6 minutes green
+  # and ~8 starved, plus ~3 for setup and the build.
   visual:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 35
     strategy:
       # Each shard is a separate signal. A failing one must not cancel the others
       # — the diffs of the shards still running are what tell you whether the
@@ -226,34 +236,28 @@ jobs:
         if: github.ref != 'refs/heads/main'
         run: git branch --track main origin/main
 
-      # The other jobs leave the decision to `nx affected` and use this only to
-      # skip the browser install. The shards call vitest directly (see below), so
-      # here the answer gates the work itself — a PR that touches neither the
-      # components nor the remote packages must not start four browsers.
+      # Gate only — `run-visual-shard` installs the browser it renders in. The
+      # other jobs leave the decision to `nx affected` and use this to skip the
+      # install; here the answer gates the work itself, because a PR that touches
+      # neither the components nor the remote packages must not start four
+      # browsers.
       - uses: ./.github/actions/prepare-browser-tests
         id: suite
         with:
           target: test:visual
+          install: "false"
 
-      # `test:visual` only declares `^build`; building the package itself is a
-      # superset of that, and one `nx run` is all the shards need to be ready.
-      - name: Build the packages the visual suite renders
+      # WebKit only, unlike the scheduled and label runs: the dark theme renders
+      # in Firefox, and trading it for half the wall clock is the deal this path
+      # makes (see the header). Skipping the action outright when the suite is
+      # unaffected also skips its install and build.
+      - uses: ./.github/actions/run-visual-shard
         if: steps.suite.outputs.run == 'true'
-        run: pnpm nx run remote-react-components:build
-
-      # Deliberately not `nx run …:test:visual`: the target is cached, and nx
-      # hands every shard of it the same task hash — with the cache shared across
-      # jobs, three of the four shards would be served a pass they never ran.
-      #
-      # vitest shards by hashing the file paths, so the split is stable and each
-      # shard still runs its files one at a time, in one browser, against the
-      # committed baselines. Same suite, four runners.
-      - name: Run visual tests in Webkit (shard ${{ matrix.shard }})
-        if: steps.suite.outputs.run == 'true'
-        run:
-          pnpm --filter @mittwald/flow-remote-react-components test:visual
-          --shard=${{ matrix.shard }}/${{ strategy.job-total }}
-          --browser.name=webkit
+        with:
+          shard: ${{ matrix.shard }}
+          shards: ${{ strategy.job-total }}
+          attempts: "3"
+          browser: webkit
 
   # The required check. Green only when every job above is.
   main:

--- a/packages/remote-react-components/CONTRIBUTE.md
+++ b/packages/remote-react-components/CONTRIBUTE.md
@@ -213,6 +213,13 @@ runs its own files one at a time, in its own browser process, against the same
 baselines — what it renders is identical to a single-runner run. A failure names
 the shard; its diff images are in that shard's `visual-diffs-*` artifact.
 
+Every path runs a failing shard up to **three times**, in a fresh browser
+process each time, and only then calls it failed. Two things fail a shard
+without a diff behind them: Firefox intermittently hangs on a single file, and a
+contended runner starves the browser until every screenshot misses its stability
+budget. A real diff fails all three attempts. A retry logs a warning, so a shard
+that went green on the second try still says so in the job log.
+
 ## Cross-version smoke tests
 
 Extension developers ship remote apps built against a **published** version of

--- a/packages/remote-react-components/CONTRIBUTE.md
+++ b/packages/remote-react-components/CONTRIBUTE.md
@@ -214,11 +214,17 @@ baselines — what it renders is identical to a single-runner run. A failure nam
 the shard; its diff images are in that shard's `visual-diffs-*` artifact.
 
 Every path runs a failing shard up to **three times**, in a fresh browser
-process each time, and only then calls it failed. Two things fail a shard
-without a diff behind them: Firefox intermittently hangs on a single file, and a
-contended runner starves the browser until every screenshot misses its stability
-budget. A real diff fails all three attempts. A retry logs a warning, so a shard
-that went green on the second try still says so in the job log.
+process each time, and only then calls it failed. It covers the one failure a
+fresh process fixes: Firefox intermittently hangs on a single file, which no
+per-test retry recovers. A real diff fails all three attempts. A retry logs a
+warning, so a shard that went green on the second try still says so in the job
+log.
+
+The attempts share the runner, so they do **not** help against the other red
+without a diff behind it: a shard where every test reports
+`Could not capture a stable screenshot within 5000ms`, from the first test on
+and in both browsers, fails all three the same way. That one is a property of
+the machine the job landed on, and it is still open.
 
 ## Cross-version smoke tests
 


### PR DESCRIPTION
The retry from #3090 landed on the label and scheduled workflows only. `test.yml`'s `visual` job called vitest itself, so the shard invocation and its retry lived in two places. This points the job at `run-visual-shard`, the action the other two paths already use.

## What changes

- **`browser` input on the action.** Empty stays both browsers — what the scheduled and label runs need — and `test.yml` passes `webkit`, keeping the existing trade of the dark theme for half the wall clock. The input also keys the Playwright cache, so a WebKit-only save can no longer leave a full run without Firefox.
- **`install: "false"` on `prepare-browser-tests`.** The visual job uses it as the `nx affected` gate only; the action installs the browser it renders in. Every other caller is untouched.
- **Timeout 20 → 35 minutes.** Three attempts of a shard have to fit inside the job. A shard is 3-6 minutes green and ~8 when every screenshot times out, plus ~3 for setup and the build.
- `CONTRIBUTE.md` documents the retry, and both it and the comments name what the retry does **not** cover — see below.

## What the retry does not fix

The first push of this PR asserted that the retry would have saved [run 33626981366](https://github.com/mittwald/flow/actions/runs/33626981366). Its own CI falsified that, so the claim is out of the comments.

Shard 1 here and shard 5 of the label run failed **all three attempts identically** — 85 of 86 tests, and 118 of 120, reporting `Could not capture a stable screenshot within 5000ms` from the first test on, in **both** browsers, while every other shard passed in four minutes. The attempts share the runner, so a machine that produces this fails all of them. The retry covers a hung browser process, which is the Firefox failure mode; it cannot cover this one.

Nor is it this PR's regression: the same whole-shard red hits roughly **4 of every 10 runs on `main`**, a different shard each time (33631694282, 33626556173, 33608121174, 33607745081, 33599165776), and run 33626981366 was one of them. It wants a fix at the root — worth its own issue.

That leaves a question for review: on the WebKit-only PR path `attempts: "3"` now triples the time to a red signal on a **genuine** diff (26 minutes instead of 8), and WebKit has not been seen to hang. Keeping it aligns the three paths; setting it to `1` here keeps the fast red. I lean towards keeping it aligned, but it is a real trade.

## Verification

Both paths run on this PR: `CONTRIBUTE.md` makes `remote-react-components` affected, so `test.yml`'s `visual` job exercises the new WebKit path, and the `run-visual-tests` label runs the changed action in its both-browsers default. The retry loop itself is confirmed working — three attempts, a warning between them, the shard's own exit code.

One-off cost: the action's cache key changes from `playwright-<os>-<hash>` to `playwright-all-<os>-<hash>`, so the label and scheduled runs install both browsers cold once.

related #3090

🤖 Generated with [Claude Code](https://claude.com/claude-code)