### PR TITLE
docs: layout and stylesheet guidance for consumers outside mStudio

### DIFF
--- a/apps/docs/src/content/foundations/structure/layout/examples/page-layout.tsx
+++ b/apps/docs/src/content/foundations/structure/layout/examples/page-layout.tsx
@@ -1,0 +1,75 @@
+import {
+  ColumnLayout,
+  Content,
+  Flex,
+  Header,
+  HeaderNavigation,
+  Heading,
+  IconMittwald,
+  Label,
+  LabeledValue,
+  LayoutCard,
+  Link,
+  Navigation,
+  NavigationGroup,
+  Section,
+  Text,
+} from "@mittwald/flow-react-components";
+
+<Flex direction="column" gap="s">
+  <Header>
+    <HeaderNavigation aria-label="Hauptnavigation">
+      <IconMittwald />
+      <Link href="#" aria-current="page">
+        Projekte
+      </Link>
+      <Link href="#">Domains</Link>
+      <Link href="#">Abrechnung</Link>
+    </HeaderNavigation>
+  </Header>
+
+  <ColumnLayout s={[null, 1]} m={[1, 2]} l={[1, 4]} gap="s">
+    <LayoutCard>
+      <Navigation aria-label="Projektnavigation">
+        <NavigationGroup collapsable defaultExpanded>
+          <Label>Projekt</Label>
+          <Link href="#" aria-current="page">
+            Übersicht
+          </Link>
+          <Link href="#">Apps</Link>
+          <Link href="#">Container</Link>
+        </NavigationGroup>
+        <NavigationGroup collapsable>
+          <Label>Daten</Label>
+          <Link href="#">Datenbanken</Link>
+          <Link href="#">Backups</Link>
+        </NavigationGroup>
+      </Navigation>
+    </LayoutCard>
+
+    <LayoutCard>
+      <Section>
+        <Heading>Übersicht</Heading>
+        <Text>
+          Das Projekt bündelt Apps, Datenbanken und Domains
+          einer Website. Die Kennzahlen darunter beziehen
+          sich auf den laufenden Abrechnungszeitraum.
+        </Text>
+        <ColumnLayout m={[1, 1]} l={[1, 1, 1]}>
+          <LabeledValue>
+            <Label>Apps</Label>
+            <Content>3</Content>
+          </LabeledValue>
+          <LabeledValue>
+            <Label>Speicherplatz</Label>
+            <Content>12,4 von 25 GB</Content>
+          </LabeledValue>
+          <LabeledValue>
+            <Label>Domains</Label>
+            <Content>2</Content>
+          </LabeledValue>
+        </ColumnLayout>
+      </Section>
+    </LayoutCard>
+  </ColumnLayout>
+</Flex>;

--- a/apps/docs/src/content/foundations/structure/layout/index.mdx
+++ b/apps/docs/src/content/foundations/structure/layout/index.mdx
@@ -34,8 +34,6 @@ Bereiche einteilen: **Header**, **Side-Navigation**, **Content** und
 Components und deren Komposition bestimmt. In unseren Components ist das
 [Spacing](/foundations/structure/spacing) bereits integriert.
 
-Verschiedene Layouts mit Code zum Kopieren finden sich unter Code Templates.
-
 <DoAndDont>
   <Info example="general-layout" heading="Layout-Aufbau">
     Grobes Layout einer Seite. Eingeteilt in Header-, Side-Navigation- und
@@ -46,6 +44,24 @@ Verschiedene Layouts mit Code zum Kopieren finden sich unter Code Templates.
     Navigation.
   </MStudio>
 </DoAndDont>
+
+## Aufbau in Code
+
+Die vier Bereiche entstehen aus der Komposition weniger Components – eigenes
+Grid- oder Flex-CSS braucht es dafür nicht. Der Header trägt eine
+[HeaderNavigation](/components/navigation/header-navigation), die
+Side-Navigation eine [Navigation](/components/navigation/navigation) in einer
+[LayoutCard](/components/structure/layout-card), der Content eine weitere
+LayoutCard mit [Section](/components/structure/section).
+
+Die Aufteilung zwischen Side-Navigation und Content übernimmt das
+[ColumnLayout](/components/structure/column-layout): `l={[1, 4]}` gibt der
+Navigation ein Fünftel der Breite, `s={[null, 1]}` blendet sie auf schmalen
+Containern aus. Es rechnet dabei mit Container Queries, nicht mit der
+Fensterbreite – ein Layout, das in einer Spalte steckt, verhält sich daher
+richtig, ohne dass du Breakpoints pflegst.
+
+<LiveCodeEditor example="page-layout" editorCollapsed />
 
 ## Header
 

