### PR TITLE
fix(ci): rebase the release commit when the line moved during publish

### DIFF
--- a/.github/scripts/push-release.mjs
+++ b/.github/scripts/push-release.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+// Advance a standing release line (`main` / `next`) to the release commit and
+// place its tag — tolerating a merge that landed on that line while this run
+// was building and publishing.
+//
+// Called only AFTER `lerna publish` succeeded, from `publish.yml`. At that
+// point npm already has the version, so this push is the last thing standing
+// between a published release and a consistent repository. It must not fail on
+// a non-fast-forward.
+//
+// WHY THE WORKFLOW'S `concurrency` GROUP DOES NOT COVER THIS
+// `mutate-main` / `mutate-next` serialize workflow RUNS against each other. A
+// pull request merged through the GitHub UI is not a run, so it can land in the
+// ~10 minute window between the release commit being created and this push.
+// Observed on 1.1.17: #3125 was merged while #3053's publish was building, the
+// plain `git push origin HEAD:main` was rejected as non-fast-forward, and the
+// release ended up on npm with no version bump commit, no tag and no GitHub
+// Release on `main`.
+//
+// Usage: node .github/scripts/push-release.mjs <branch> <tag>
+
+import { spawnSync } from "node:child_process";
+
+// Enough to outlast a burst of merges; one rebase attempt costs about a second.
+// Bounded so a pathological loop fails the job instead of running to the step
+// timeout.
+const MAX_ATTEMPTS = 5;
+
+const [branch, tag] = process.argv.slice(2);
+
+if (!branch || !tag) {
+  console.error("Usage: push-release.mjs <branch> <tag>");
+  process.exit(1);
+}
+
+const tryGit = (...args) => spawnSync("git", args, { stdio: "inherit" }).status;
+
+const git = (...args) => {
+  const status = tryGit(...args);
+  if (status !== 0) {
+    fail(`git ${args.join(" ")} exited with ${status}.`);
+  }
+};
+
+function fail(message) {
+  console.error(
+    `::error::${message} The packages are already on npm — advance ` +
+      `'${branch}' and push tag '${tag}' by hand.`,
+  );
+  process.exit(1);
+}
+
+// `--no-verify` at every push even though the workflow sets
+// SKIP_INSTALL_SIMPLE_GIT_HOOKS: this is the one place where a `pre-push` hook
+// aborting strands a release npm has already accepted (#2932), so the guard
+// does not depend on a workflow-level env var staying put.
+const push = () => tryGit("push", "--no-verify", "origin", `HEAD:${branch}`);
+
+for (let attempt = 1; push() !== 0; attempt++) {
+  if (attempt >= MAX_ATTEMPTS) {
+    fail(
+      `Could not push the release commit to '${branch}' after ${MAX_ATTEMPTS} attempts.`,
+    );
+  }
+
+  console.log(
+    `::warning::'${branch}' advanced while this release was building — ` +
+      `rebasing the release commit onto the new tip (attempt ${attempt}).`,
+  );
+
+  git("fetch", "origin", branch);
+
+  // Rebase onto FETCH_HEAD, not `origin/<branch>`: actions/checkout configures
+  // a single-branch refspec, so whether the remote-tracking ref follows this
+  // fetch depends on which line the run is on. FETCH_HEAD is what we just
+  // fetched, always.
+  //
+  // The only commit replayed is the `chore(release):` bump — or nothing at all,
+  // for a pre-graduated promotion whose version commit arrived with the merge,
+  // where the rebase degenerates into the fast-forward that push needed. It
+  // touches package manifests and changelogs, which no concurrent merge writes:
+  // every other writer of those files serializes on the same concurrency group.
+  // A conflict therefore means something unmodelled happened. Stop with the
+  // working tree clean rather than resolve it blind.
+  //
+  // `--autostash` because `pnpm build` ran between the release commit and here:
+  // a stray regenerated file would otherwise make rebase refuse outright, and
+  // the tree's contents no longer matter — everything is published.
+  if (tryGit("rebase", "--autostash", "FETCH_HEAD") !== 0) {
+    tryGit("rebase", "--abort");
+    fail(`Rebasing the release commit onto 'origin/${branch}' hit a conflict.`);
+  }
+}
+
+// Re-point rather than create-if-missing. A rebase leaves lerna's tag on the
+// pre-rebase commit, which is now unreachable — without `-f` the tag would mark
+// a commit that is on no branch. In the happy path HEAD is already what lerna
+// tagged, so this rewrites the tag onto the same commit: a no-op. The
+// pre-graduated promotion path (RFC #2711) has no tag yet and gets one here,
+// exactly as before.
+git("tag", "-f", "-m", tag, tag, "HEAD");
+git("push", "--no-verify", "origin", `refs/tags/${tag}`);

