### PR TITLE
refactor(DateRangePicker): use the size scale for the date segment padding

### DIFF
--- a/packages/components/src/components/DateRangePicker/components/DateRangeInput/DateRangeInput.module.scss
+++ b/packages/components/src/components/DateRangePicker/components/DateRangeInput/DateRangeInput.module.scss
@@ -32,11 +32,11 @@
   }
 
   :global(.react-aria-DateInput):first-of-type {
-    padding-inline-end: 2px;
+    padding-inline-end: var(--size-px--xxs);
   }
 
   :global(.react-aria-DateInput):last-of-type {
-    padding-inline-start: 2px;
+    padding-inline-start: var(--size-px--xxs);
   }
 
   :global(.flow--button) {


### PR DESCRIPTION
## What & why

The two paddings that nudge the react-aria date segments apart in `DateRangeInput.module.scss` were hardcoded `2px` — the only literal spacing values left in `packages/components/src`. `2px` is `xxs` on the size scale, so they now read `var(--size-px--xxs)`.

```diff
-    padding-inline-end: 2px;
+    padding-inline-end: var(--size-px--xxs);
-    padding-inline-start: 2px;
+    padding-inline-start: var(--size-px--xxs);
```

Surfaced by an external spacing audit — related to #3129, which asked where our spacing scale lives and reported exactly these two values. The issue itself is a question and stays open for the follow-up audit; this PR only closes the finding.

**For the reviewer**

- **Visually a no-op.** `--size-px--xxs` is exactly `2px`, so no snapshot churn is expected. `run-visual-tests` is on the PR to prove that against the existing baselines rather than assert it.
- **No new component token.** The file already references `var(--size-px--xxxs)` a few lines down, so reaching for the scale directly here matches its existing style. A `--date-picker--*` token for a react-aria-internal nudge would be more surface than the value earns.
- **After this, `packages/components/src` has zero literal spacing values.** The remaining grep hits are a `15%`, a `0 auto`, and two `0 var(--size-…)` — none of them findings.

## Base branch & title

`refactor:` → base `main`.

## Checklist

- [x] PR title is a Conventional Commit and matches the base branch above
- [x] `pnpm lint` is clean (pre-push); only the file's two pre-existing `selector-max-type` warnings on `> div` / `> span`
- [x] **Generated code is committed** — class names unchanged, so no `*.module.d.scss.ts` diff; the change is one file
- [x] User-facing strings — n/a, no strings
- [x] Docs updated if a public API changed — n/a; no visual change, so no snapshot update. `run-visual-tests` added to verify
