### PR TITLE
ci: don't report a superseded label run as failed

### DIFF
--- a/.github/workflows/test-cross-version-label.yml
+++ b/.github/workflows/test-cross-version-label.yml
@@ -109,7 +109,10 @@ jobs:
           test:cross-version-inprocess
 
       - name: Summary
-        if: always()
+        # Not `always()`: that reports a run superseded by `cancel-in-progress`
+        # as a failure, and the comment below is a single upserted one, so the
+        # false ❌ stays on the PR.
+        if: "!cancelled()"
         env:
           IFRAME_OUTCOME: ${{ steps.crossversion.outcome }}
           IFRAME_FAILURES: ${{ steps.crossversion.outputs.failures }}
@@ -154,7 +157,7 @@ jobs:
           cat "$RUNNER_TEMP/cross-version-summary.md" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Comment summary on PR
-        if: always() && github.event_name == 'pull_request'
+        if: "!cancelled() && github.event_name == 'pull_request'"
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/test-visual-label.yml
+++ b/.github/workflows/test-visual-label.yml
@@ -138,10 +138,18 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-  # Reports for the run as a whole: one comment, whatever the shards did.
+  # Reports for the run as a whole: one comment, whatever the shards did — but
+  # only for a run that was not superseded. `always()` runs on a cancelled run
+  # too, and `cancel-in-progress` cancels one whenever two runs start on the
+  # same branch; the comment is a single upserted one, so a cancelled run's ❌
+  # stays on the PR. `!cancelled()` covers the cancelled run, the `cancelled`
+  # result a shard cancelled without the run itself being.
   summary:
     needs: run-visual-tests
-    if: always() && needs.run-visual-tests.result != 'skipped'
+    if: >
+      !cancelled() &&
+      needs.run-visual-tests.result != 'skipped' &&
+      needs.run-visual-tests.result != 'cancelled'
     runs-on: ubuntu-latest
     timeout-minutes: 5
 


### PR DESCRIPTION
A run cancelled by `cancel-in-progress` posts **### ❌ Visual Regression Tests Failed** on the PR.

`always()` runs a job (or step) on a cancelled run too, and both label workflows' summaries branch on `result == 'success'` and treat everything else as a failure — so `cancelled` renders as ❌.

Seen on #3130: `gh pr create --label run-visual-tests` delivers `opened` and `labeled` within the same second, so three "Run Visual Regression Tests" runs started at once. `concurrency: cancel-in-progress` cancelled runs 34107199048 and 34107199008 at `prepare` — and 34107199048's `summary` job still ran and commented.

## Why it matters

The comment is a single upserted one (keyed on `<!-- visual-regression-summary -->`), so a cancelled run's ❌ survives until some later labeled-path run overwrites it. If the surviving run came from `opened`/`synchronize`, the `prepare` gate skips it, `summary` never runs, and the false ❌ stays on the PR permanently — indistinguishable from a real snapshot diff. That is exactly the situation `AGENTS.md` warns about, where the reflex is to slap on `update-screenshots` and entrench whatever renders now as the baseline.

## Change

Both workflows gate on `!cancelled()` instead of `always()`:

- `test-visual-label.yml` — the `summary` job. It additionally excludes a `cancelled` `needs.run-visual-tests.result`, which covers a shard cancelled without the run itself being cancelled. Nothing is written to `$GITHUB_STEP_SUMMARY` and no comment is posted for a superseded run; the run that survives reports.
- `test-cross-version-label.yml` — the `Summary` and `Comment summary on PR` steps. Same job-level `cancel-in-progress` concurrency, same upserted comment (`<!-- cross-version-summary -->`), same defect on a re-label that supersedes an in-flight run.

The "Run in-process cross-version tests" step keeps its `always()`: its `steps.crossversion.outcome == 'success' || 'failure'` guard already excludes a cancelled run.

A job timeout is unaffected — it does not cancel the workflow, so `cancelled()` stays false and a timed-out run still reports ❌, as it should.

CI workflows only; no product code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)