--- a/.github/scripts/push-release.test.mjs
+++ b/.github/scripts/push-release.test.mjs
@@ -1,0 +1,225 @@
+// @ts-check
+// Integration tests for `push-release.mjs`, driven against real git
+// repositories in a temp directory. The whole point of the script is how git
+// behaves under a concurrent push, so there is nothing worth testing in
+// isolation from git itself.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const SCRIPT = resolve(import.meta.dirname, "push-release.mjs");
+
+const git = (cwd, ...args) =>
+  execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+
+/** A clone with an identity and no hooks, so pushes behave like the runner's. */
+const clone = (origin, dir) => {
+  execFileSync("git", ["clone", "--quiet", origin, dir]);
+  git(dir, "config", "user.name", "Test");
+  git(dir, "config", "user.email", "test@example.com");
+  return dir;
+};
+
+const commit = (dir, file, contents, message) => {
+  writeFileSync(join(dir, file), contents);
+  git(dir, "add", file);
+  git(dir, "commit", "--quiet", "-m", message);
+};
+
+const pushRelease = (cwd, branch, tag) =>
+  spawnSync("node", [SCRIPT, branch, tag], { cwd, encoding: "utf8" });
+
+/**
+ * A bare `origin` on `main` with one commit, plus a `work` clone standing in
+ * for the runner's checkout.
+ */
+const setup = (t) => {
+  const root = mkdtempSync(join(tmpdir(), "push-release-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const origin = join(root, "origin.git");
+  execFileSync("git", ["init", "--quiet", "--bare", "-b", "main", origin]);
+
+  const seed = clone(origin, join(root, "seed"));
+  commit(seed, "package.json", '{"version":"1.0.0"}\n', "chore: seed");
+  git(seed, "push", "--quiet", "origin", "main");
+
+  return { root, origin, work: clone(origin, join(root, "work")) };
+};
+
+/** What a concurrent PR merge does to the line mid-build. */
+const concurrentMerge = (root, origin, name) => {
+  const other = clone(origin, join(root, name));
+  commit(other, `${name}.md`, "merged mid-build\n", `fix: ${name}`);
+  git(other, "push", "--quiet", "origin", "main");
+};
+
+/** The `chore(release):` commit plus the tag lerna places on it. */
+const releaseCommit = (work, version) => {
+  commit(
+    work,
+    "package.json",
+    `{"version":"${version}"}\n`,
+    `chore(release): bump version to ${version}`,
+  );
+  git(work, "tag", "-m", version, version);
+};
+
+test("pushes and tags when nothing else touched the line", async (t) => {
+  const { origin, work } = setup(t);
+  releaseCommit(work, "1.0.1");
+
+  const result = pushRelease(work, "main", "1.0.1");
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(
+    git(origin, "rev-parse", "main"),
+    git(work, "rev-parse", "HEAD"),
+  );
+  assert.equal(
+    git(origin, "rev-parse", "1.0.1^{commit}"),
+    git(origin, "rev-parse", "main"),
+  );
+});
+
+test("rebases onto a merge that landed while the release was building", async (t) => {
+  const { root, origin, work } = setup(t);
+  releaseCommit(work, "1.0.1");
+  concurrentMerge(root, origin, "concurrent");
+
+  const result = pushRelease(work, "main", "1.0.1");
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /advanced while this release was building/);
+
+  // The release commit sits on top of the merge, and both are on the line.
+  const log = git(origin, "log", "--format=%s", "main").split("\n");
+  assert.deepEqual(log.slice(0, 2), [
+    "chore(release): bump version to 1.0.1",
+    "fix: concurrent",
+  ]);
+
+  // The tag followed the rebase instead of staying on the orphaned commit.
+  assert.equal(
+    git(origin, "rev-parse", "1.0.1^{commit}"),
+    git(origin, "rev-parse", "main"),
+  );
+  assert.equal(
+    git(origin, "show", "1.0.1:package.json").trim(),
+    '{"version":"1.0.1"}',
+  );
+});
+
+test("survives several merges landing in a row", async (t) => {
+  const { root, origin, work } = setup(t);
+  releaseCommit(work, "1.0.1");
+  concurrentMerge(root, origin, "first");
+  concurrentMerge(root, origin, "second");
+
+  const result = pushRelease(work, "main", "1.0.1");
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(
+    git(origin, "log", "--format=%s", "main").split("\n").slice(0, 3),
+    ["chore(release): bump version to 1.0.1", "fix: second", "fix: first"],
+  );
+});
+
+test("fast-forwards a pre-graduated promotion whose line advanced", async (t) => {
+  // RFC #2711: the version commit arrived with the merge, so the runner has no
+  // commit of its own to replay — but the line moved on and the plain push is
+  // still rejected. The tag does not exist yet and is created here.
+  const { root, origin, work } = setup(t);
+  concurrentMerge(root, origin, "concurrent");
+
+  const result = pushRelease(work, "main", "1.0.1");
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(
+    git(origin, "rev-parse", "1.0.1^{commit}"),
+    git(origin, "rev-parse", "main"),
+  );
+  assert.equal(
+    git(origin, "log", "--format=%s", "-1", "main"),
+    "fix: concurrent",
+  );
+});
+
+test("aborts the rebase and fails loudly on a conflict", async (t) => {
+  const { root, origin, work } = setup(t);
+  releaseCommit(work, "1.0.1");
+
+  // A concurrent merge writing the same file is not a case the release flow
+  // models — the script must stop rather than guess a resolution.
+  const other = clone(origin, join(root, "conflicting"));
+  commit(other, "package.json", '{"version":"9.9.9"}\n', "fix: conflicting");
+  git(other, "push", "--quiet", "origin", "main");
+
+  const result = pushRelease(work, "main", "1.0.1");
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /hit a conflict/);
+  assert.match(result.stderr, /already on npm/);
+
+  // Nothing half-applied: the line is untouched and no rebase is in progress.
+  assert.equal(
+    git(origin, "log", "--format=%s", "-1", "main"),
+    "fix: conflicting",
+  );
+  assert.equal(git(work, "status", "--porcelain"), "");
+  assert.equal(
+    git(work, "log", "--format=%s", "-1", "HEAD"),
+    "chore(release): bump version to 1.0.1",
+  );
+});
+
+test("rebases past a build artifact left in the working tree", async (t) => {
+  // `pnpm build` runs between the release commit and this push, so the tree can
+  // carry a regenerated file. Rebase refuses outright on unstaged changes.
+  const { root, origin, work } = setup(t);
+  releaseCommit(work, "1.0.1");
+  concurrentMerge(root, origin, "concurrent");
+  writeFileSync(
+    join(work, "package.json"),
+    '{"version":"1.0.1"}\n// rebuilt\n',
+  );
+
+  const result = pushRelease(work, "main", "1.0.1");
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(
+    git(origin, "log", "--format=%s", "-1", "main"),
+    "chore(release): bump version to 1.0.1",
+  );
+});
+
+test("rebases when the clone tracks a single branch", async (t) => {
+  // actions/checkout narrows `remote.origin.fetch` to the run's own branch, so
+  // `origin/<branch>` is not guaranteed to follow the fetch — the rebase has to
+  // go through FETCH_HEAD.
+  const { root, origin, work } = setup(t);
+  git(
+    work,
+    "config",
+    "remote.origin.fetch",
+    "+refs/heads/nothing:refs/remotes/origin/nothing",
+  );
+  releaseCommit(work, "1.0.1");
+  concurrentMerge(root, origin, "concurrent");
+
+  const result = pushRelease(work, "main", "1.0.1");
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(
+    git(origin, "rev-parse", "1.0.1^{commit}"),
+    git(origin, "rev-parse", "main"),
+  );
+});
+
+test("refuses to run without both arguments", async (t) => {
+  const { work } = setup(t);
+  assert.equal(spawnSync("node", [SCRIPT, "main"], { cwd: work }).status, 1);
+});

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -521,19 +521,12 @@ jobs:
           tag="$(node -p "require('./lerna.json').version")"
 
           echo "Advancing main and tagging ${tag}"
