### PR TITLE
fix(NotificationProvider): keep notifications interactive over an open overlay

### DIFF
--- a/packages/components/src/components/NotificationProvider/NotificationContainer/NotificationContainer.tsx
+++ b/packages/components/src/components/NotificationProvider/NotificationContainer/NotificationContainer.tsx
@@ -30,7 +30,7 @@ export const NotificationContainer: FC<NotificationsContainerProps> = (
   const content = (
     <MotionConfig reducedMotion="user">
       <LazyMotion features={domAnimation}>
-        <div className={rootClassName} {...rest}>
+        <div className={rootClassName} {...rest} data-react-aria-top-layer>
           <AnimatePresence>
             {notifications.map((n) => (
               <m.div

--- a/packages/components/src/components/NotificationProvider/NotificationProvider.browser.test.tsx
+++ b/packages/components/src/components/NotificationProvider/NotificationProvider.browser.test.tsx
@@ -1,0 +1,113 @@
+import Button from "@/components/Button";
+import Content from "@/components/Content";
+import Heading from "@/components/Heading";
+import Modal from "@/components/Modal/Modal";
+import Notification from "@/components/Notification/Notification";
+import {
+  NotificationProvider,
+  useNotificationController,
+} from "@/components/NotificationProvider";
+import type NotificationController from "@/components/NotificationProvider/NotificationController";
+import Text from "@/components/Text";
+import { useOverlayController } from "@/lib/controller";
+import { sleep } from "@/lib/promises/sleep";
+import type { FC } from "react";
+import { useEffect } from "react";
+import { render } from "vitest-browser-react";
+import { page } from "vitest/browser";
+
+const onClose = vitest.fn();
+
+const notify = (controller: NotificationController) =>
+  controller.add(
+    <Notification onClose={onClose}>
+      <Heading>Saved</Heading>
+      <Text>Your changes have been stored.</Text>
+    </Notification>,
+  );
+
+const modalContent = (
+  <>
+    <Heading>Install</Heading>
+    <Content>
+      <Text>Hello World</Text>
+    </Content>
+  </>
+);
+
+/**
+ * React-aria's `ariaHideOutside` sets `inert` on every `document.body` child
+ * outside the open overlay, and an `inert` node stays visible but takes no
+ * input. The notification container is portalled into `document.body`, so it
+ * only escapes that isolation by being an always-visible node itself.
+ */
+const expectNotificationIsInteractive = async () => {
+  onClose.mockClear();
+
+  const notification = document.querySelector('[role="alert"]') as HTMLElement;
+  const container = notification.closest("body > div") as HTMLElement;
+  expect(container.inert).toBe(false);
+
+  const { x, y, width, height } = notification.getBoundingClientRect();
+  expect(
+    notification.contains(
+      document.elementFromPoint(x + width / 2, y + height / 2),
+    ),
+  ).toBe(true);
+
+  const closeButton = notification.querySelector("button") as HTMLElement;
+  await page.elementLocator(closeButton).click();
+  expect(onClose).toHaveBeenCalled();
+};
+
+test("a notification raised while a modal is open stays interactive", async () => {
+  const Fixture: FC = () => {
+    const modal = useOverlayController("Modal", { isDefaultOpen: true });
+    const controller = useNotificationController();
+
+    useEffect(() => {
+      const timeout = setTimeout(() => notify(controller), 300);
+      return () => clearTimeout(timeout);
+    }, [controller]);
+
+    return <Modal controller={modal}>{modalContent}</Modal>;
+  };
+
+  render(
+    <NotificationProvider>
+      <Fixture />
+    </NotificationProvider>,
+  );
+
+  await sleep(1000);
+
+  await expectNotificationIsInteractive();
+});
+
+test("a notification raised before a modal opens stays interactive", async () => {
+  const Fixture: FC = () => {
+    const modal = useOverlayController("Modal");
+    const controller = useNotificationController();
+
+    useEffect(() => void notify(controller), [controller]);
+
+    return (
+      <>
+        <Button onPress={() => modal.open()}>Open</Button>
+        <Modal controller={modal}>{modalContent}</Modal>
+      </>
+    );
+  };
+
+  const dom = await render(
+    <NotificationProvider>
+      <Fixture />
+    </NotificationProvider>,
+  );
+
+  await sleep(500);
+  await dom.getByRole("button", { name: "Open" }).click();
+  await sleep(500);
+
+  await expectNotificationIsInteractive();
+});


### PR DESCRIPTION
While a modal (or any overlay) is open, a notification is painted on top of it
but takes no input. `onClick`, `href` and the close button are all dead — the
user sees a toast they can neither dismiss nor follow.

## Cause

react-aria's `ariaHideOutside` sets `inert` on every `document.body` child
outside the open overlay. `NotificationContainer` portals into `document.body`,
so it gets `inert` too, and `inert` inherits to the notification inside it.

`Notification` already sets `data-react-aria-top-layer` — but on the wrong node.
`ariaHideOutside` honours that attribute in exactly two places:

1. the **initial walk**, via
   `root.querySelectorAll('[data-live-announcer], [data-react-aria-top-layer]')`
   — matching nodes go into `visibleNodes`, and their ancestors are then
   `FILTER_SKIP`ped instead of hidden;
2. its **MutationObserver**, via `isAlwaysVisibleNode(node)` — but only for
   nodes added to a parent that is not already hidden.

Once the container is `inert`, neither applies. The observer's guard
`[...visibleNodes, ...hiddenNodes].some((node) => nodeContains(node, change.target))`
is true (the container is in `hiddenNodes` and contains itself), so the whole
branch is skipped and the new notification is never re-examined.

That makes the bug **order-dependent**, measured in WebKit:

| Scenario | `container.inert` | Notification in hit stack | Close button |
| --- | --- | --- | --- |
| Toast raised while the modal is open | `true` | no | `locator.click` times out, `onClose` never fires |
| Toast and modal in the same effect flush | `true` | no | same |
| Toast already painted, *then* the modal opens | `false` | yes | works |

The first case is the realistic one — act inside the modal, get a toast. The
third works only because the initial walk finds the attribute on the
`Notification` itself.

The impact is measured, not inferred:

```
locator.click: Timeout 2000ms exceeded.
  - locator resolved to <button aria-label="Close" class="… flow--notification--close">
  - 7 × waiting for element to be visible, enabled and stable
[close-button] clicked=false onClose=0
```

## Fix

Move `data-react-aria-top-layer` to the portal container — the node
`document.body` actually sees. No `MutationObserver` needed, unlike
`useKeepBrowserExtensionsInteractive`: this node is ours and static.

It also stops hiding the toast from screen readers while a modal is open, which
is what a `role="alert"` live region wants.

## Why this is a fix, not a new UX decision

The behaviour is already the codebase's intent, just applied inconsistently:

- `.notificationContainer`'s `z-index: 1` exists only to paint over overlays;
- `Notification` already carries `data-react-aria-top-layer`;
- the third scenario above already behaves this way today;
- react-aria's own comment names this the intended use —
  `// Keep live announcer and top layer elements (e.g. toasts) visible.`

This makes the first two scenarios agree with the third.

**Open for UX/PM, separately:** whether toasts should be painted above a modal
*at all*. Answering "no" is a different change — it would remove the
`z-index: 1` — and is not what this PR decides.

## Known quirk, not addressed here

`.notificationContainer` has `pointer-events: auto` and its box includes each
toast's `padding-bottom` spacing, so clicks in the gap between toasts and in the
strip below the last one hit the container rather than the page beneath. That is
pre-existing whenever no overlay is open; this fix only extends it to the
modal-open case. The usual `pointer-events: none` / `auto` split does not apply
cleanly, because the spacing is `padding-bottom` on the animated wrapper — the
exit animation animates it to `0`, so it cannot become a flex `gap`.

## Tests

`NotificationProvider.browser.test.tsx` asserts the real contract — close button
clickable, `onClose` called — for both orderings. The first test fails without
the fix, the second passes with and without it, pinning the asymmetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