--- a/apps/docs/src/content/get-started/installation/index.mdx
+++ b/apps/docs/src/content/get-started/installation/index.mdx
@@ -27,6 +27,47 @@ diese Zeile zum Einstiegspunkt deines Projektes hinzu.
 import "@mittwald/flow-react-components/all.css";
 ```
 
+## Flows Styles überschreiben
+
+`all.css` ist ungelayert: welche Regel gewinnt, entscheidet sich über Spezifität
+und Quell-Reihenfolge. Jede eigene Überschreibung muss deshalb den Selektor von
+Flow übertreffen – in der Praxis mit Nachfahren-Ketten oder `!important`.
+
+Willst du Flows Styles überschreiben, importiere stattdessen die gelayerte
+Variante:
+
+```
+import "@mittwald/flow-react-components/all-layered.css";
+```
+
+Ihre Styles liegen in
+[CSS Cascade Layers](https://developer.mozilla.org/de/docs/Web/CSS/@layer). Nach
+deren Regeln gewinnt ungelayertes CSS immer gegen gelayertes – dein eigenes CSS
+setzt sich damit ohne Spezifitäts-Tricks durch:
+
+```css
+/* Gewinnt gegen Flows .flow--button, ohne !important */
+.flow--button {
+  border-radius: 0;
+}
+```
+
+Wie die Klassennamen aufgebaut sind und wann welche Variante passt, steht unter
+[Standalone Stylesheet](/get-started/stylesheet).
+
+## Schriftarten
+
+Das Stylesheet lädt Inter und FiraCode per `@font-face` von `cdn.mittwald.de`.
+Setzt deine Anwendung eine Content Security Policy, muss `font-src` diesen Host
+erlauben:
+
+```
+font-src 'self' https://cdn.mittwald.de;
+```
+
+Fehlt die Freigabe, bricht der Font-Request ab und der Browser stellt die
+Anwendung ohne Rückmeldung in der Systemschrift dar.
+
 ---
 
 # Defaults für Components festlegen


### PR DESCRIPTION
Two documentation gaps found by reverse-engineering [mittwald/mstudiofaq](https://github.com/mittwald/mstudiofaq), the first larger external consumer of Flow 1.1. Both cost that app real code, and both are fixable with material Flow already has.

## The layout page pointed at a section that does not exist

`foundations/structure/layout` described Header, Side-Navigation and Content in prose and closed with:

> Verschiedene Layouts mit Code zum Kopieren finden sich unter Code Templates.

That was the only occurrence of "Code Template" in the whole content tree — the single pointer to copyable layout code led nowhere. What the page does show, `general-layout.tsx` and `mStudio-layout.tsx`, are wireframe drawings made from a raw `div` with inline `gridTemplateAreas`: they explain the concept and model the wrong approach at the same time.

The consumer's answer was 438 lines of own grid CSS with BEM classes and a hand-maintained 900px breakpoint, for a shell that mStudio covers in 26 lines because its structure lives in `ShellComponent`.

This adds an "Aufbau in Code" section that assembles the four areas from Flow components — `HeaderNavigation` in a `Header`, `Navigation` in a `LayoutCard`, a `LayoutCard` with `Section` for the content — and lets `ColumnLayout` carry the split. The prose names the two props that do the work (`l={[1, 4]}`, `s={[null, 1]}`) and the fact that `ColumnLayout` measures its container rather than the window, so a nested layout needs no breakpoints of its own. The dead reference is gone.

Verified in the dev server: at a 1116px container the grid resolves to `221.6px 886.4px`, at a 375px viewport to a single column with the navigation `display: none` and no horizontal page scroll.

## Two first-day facts lived on pages a React consumer never opens

`all-layered.css` and the reason to prefer it are documented on the Standalone Stylesheet page, whose introduction addresses people *using their own framework instead of* the React components. So a React consumer takes `all.css` from the installation page and then fights specificity — the consumer app ended up with descendant chains and an `!important` for overrides the layered variant makes trivial.

Separately, the `@font-face` rules load Inter and FiraCode from `cdn.mittwald.de`. An app with a Content Security Policy must allow that host in `font-src`, or the request fails and the app renders in the system font with no error.

Both are now on the installation page next to the import line, with a pointer to the stylesheet page for the details.

## Scope

Docs only, so this publishes nothing. Content is German per `apps/docs/README.md`; `pnpm nx test:links docs` passes.

Two findings from the same analysis are deliberately **not** in here, because checking them refuted them:

- **Alert heading level.** `Alert` already sets `level: 3` in its PropsContext (`Notification` sets `level: 4`). The consumer's `h2`-before-`h1` came from passing `level={2}` explicitly, overriding a correct default. Forcing the level would remove a legitimate escape hatch and break consumers.
- **Font delivery.** `cdn.mittwald.de` answers `access-control-allow-origin: *` for every origin tested, including localhost. The consumer's comment claiming the CDN restricts CORS to mittwald domains is wrong, so there is nothing to fix in `fonts.scss` — only the CSP note above, which is real.

Remaining items from the analysis that need a decision rather than a patch: merging the `templates/` section that sits unmerged on another branch (it is what the layout page's dead reference was reaching for), the 2.4 MB a ~20-component app pulls in despite `sideEffects` being set, the unexplained `@teispace/next-themes` republish in `packages/components`, and two missing building blocks — a clickable card and a theme toggle with sun/moon icons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)