-          # No-op for a pre-graduated promotion (the version commit arrived with
-          # the merge, so HEAD is already origin/main); pushes the new commit for
-          # the one-time-cut / dispatch paths where lerna versioned above.
-          #
-          # --no-verify belongs at both pushes even with
-          # SKIP_INSTALL_SIMPLE_GIT_HOOKS set above: this is the one place where a
-          # hook aborting the push strands a release that npm has already accepted
-          # (#2932), so it does not depend on a workflow-level env var staying put.
-          git push --no-verify origin HEAD:main
-          # Pre-graduated promotion: no tag exists yet — create it at the merge
-          # commit. Cut/dispatch paths: lerna already tagged, so keep that tag.
-          git rev-parse -q --verify "refs/tags/${tag}" >/dev/null || git tag -m "${tag}" "${tag}"
-          git push --no-verify origin "refs/tags/${tag}"
+          # Rebase-and-retry, because `main` can move under this run: the
+          # concurrency group serializes workflow RUNS, but a PR merged through
+          # the GitHub UI is not a run and lands in the ~10 minutes this job
+          # spends building and publishing. The script carries the full
+          # reasoning, the tag handling and the `--no-verify` rule (#2932).
+          node .github/scripts/push-release.mjs main "${tag}"
 
           # Release notes. Preferred source for a promotion: the curated,
           # user-facing notes in the PR body, verbatim between the
