### PR TITLE
ci(update-screenshots): run the update in the verify runs' six shards

### DIFF
--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -103,8 +103,31 @@ jobs:
       # output made it into the job log, the failure summary never did — three
       # runs in a row went red with nothing but a line cut off mid-word to show
       # for it. Calling vitest directly streams the whole run.
+      #
+      # In the same six shards the verify runs use (test-visual-label.yml,
+      # test-visual-scheduled.yml), one after another: the update needs every
+      # baseline in one checkout, so it cannot spread them over runners. The
+      # split is not for speed. With `fileParallelism: false` vitest opens one
+      # page per browser for the whole run and plays every test file into it as
+      # an iframe, and that page's memory grows with each file — every
+      # unsharded run since 2026-09-02 lost the browser around the 105th of 168
+      # file runs (`[vitest] Browser connection was closed while running
+      # tests`, #3118). Each shard is its own vitest process with fresh
+      # browsers, so no page ever carries more than a sixth of the suite — the
+      # conditions the baselines are verified under. vitest hashes the file
+      # paths into shards, so the split is the verify runs' split.
       - name: Update Visual Regression Screenshots
-        run: pnpm --filter @mittwald/flow-remote-react-components test:visual:update
+        run: |
+          shards=6
+          for shard in $(seq 1 "$shards"); do
+            echo "::group::Visual tests, shard $shard/$shards"
+            if ! pnpm --filter @mittwald/flow-remote-react-components test:visual:update --shard="$shard/$shards"; then
+              echo "::endgroup::"
+              echo "::error::Shard $shard/$shards failed."
+              exit 1
+            fi
+            echo "::endgroup::"
+          done
       # check what changed
       - name: Check for changes
         id: check_changes

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -92,8 +92,19 @@ jobs:
 
       - run: pnpm test:browser:prepare --only-shell
 
+      # `test:visual` only declares `^build`; building the package itself is a
+      # superset of that (same as .github/actions/run-visual-shard).
+      - name: Build the packages the visual suite renders
+        run: pnpm nx run remote-react-components:build
+
+      # Deliberately not `pnpm test:visual --update` (= `nx run-many`): nx
+      # buffers a task's output and prints it when the task ends, and the
+      # process exits before the pipe is drained. The first ~64 KB of vitest's
+      # output made it into the job log, the failure summary never did — three
+      # runs in a row went red with nothing but a line cut off mid-word to show
+      # for it. Calling vitest directly streams the whole run.
       - name: Update Visual Regression Screenshots
-        run: pnpm test:visual --update
+        run: pnpm --filter @mittwald/flow-remote-react-components test:visual:update
       # check what changed
       - name: Check for changes
         id: check_changes


### PR DESCRIPTION
Every `update-screenshots` run since 2026-09-02 died after ~5.7 min of vitest (33646718925, 33728354705, 33730938281, plus the re-labels on #3082 / #3094), while the sharded verify runs on the same `main` state were green. The log could not say why: `pnpm test:visual --update` ran through `nx run-many`, which buffers the task output and prints it at the end — the process exited before the pipe was drained, so the log stopped mid-word after the first ~64 KB of vitest output.

Streaming the output (first commit) showed the failure:

```
Error: Failed to run the test …/src/tests/visual/Checkbox.browser.test.tsx.
Caused by: Error: [vitest] Browser connection was closed while running tests. Was the page closed unexpectedly?
Caused by: Error: [birpc] rpc is closed, cannot call "createTesters"
 Test Files  105 passed (168)
```

Deterministic, not flaky: four runs on three branches died around the 105th of 168 file runs. With `fileParallelism: false` vitest opens one page per browser for the whole run and plays every test file into it as an iframe, and that page's memory grows with each file (on macOS the WebKit content process peaks at 6.5 GB). The verify runs never saw it because they run six shards on six runners.

## Changes

- Build through nx, then call vitest directly — the split `.github/actions/run-visual-shard` already uses — so the whole run streams into the log.
- Run the update in the verify runs' six shards, one after another in the same job: each shard is a fresh vitest process with fresh browsers, no page carries more than a sixth of the suite, and the baselines are written under the conditions they are verified under.

## Verification

Run 33739227127 on this branch: six shards, 28 files each, 716 tests green, 11 min for the step, no baseline changes (`main` is current). The unsharded variant on the previous commit (33737631168) reproduced the crash.

The memory growth itself is tracked in #3119.

Related: #3094, #3106, #3119

🤖 Generated with [Claude Code](https://claude.com/claude-code)