### PR TITLE
test(remote-react-components): keep the cross-version harness in one tester iframe

### DIFF
--- a/packages/remote-react-components/e2e/cross-version-inprocess/vitest.config.ts
+++ b/packages/remote-react-components/e2e/cross-version-inprocess/vitest.config.ts
@@ -28,6 +28,25 @@ export default mergeConfig(viteConfig, {
       "dev/vitest/setupBrowser.ts",
     ],
     include: REUSED_VISUAL_TESTS,
+    /*
+     * One tester iframe for the whole run, for the same reason the package's
+     * `visual` project sets it: Playwright's WebKit never releases a removed
+     * iframe's document, so vitest's per-file iframe churn leaves every
+     * finished file's realm behind — component library, all.css, fonts, last
+     * render — until the page dies mid-run (#3119). This harness reuses the
+     * same corpus on one browser, and it died at file 60 of 84 with
+     * `Browser connection was closed while running tests`.
+     *
+     * The shared realm suits it: setup.ts's first-wins `customElements.define`
+     * patch keeps the OLD flr-* registrations for the whole run, which is
+     * exactly one version per run anyway.
+     */
+    isolate: false,
+    /*
+     * One page at a time. `browser.fileParallelism` is deprecated in vitest 4
+     * in favour of this top-level option.
+     */
+    fileParallelism: false,
     browser: {
       ...vitestBrowserTestConfig.browser,
       // dev/vitest/setupBrowser.ts calls it, so it has to be registered here
@@ -37,7 +56,6 @@ export default mergeConfig(viteConfig, {
         serveFontsLocally,
       },
       headless: true,
-      fileParallelism: false,
       // HTML comparison, not pixels — failure screenshots would only pollute the
       // reused tests' src/**/__screenshots__ dir.
       screenshotFailures: false,


### PR DESCRIPTION
The in-process cross-version run dies mid-suite in the label workflow: `Browser connection was closed while running tests. Was the page closed unexpectedly?` at file 60 of 84 — 59 files and 150 tests green, no test failure of its own. Seen on the `run-cross-version-tests` label run of #3084, which is otherwise unrelated to this.

## Cause

The WebKit iframe leak from #3119. Vitest gives every test file a fresh tester iframe and removes the previous one, and Playwright's WebKit never releases a removed iframe's document — component library, `all.css`, fonts and last render stay alive, roughly 200 MB per file.

`e2e/cross-version-inprocess/vitest.config.ts` inherits the shared browser config but never got the `isolate: false` that #3119 put on the package's `visual` project. It reuses the same corpus that killed the unsharded `update-screenshots` run, on one browser, so it hits the same wall.

The scheduled workflow survives only because it shards the run three ways (`FLOW_CROSS_VERSION_SHARD=n/3`, ~28 files per shard — under the threshold). `test-cross-version-label.yml` runs all 84 files in one process, so the failure shows up there alone.

## Change

- `isolate: false` — one tester iframe for the whole run. The shared realm suits this harness: `setup.ts`'s first-wins `customElements.define` patch keeps the OLD `flr-*` registrations for the whole run, and one run covers exactly one version anyway.
- `fileParallelism` moves out of `browser`, where vitest 4 deprecates it in favour of the top-level option. Behaviour unchanged — the run was already serial.

No sharding added to the label workflow: without the per-file iframe churn there is nothing left to accumulate, and the run is now short enough that shard setup would cost more than it saves.

## Verification

Ran the exact reference pass that failed in CI (`FLOW_CROSS_VERSION=current … --update`):

| | before (CI) | after (local) |
| --- | --- | --- |
| test files | 59 passed, died at 60 of 84 | **84/84 passed** |
| tests | 150 | **179** |
| duration | 243 s | **86 s** |
| import | 129.7 s | **3.3 s** |

The import collapse is the library being loaded once instead of per file. The label run on this PR exercises the full path.

related #3119