### PR TITLE
fix(ci): read preview TLS certificate IDs from secrets, not vars

### DIFF
--- a/.github/workflows/build-previews.yml
+++ b/.github/workflows/build-previews.yml
@@ -160,9 +160,9 @@ jobs:
           MITTWALD_PROJECT_ID: ${{ secrets.MITTWALD_PROJECT_ID }}
           MITTWALD_API_TOKEN: ${{ secrets.MITTWALD_API_TOKEN }}
           MITTWALD_TLS_CERTIFICATE_ID_DOCS:
-            ${{ vars.MITTWALD_TLS_CERTIFICATE_ID_DOCS }}
+            ${{ secrets.MITTWALD_TLS_CERTIFICATE_ID_DOCS }}
           MITTWALD_TLS_CERTIFICATE_ID_STORYBOOK:
-            ${{ vars.MITTWALD_TLS_CERTIFICATE_ID_STORYBOOK }}
+            ${{ secrets.MITTWALD_TLS_CERTIFICATE_ID_STORYBOOK }}
           # Derive the exact refs the build job pushed (type=ref,event=pr =>
           # `pr-<number>`). Deriving them here avoids the matrix job-output
           # clobber that left one of the two empty and half-deployed previews.

--- a/dev/deploy-review.ts
+++ b/dev/deploy-review.ts
@@ -315,7 +315,15 @@ class ReviewDeployer {
   ): Promise<void> {
     const certificateId = this.getTlsCertificateId(imageType);
 
+    // Loudly, because this used to be a silent `return`: the workflow read the
+    // IDs from `vars.*` while they are stored as secrets, so every preview fell
+    // back to ACME without a trace in the log — until enough PRs had piled up to
+    // hit the ACME rate limit and the hosts started serving the ingress
+    // controller's placeholder certificate.
     if (!certificateId) {
+      console.warn(
+        `⚠️  No TLS certificate ID configured for ${imageType} — ingress ${ingressId} falls back to ACME`,
+      );
       return;
     }
 


### PR DESCRIPTION
## What & why

Preview deploys have linked the wildcard certificate since #2798, but that has never actually taken effect.

`build-previews.yml` reads the two IDs from `vars.*`:

```yaml
MITTWALD_TLS_CERTIFICATE_ID_DOCS: ${{ vars.MITTWALD_TLS_CERTIFICATE_ID_DOCS }}
```

Both values are stored as **repository secrets**, not variables — `gh variable list` knows only `AUTO_PUBLISH_ENABLED`, while `gh secret list` shows `MITTWALD_TLS_CERTIFICATE_ID_DOCS` and `..._STORYBOOK` (added 2026-08-05, matching #2798). `vars.X` resolves to an empty string when the variable does not exist, so `getTlsCertificateId()` always returned `""` and `connectTlsCertificate()` bailed out at its `if (!certificateId)` guard — silently, with no log line.

The consequence, measured across the review project's 83 hostnames with `openssl s_client`:

| Served certificate | Hosts |
|---|---:|
| matching wildcard | 4 |
| own single-host ACME certificate | 42 |
| **`CN=Kubernetes Ingress Controller Fake Certificate`** | **37** |

Every preview fell back to ACME. Once enough PRs were open to exhaust the Let's Encrypt rate limit, new hosts stopped getting a certificate at all and served the ingress controller's placeholder — a TLS warning in the browser on 37 of them.

This PR:

1. Switches both env values to `secrets.*`, which is all that is needed for new previews to pick up the wildcard.
2. Makes the skip visible. The silent `return` is why this went unnoticed for weeks; now a missing ID says so in the deploy log.

The ~76 already-affected ingresses have been corrected out of band via `PATCH /v2/ingresses/{id}/tls`, so all docs and storybook review hosts currently serve their wildcard. This PR is what keeps it that way for new PRs.

An alternative worth considering: certificate IDs are not secret, so moving them to repository *variables* and dropping the secrets would fit `vars.*` better. Either direction works — the bug is only that the two halves disagree. Happy to flip it if maintainers prefer that.

## Base branch & title

`fix:` → base `main`.

## Checklist

- [x] PR title is a Conventional Commit and matches the base branch above
- [x] `prettier --check` and `eslint` clean on both changed files (no test target covers `dev/deploy-review.ts`; the change is a log line plus two workflow expressions)
- [x] **Generated code is committed** — no generated output affected
- [x] User-facing strings — none (CI log output only)
- [x] Docs updated if a public API changed — no public API change