@@ -611,8 +604,7 @@ jobs:
           # the stable line: what we publish is what lerna.json says.
           tag="$(node -p "require('./lerna.json').version")"
           echo "Pushing release commit and tag ${tag} to next"
-          # --no-verify at the push itself, not only via the env var above: a hook
-          # aborting here strands a prerelease that npm has already accepted
-          # (#2932).
-          git push --no-verify origin HEAD:next
-          git push --no-verify origin "refs/tags/${tag}"
+          # Same rebase-and-retry as on the stable line, and for the same reason:
+          # `feat` PRs merge straight into `next`, so the window between the
+          # release commit and this push is just as open here.
+          node .github/scripts/push-release.mjs next "${tag}"

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -103,6 +103,14 @@ flowchart LR
   itself as `0.2.0-alpha.1058`. A `grep` step between build and publish compares
   stamp against manifest, because the mismatch is otherwise invisible — nothing
   fails, the wrong string just ships.
+- **The release commit is pushed last, and rebases if it has to.** Versioning
+  commits and tags locally; the push and the GitHub Release wait until npm has
+  accepted the publish, so a failed publish cannot ratchet a line ahead of npm.
+  The cost is a ~10 minute window in which someone can merge a PR into the same
+  line — the workflow `concurrency` group serializes runs, not UI merges. A
+  plain fast-forward push loses that race after npm is already committed
+  (observed on 1.1.17), so `.github/scripts/push-release.mjs` rebases the
+  release commit onto the new tip, moves the tag with it, and retries.
 - **Forward-merge cascade.** Every push to `main` is automatically merged up
   into `next` (and `next` into the major line when it exists), so the higher
   lines are always a superset of the lower ones — no cherry-picking. Merge


### PR DESCRIPTION
The release push in `publish.yml` is a plain fast-forward, so a PR merged into the same line while the run builds and publishes (~10 minutes) makes it fail:

