### PR TITLE
refactor(components): isolate the z-indexes that leaked out of their component

### DIFF
--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -229,6 +229,17 @@ if ("action" in props) {
   Group repeated variants in local mixins.
 - Structure sections with comments: `/* Elements */`, `/* States */`,
   `/* Size */`, `/* Variants */`.
+- **A `z-index` is scoped by the nearest ancestor stacking context** — mark that
+  element `isolation: isolate` explicitly. `position: relative`, a scroll
+  container (`overflow: auto`) and a flex/grid parent are **not** stacking
+  contexts, so without it the value competes with the whole page instead of the
+  siblings it was written for. A `transform` animation in between is one only
+  _while it runs_, so the scope otherwise changes with the animation state.
+  Isolating does not reorder anything inside the component: among positioned
+  siblings, `z-index: auto` and a `0`-equivalent stacking context paint in the
+  same step, in tree order. The exception is an element portalled into
+  `document.body` (`NotificationContainer`) — that one sits in the root stacking
+  context by construction and cannot be scoped; say so in a comment.
 - **Overriding a dependency that injects its own stylesheet** (CodeMirror,
   react-easy-crop, FontAwesome) needs `@layer flow.unlayered { … }`: their
   `<style>` elements are unlayered, and unlayered CSS beats layered CSS

--- a/packages/components/src/components/List/components/Items/components/Item/Item.module.scss
+++ b/packages/components/src/components/List/components/Items/components/Item/Item.module.scss
@@ -2,6 +2,11 @@
 
 .item {
   position: relative;
+
+  /* The link overlay and the interactive content lifted above it (see .link
+     below) stack against each other only — never against anything outside the
+     item. */
+  isolation: isolate;
   cursor: default;
   background-color: var(--list-item--background-color--default);
   transition-property: background-color;

--- a/packages/components/src/components/Modal/Modal.browser.test.tsx
+++ b/packages/components/src/components/Modal/Modal.browser.test.tsx
@@ -5,6 +5,7 @@ import Content from "@/components/Content";
 import Heading from "@/components/Heading";
 import Label from "@/components/Label";
 import ModalTrigger from "@/components/Modal/components/ModalTrigger";
+import Skeleton from "@/components/Skeleton";
 import Modal from "@/components/Modal/Modal";
 import Text from "@/components/Text";
 import TextField from "@/components/TextField";
@@ -766,6 +767,14 @@ test("mobile Modal is a single scroll container with sticky header and footer", 
               <Label>Pilot {index + 1}</Label>
             </TextField>
           ))}
+          {/* `position: relative`, so without the sticky elements' z-index it
+              would paint over the header it scrolls underneath. */}
+          <Skeleton />
+          {Array.from({ length: 12 }, (_, index) => (
+            <TextField key={index}>
+              <Label>Gunner {index + 1}</Label>
+            </TextField>
+          ))}
         </Content>
         <ActionGroup>
           <Action closeModal>
@@ -792,6 +801,27 @@ test("mobile Modal is a single scroll container with sticky header and footer", 
     // at rest the header sticks to the top and the footer to the bottom
     expect(getComputedStyle(header).position).toBe("sticky");
     expect(getComputedStyle(footer).position).toBe("sticky");
+
+    // The dialog is a stacking context, so the sticky z-index above cannot
+    // leak out of it into the overlay.
+    expect(getComputedStyle(dialog).isolation).toBe("isolate");
+
+    // Scroll the positioned skeleton up under the header: it comes later in the
+    // DOM, so the sticky z-index is what keeps the header painted on top.
+    const skeleton = dialog.querySelector('[class*="skeleton"]') as HTMLElement;
+    dialog.scrollTop +=
+      skeleton.getBoundingClientRect().top - header.getBoundingClientRect().top;
+    await vitest.waitFor(() => {
+      expect(skeleton.getBoundingClientRect().top).toBeCloseTo(
+        header.getBoundingClientRect().top,
+        0,
+      );
+    });
+
+    const { x, y, width, height } = skeleton.getBoundingClientRect();
+    expect(
+      header.contains(document.elementFromPoint(x + width / 2, y + height / 2)),
+    ).toBe(true);
   } finally {
     await page.viewport(1280, 720);
   }

