### PR TITLE
revert: retry a hung visual shard on the label and scheduled visual runs

### DIFF
--- a/.github/actions/run-visual-shard/action.yml
+++ b/.github/actions/run-visual-shard/action.yml
@@ -15,7 +15,10 @@ inputs:
       How often to run the shard before calling it failed. Firefox
       intermittently hangs on a single file in headless CI — a hang vitest's
       per-test `retry` cannot recover, only a fresh browser process can. A real
-      diff fails every attempt.
+      diff fails every attempt. No caller passes it any more, because the
+      failure it was aimed at is not one a re-run recovers — the attempts share
+      the runner, so all three fail identically (#3106). Kept for a hang that
+      shows up on its own.
     default: "1"
 
 runs:

--- a/.github/workflows/test-visual-label.yml
+++ b/.github/workflows/test-visual-label.yml
@@ -69,15 +69,10 @@ jobs:
   # browsers, so one runner spent 24-34 minutes on it. Sharding is the only split
   # that keeps each file's conditions identical: every shard still runs its own
   # files one at a time, in its own browser process.
-  #
-  # `attempts` matches the scheduled run, and the timeout matches it for the same
-  # reason: three attempts of a shard have to fit inside the job. This is the
-  # path contributors are told to use, so it is the path that must not report a
-  # contended runner as a diff.
   run-visual-tests:
     needs: prepare
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 30
     strategy:
       # A failing shard must not cancel the others — the diffs of the shards
       # still running are what tell you whether the change is broad or local.
@@ -98,7 +93,6 @@ jobs:
         with:
           shard: ${{ matrix.shard }}
           shards: ${{ strategy.job-total }}
-          attempts: "3"
 
       # vitest writes the diffs into `.vitest-attachments`, six directory levels
       # deep. Uploaded as they lie, the zip opens on a dot directory Finder does

--- a/.github/workflows/test-visual-scheduled.yml
+++ b/.github/workflows/test-visual-scheduled.yml
@@ -12,12 +12,15 @@ jobs:
   # styling from any page it is not showing), and it renders every file in both
   # browsers, so one runner spent 24-34 minutes on it. Sharding is the only split
   # that keeps each file's conditions identical: every shard still runs its own
-  # files one at a time, in its own browser process. The retry lives inside the
-  # shard now, so a flaky firefox hang re-runs a sixth of the suite, not all of
-  # it.
+  # files one at a time, in its own browser process.
+  #
+  # No retry: the three attempts this job carried since before the sharding never
+  # recovered the failure they were aimed at. All three fail identically, because
+  # they share the runner — see #3106. The timeout is the label path's, which is
+  # calibrated for this same shape at one attempt.
   visual:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -33,7 +36,6 @@ jobs:
         with:
           shard: ${{ matrix.shard }}
           shards: ${{ strategy.job-total }}
-          attempts: "3"
 
   alert:
     needs: visual


### PR DESCRIPTION
Reverts #3090, and removes the same retry from the scheduled run.

The premise did not hold. #3090 read the whole-shard failure — every test in one shard reporting `Could not capture a stable screenshot within 5000ms`, 63 of 64 blocks on `firefox-linux` — as a hung browser process, and gave the label path three attempts against it.

The first real exercise of that retry was [run 33633352648](https://github.com/mittwald/flow/actions/runs/33633352648) on #3104. It ran all three attempts: **118 of 120 tests failed each time**, in both browsers, 1110s in total. Shard 1 of the same PR's `test.yml` run did the same — 85 of 86 tests, at 474s, 472s and 472s. The attempts share the runner, so a machine that produces this failure produces it three times.

So the retry buys nothing on the observed evidence, and it costs the label path 15 minutes of `timeout-minutes` plus up to 3× the runner time whenever a diff is genuine — the case where a reviewer wants the diff artifacts quickly.

## Two commits, because only one of them is a revert

**[Revert #3090](https://github.com/mittwald/flow/pull/3107/commits/1a4a99e72)** — `attempts: "3"` and `timeout-minutes: 45` off the label path, back to 30. A plain `git revert`, one file.

**The scheduled run** is not #3090's doing, so removing its retry is a change rather than a revert. It is where the retry started: three attempts as a step-level loop over the whole unsharded suite, from before #3006 sharded it, on the same firefox-hang reasoning. Same evidence applies, so it goes too. Nightly runner time is cheaper than a PR's, but three identical failures buy nothing at any price, and the red they report is unchanged.

Its timeout goes 45 → 30 as well, the label path's number for this same shape at one attempt. 45 was sized for the unsharded job, where a single attempt took 24-34 minutes.

## What stays

`attempts` stays on `.github/actions/run-visual-shard`, now with no caller. It documents a real mechanism for a hang that shows up on its own, and deleting the loop would reach past this revert into #3006. Its description now names the failure it does **not** cover and points at #3106. Say the word and I strip it.

## What remains open

The failure itself is #3106, with the five `main` runs it hit and the lead #3090 already noted: `toMatchScreenshot` runs on vitest's default 5000ms stability budget, while `waitForPaintedContent` right beside it deliberately carries 20s for slower CI hardware.

After this, nothing retries a visual shard anywhere, so #3106 reports as a plain red shard with no diff artifacts until it is fixed. #3104, which wired the same retry into `test.yml`, is closed for the same reason.

related #3090, #3106

🤖 Generated with [Claude Code](https://claude.com/claude-code)