```
! [rejected]  HEAD -> main (fetch first)
```

By then npm already has the version. That is exactly what happened to **1.1.17** ([run 33844897130](https://github.com/mittwald/flow/actions/runs/33844897130/job/100934569702)): #3125 was merged while #3053's publish was building, all packages went to the registry as 1.1.17, and `main` kept no version bump commit, no tag and no GitHub Release.

It happened again three days later, on 2026-09-07, in the worse shape: #3070 was merged while #3105's publish was building.

- 05:58 — #3105's run ([34088841973](https://github.com/mittwald/flow/actions/runs/34088841973/job/101638098631)) versions to 1.1.21 and publishes all 13 packages from `953cb556f`, i.e. **without #3070** (06:00:59–06:01:54). Its push is rejected at 06:01:55.
- 05:59 — #3070's run ([34088901465](https://github.com/mittwald/flow/actions/runs/34088901465/job/101638746344)) versions to 1.1.21 as well, because `lerna.json` still says 1.1.20. It builds, and `lerna publish from-package` reports `No unpublished release found` — it ships nothing. Its push then succeeds: `main` gets the release commit `33f039bd1`, the `1.1.21` tag, a changelog listing both fixes, and a GitHub Release. **The run is green.**

npm's 1.1.21 therefore does not contain #3070, while the tag, the changelog and the Release all say it does. Verified against the registry: in the published `@mittwald/flow-react-components@1.1.21`, `dist/css/all.css` is byte-identical to 1.1.20 and still carries the `.flow--navigation--item{flex-wrap:wrap}` that #3070 removed. #3105 is in (`unwrapDisallowed` reaches `dist/js`).

The two shapes are worth separating. 1.1.17 was loud: one red run, npm ahead of the line. 1.1.21 is silent: the line looks released, the artifact is one fix short, and nothing is red — the second run's `from-package` no-op is what swallows it.

The workflow's `mutate-main` / `mutate-next` concurrency group cannot close this. It serializes workflow **runs** against each other — a merge through the GitHub UI is not a run and lands in the window regardless.

## What changes

Both push steps now call `.github/scripts/push-release.mjs`, which rebases the release commit onto the new tip and retries, up to five times.

- The tag is re-pointed with `git tag -f`. A rebase otherwise leaves lerna's tag on a commit that is on no branch.
- The rebase goes through `FETCH_HEAD`, because actions/checkout narrows `remote.origin.fetch` to the run's own branch, so `origin/<branch>` is not guaranteed to follow the fetch.
- `--autostash`, since `pnpm build` ran between the release commit and the push and a regenerated file would make rebase refuse outright.
- A conflict aborts the rebase and fails loudly rather than resolving blind. The replayed commit only touches manifests and changelogs, which no concurrent merge writes — a conflict means something unmodelled happened, and a human should look.

`next` gets the same treatment: `feat` PRs merge straight into it, so the window is just as open there.

Unchanged: the deferral itself. Versioning still commits and tags locally and the push still waits until npm accepted the publish, so a failed publish cannot ratchet a line ahead of npm.

## Tests

`push-release.test.mjs` drives the script against real git repositories in a temp dir — the whole behaviour is git under a concurrent push, so there is nothing worth testing away from git. Covered: the happy path, the race, several merges in a row, the pre-graduated promotion fast-forward (RFC #2711), a dirty working tree, the conflict path, and missing arguments.

They run in the existing `node --test .github/scripts/*.test.mjs` step in `test.yml`, so no wiring was needed.

Verified the suite actually bites: with `git tag -f` reverted to the old create-if-missing, the race test fails.

## Not in this PR

Repairing what the two incidents left behind.

- **1.1.17** is done — commit `1688d947d`, tag `1.1.17` and the GitHub Release are on `main`, and `lerna.json` moved on.
- **1.1.21** is not. npm holds a 1.1.21 without #3070 and the version cannot be overwritten, so the fix needs a republish (1.1.22) to actually ship. Its changelog entry claims otherwise in the meantime.

related #2932