--- a/packages/components/src/components/Modal/Modal.module.scss
+++ b/packages/components/src/components/Modal/Modal.module.scss
@@ -47,10 +47,12 @@
     display: none;
   }
 
-  /* The dialog card itself — a flex column. */
+  /* The dialog card itself — a flex column. It is also the scroll container on
+     mobile, and the sticky header/footer stack against its content only. */
   [role="dialog"] {
     display: flex;
     flex-direction: column;
+    isolation: isolate;
     max-height: 100%;
     overflow: hidden;
     outline: none;

--- a/packages/components/src/components/NotificationProvider/NotificationContainer/NotificationContainer.module.scss
+++ b/packages/components/src/components/NotificationProvider/NotificationContainer/NotificationContainer.module.scss
@@ -1,3 +1,8 @@
+/* This container is portalled into `document.body`, so its z-index lives in the
+   root stacking context and cannot be isolated. It has to: overlays render into
+   a container that is kept as body's *last* child (see
+   `OverlayContent.getOverlayContainer`), and this is what keeps a notification
+   painted over an open modal. */
 .notificationContainer {
   position: fixed;
   top: var(--notification-provider--window-to-provider-spacing);


### PR DESCRIPTION
`position: relative` and a scroll container are not stacking contexts, so two
z-index clusters escaped the component that owns them. Both get
`isolation: isolate` on the element the value is meant to be relative to.

Of the 14 z-index declarations in the repo, nine were already isolated
(`SegmentedControl`, `CodeEditor`, `Calendar`, `CartesianChart`, and the four in
`apps/docs`). Three were not.

## `List` item

The link overlay (`z-index: 1`) and the interactive content lifted back above it
(`z-index: 2`) come from #3084. `.item` is `position: relative`, which is not a
stacking context, so both stacked against whatever ancestor stacking context the
consumer happened to provide — not against the item.

## `Modal` dialog

The mobile sticky header and footer (`z-index: 1`, #2423) escaped
`[role="dialog"]` up into `.overlay`. `overflow: hidden auto` does not create a
stacking context either.

The scope even changed with the animation state: the wrapper in between is a
stacking context only while its `transform` animation runs, and not at rest.

`isolation` goes on the base `[role="dialog"]` rule, so `OffCanvas` is covered
too.

## `NotificationContainer` keeps its z-index

It portals into `document.body`, so it sits in the root stacking context by
construction — and it has to. Overlays render into a container that
`OverlayContent.getOverlayContainer` keeps as body's *last* child, so
`z-index: 1` is the only thing that keeps a notification painted over an open
modal. Removing it would be a behaviour change, not a cleanup.

Recorded in a comment on the rule.

## Paint order is unchanged

Among positioned siblings, `z-index: auto` and a `0`-equivalent stacking context
paint in the same step, in tree order. Neither component has a negative z-index
descendant that would now be trapped above the parent's background.

## Tests

The existing mobile `Modal` test gains a paint-order assertion: a positioned
`Skeleton` is scrolled up under the sticky header, which is where the z-index
earns its keep. Verified to fail without it.

No test for the notification/overlay ordering. Asserting it means asserting
react-aria's overlay-container placement and its `inert` isolation, which are
not ours to pin. The reasoning lives in a comment on the rule instead.

## Two findings alongside

**Notifications are `inert` while a modal is open.** react-aria's
`ariaHideOutside` marks every body child outside the overlay `inert`, and the
notification container is one of them. A toast is painted on top of the modal
but takes no input — `onClick`, `href` and the close button are all dead. It
also means hit testing cannot observe paint order there at all without clearing
`inert` first. Not addressed here; it needs a UX call on whether toasts should
be interactive over a modal.

**`getComputedStyle` lies in browser tests after an unbuilt SCSS edit.**
`dev/vitest/setupBrowser.ts` imports the built
`packages/stylesheet/dist/styles.css`, so a test page carries the built CSS
alongside the freshly transformed source modules — two live copies of every
rule. Delete a declaration and the built copy keeps supplying it, per
declaration, so the rule reads half-updated. Clearing `node_modules/.vite` does
nothing; `pnpm nx build stylesheet` fixes it. This cost me the first attempt at
proving the Modal assertion. Not written down here — worth its own note if
someone hits it again.

The isolation rule itself is now a bullet in
`packages/components/AGENTS.md` § Styling.

related #3084, #2423
