### PR TITLE
fix(ci): retry the review environment API calls instead of failing the job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,9 +45,12 @@ jobs:
 
       # The CI guard scripts are plain node:test files outside the nx graph, so
       # `pnpm affected:test` never sees them. Run them here so a broken
-      # classifier fails the PR rather than the next release.
+      # classifier fails the PR rather than the next release. `dev/` holds the
+      # same kind of code in TypeScript, so it needs the tsx loader.
       - name: Test the CI guard scripts
-        run: node --test .github/scripts/*.test.mjs
+        run: |
+          node --test .github/scripts/*.test.mjs
+          node --test --import tsx dev/*.test.ts
 
       # Fixed versioning means every Lerna-managed package carries `lerna.json`'s
       # version. A merge can break that silently — no conflict markers, and the

--- a/dev/apiFetch.test.ts
+++ b/dev/apiFetch.test.ts
@@ -1,0 +1,171 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  apiFetch,
+  isConnectPhaseError,
+  isRetryableStatus,
+} from "./apiFetch.ts";
+
+/** The shape undici produces when the TCP handshake never completes. */
+const connectTimeout = (): Error =>
+  Object.assign(new TypeError("fetch failed"), {
+    cause: Object.assign(new Error("Connect Timeout Error"), {
+      code: "UND_ERR_CONNECT_TIMEOUT",
+    }),
+  });
+
+/** A socket that died after the request went out — the server may have acted. */
+const socketReset = (): Error =>
+  Object.assign(new TypeError("fetch failed"), {
+    cause: Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" }),
+  });
+
+const response = (status: number): Response =>
+  new Response(status === 204 ? null : "{}", { status });
+
+interface Harness {
+  fetchImpl: typeof globalThis.fetch;
+  sleep: (ms: number) => Promise<void>;
+  calls: () => number;
+  delays: () => number[];
+}
+
+/** Replays `outcomes` one per attempt; an Error is thrown, a Response returned. */
+const harness = (outcomes: (Response | Error)[]): Harness => {
+  let calls = 0;
+  const delays: number[] = [];
+
+  return {
+    fetchImpl: (() => {
+      const outcome = outcomes[calls++] ?? outcomes.at(-1);
+      if (outcome instanceof Error) return Promise.reject(outcome);
+      return Promise.resolve(outcome as Response);
+    }) as unknown as typeof globalThis.fetch,
+    sleep: (ms) => {
+      delays.push(ms);
+      return Promise.resolve();
+    },
+    calls: () => calls,
+    delays: () => delays,
+  };
+};
+
+const call = (h: Harness, idempotent: boolean): Promise<Response> =>
+  apiFetch(
+    "https://api.example.test/v2/things",
+    { method: idempotent ? "GET" : "POST" },
+    { label: "things", idempotent, fetchImpl: h.fetchImpl, sleep: h.sleep },
+  );
+
+test("classifies connect-phase errors", () => {
+  assert.equal(isConnectPhaseError(connectTimeout()), true);
+  assert.equal(isConnectPhaseError(socketReset()), false);
+  assert.equal(isConnectPhaseError(new Error("boom")), false);
+});
+
+// The whole policy keys on `cause.code`, so pin the shape undici really
+// produces rather than only the hand-built errors above. A closed loopback port
+// refuses instantly and needs no network.
+test("recognises a real undici connect failure", async () => {
+  await assert.rejects(fetch("http://127.0.0.1:45999/"), (error: unknown) => {
+    assert.equal(
+      (error as { cause?: { code?: string } }).cause?.code,
+      "ECONNREFUSED",
+    );
+    assert.equal(isConnectPhaseError(error), true);
+    return true;
+  });
+});
+
+test("classifies retryable statuses", () => {
+  assert.deepEqual([429, 500, 502, 503].map(isRetryableStatus), [
+    true,
+    true,
+    true,
+    true,
+  ]);
+  assert.deepEqual([200, 201, 400, 404, 422].map(isRetryableStatus), [
+    false,
+    false,
+    false,
+    false,
+    false,
+  ]);
+});
+
+test("retries a connect timeout even for a non-idempotent request", async () => {
+  const h = harness([connectTimeout(), connectTimeout(), response(200)]);
+
+  const result = await call(h, false);
+
+  assert.equal(result.status, 200);
+  assert.equal(h.calls(), 3);
+});
+
+test("does not retry a mid-flight failure for a non-idempotent request", async () => {
+  const h = harness([socketReset(), response(200)]);
+
+  await assert.rejects(call(h, false), (error: unknown) => {
+    assert.equal(
+      (error as { cause?: { code?: string } }).cause?.code,
+      "ECONNRESET",
+    );
+    return true;
+  });
+  assert.equal(
+    h.calls(),
+    1,
+    "must not replay a request the server may have seen",
+  );
+});
+
+test("retries a mid-flight failure for an idempotent request", async () => {
+  const h = harness([socketReset(), response(200)]);
+
+  const result = await call(h, true);
+
+  assert.equal(result.status, 200);
+  assert.equal(h.calls(), 2);
+});
+
+test("retries 5xx and 429 only for an idempotent request", async () => {
+  const idempotent = harness([response(503), response(429), response(200)]);
+  assert.equal((await call(idempotent, true)).status, 200);
+  assert.equal(idempotent.calls(), 3);
+
+  const nonIdempotent = harness([response(503), response(200)]);
+  assert.equal(
+    (await call(nonIdempotent, false)).status,
+    503,
+    "hands the 503 back instead of replaying a create",
+  );
+  assert.equal(nonIdempotent.calls(), 1);
+});
+
+test("returns a 4xx immediately", async () => {
+  const h = harness([response(404), response(200)]);
+
+  assert.equal((await call(h, true)).status, 404);
+  assert.equal(h.calls(), 1);
+});
+
+test("gives up after four attempts and rethrows the last error", async () => {
+  const h = harness([connectTimeout()]);
+
+  await assert.rejects(call(h, false), /fetch failed/);
+  assert.equal(h.calls(), 4);
+});
+
+test("returns the last response instead of retrying forever", async () => {
+  const h = harness([response(503)]);
+
+  assert.equal((await call(h, true)).status, 503);
+  assert.equal(h.calls(), 4);
+});
+
+test("backs off exponentially", async () => {
+  const h = harness([connectTimeout()]);
+
+  await assert.rejects(call(h, false));
+  assert.deepEqual(h.delays(), [500, 1000, 2000]);
+});

--- a/dev/apiFetch.ts
+++ b/dev/apiFetch.ts
@@ -1,0 +1,115 @@
+/**
+ * `fetch` for the review-environment scripts, with a retry for the failures a
+ * GitHub runner produces on its own rather than because a request was wrong.
+ *
+ * A bare `fetch` gives every call one attempt and undici's 10 s connect
+ * default, so a single stalled TCP handshake fails a whole preview deploy.
+ *
+ * What is retried is deliberately narrow:
+ *
+ * - **Connect-phase errors** — retried for every request. The failure happened
+ *   before the request reached the server, so replaying it cannot duplicate a
+ *   side effect.
+ * - **Anything else** (a socket that died mid-flight, a per-attempt timeout, HTTP
+ *   429, HTTP 5xx) — retried only for a request marked `idempotent`. Once a
+ *   request may have reached the server, replaying a non-idempotent one could
+ *   create a second ingress or a second PR comment.
+ *
+ * A 4xx is the server rejecting the request on its merits and is never retried;
+ * it comes back for the caller to handle.
+ */
+
+const MAX_ATTEMPTS = 4;
+const ATTEMPT_TIMEOUT_MS = 30_000;
+const BASE_BACKOFF_MS = 500;
+
+// undici surfaces these while still establishing the connection, i.e. before
+// the server can have seen the request.
+const CONNECT_PHASE_CODES = new Set([
+  "UND_ERR_CONNECT_TIMEOUT",
+  "ECONNREFUSED",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+]);
+
+export interface ApiFetchOptions {
+  /** Names the request in the retry log. */
+  label: string;
+  /**
+   * Whether replaying this request is harmless — true for every read, and for a
+   * write whose body describes a desired end state (a declarative PATCH) or
+   * whose repetition is a no-op. False for a request that creates a resource.
+   */
+  idempotent?: boolean;
+  /** Seams for the tests; production uses the globals. */
+  fetchImpl?: typeof globalThis.fetch;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+const causeCode = (error: unknown): string | undefined => {
+  const cause = (error as { cause?: unknown } | null)?.cause;
+  const code = (cause as { code?: unknown } | null)?.code;
+  return typeof code === "string" ? code : undefined;
+};
+
+export const isConnectPhaseError = (error: unknown): boolean =>
+  CONNECT_PHASE_CODES.has(causeCode(error) ?? "");
+
+export const isRetryableStatus = (status: number): boolean =>
+  status === 429 || status >= 500;
+
+const describeError = (error: unknown): string => {
+  const code = causeCode(error);
+  const message = error instanceof Error ? error.message : String(error);
+  return code ? `${message} (${code})` : message;
+};
+
+export const apiFetch = async (
+  url: string,
+  init: RequestInit,
+  options: ApiFetchOptions,
+): Promise<Response> => {
+  const {
+    label,
+    idempotent = false,
+    fetchImpl = globalThis.fetch,
+    sleep = defaultSleep,
+  } = options;
+
+  for (let attempt = 1; ; attempt++) {
+    const isLastAttempt = attempt >= MAX_ATTEMPTS;
+
+    const backOff = async (reason: string): Promise<void> => {
+      const delay = BASE_BACKOFF_MS * 2 ** (attempt - 1);
+      console.warn(
+        `⏳ ${label} failed (${reason}) — attempt ${attempt}/${MAX_ATTEMPTS}, retrying in ${delay} ms`,
+      );
+      await sleep(delay);
+    };
+
+    try {
+      const response = await fetchImpl(url, {
+        ...init,
+        signal: AbortSignal.timeout(ATTEMPT_TIMEOUT_MS),
+      });
+
+      if (!isRetryableStatus(response.status) || !idempotent || isLastAttempt) {
+        return response;
+      }
+
+      // The body is not read on a retry; release the socket instead of leaving
+      // it to the GC.
+      await response.body?.cancel().catch(() => undefined);
+      await backOff(`HTTP ${response.status}`);
+    } catch (error) {
+      if (!(isConnectPhaseError(error) || idempotent) || isLastAttempt) {
+        throw error;
+      }
+
+      await backOff(describeError(error));
+    }
+  }
+};

--- a/dev/cleanup-review.ts
+++ b/dev/cleanup-review.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+import { apiFetch } from "./apiFetch.ts";
+
 interface MittwaldService {
   id: string;
   serviceName: string;
@@ -53,12 +55,13 @@ class ReviewCleanup {
     console.log("📋 Fetching existing services...");
 
     try {
-      const response = await fetch(
+      const response = await apiFetch(
         `https://api.mittwald.de/v2/projects/${this.projectId}/services`,
         {
           method: "GET",
           headers: getApiHeaders(),
         },
+        { label: "fetching services", idempotent: true },
       );
 
       if (!response.ok) {
@@ -76,12 +79,13 @@ class ReviewCleanup {
     console.log("🔗 Fetching existing ingresses...");
 
     try {
-      const response = await fetch(
+      const response = await apiFetch(
         `https://api.mittwald.de/v2/ingresses?projectId=${this.projectId}`,
         {
           method: "GET",
           headers: getApiHeaders(),
         },
+        { label: "fetching ingresses", idempotent: true },
       );
 
       if (!response.ok) {
@@ -99,15 +103,18 @@ class ReviewCleanup {
     console.log(`🗑️  Deleting ingress ${hostname} (${ingressId})...`);
 
     try {
-      const response = await fetch(
+      const response = await apiFetch(
         `https://api.mittwald.de/v2/ingresses/${ingressId}`,
         {
           method: "DELETE",
           headers: getApiHeaders(),
         },
+        { label: `deleting ingress ${hostname}`, idempotent: true },
       );
 
-      if (!response.ok) {
+      // A retried DELETE whose first attempt did reach the server finds the
+      // ingress already gone. That is the goal state, not a failure.
+      if (!response.ok && response.status !== 404) {
         throw new Error(`Failed to delete ingress: ${response.statusText}`);
       }
 
@@ -127,7 +134,7 @@ class ReviewCleanup {
     });
 
     try {
-      const response = await fetch(
+      const response = await apiFetch(
         `https://api.mittwald.de/v2/stacks/${this.projectId}`,
         {
           method: "PATCH",
@@ -136,6 +143,9 @@ class ReviewCleanup {
             services: serviceUpdates,
           }),
         },
+        // The body is the stack's desired state, so a replay lands on the same
+        // state rather than removing anything else.
+        { label: "deleting services", idempotent: true },
       );
 
       if (!response.ok) {

--- a/dev/deploy-review.ts
+++ b/dev/deploy-review.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+import { apiFetch } from "./apiFetch.ts";
+
 interface DockerImage {
   name: string;
   tag: string;
@@ -136,7 +138,7 @@ class ReviewDeployer {
 
     const [owner, repoName] = repo.split("/");
     try {
-      const response = await fetch(
+      const response = await apiFetch(
         `https://api.github.com/repos/${owner}/${repoName}/pulls/${this.prNumber}`,
         {
           headers: {
@@ -144,6 +146,7 @@ class ReviewDeployer {
             Accept: "application/vnd.github.v3+json",
           },
         },
+        { label: `PR #${this.prNumber} state`, idempotent: true },
       );
 
       if (!response.ok) {
@@ -168,12 +171,13 @@ class ReviewDeployer {
     console.log("📋 Fetching existing services...");
 
     try {
-      const response = await fetch(
+      const response = await apiFetch(
         `https://api.mittwald.de/v2/projects/${this.projectId}/services`,
         {
           method: "GET",
           headers: getApiHeaders(),
         },
+        { label: "fetching services", idempotent: true },
       );
 
       if (!response.ok) {
@@ -191,12 +195,13 @@ class ReviewDeployer {
     console.log("🔗 Fetching existing ingresses...");
 
     try {
-      const response = await fetch(
+      const response = await apiFetch(
         `https://api.mittwald.de/v2/ingresses?projectId=${this.projectId}`,
         {
           method: "GET",
           headers: getApiHeaders(),
         },
+        { label: "fetching ingresses", idempotent: true },
       );
 
       if (!response.ok) {
@@ -214,7 +219,7 @@ class ReviewDeployer {
     console.log("🚀 Updating services...");
 
     try {
-      const response = await fetch(
+      const response = await apiFetch(
         `https://api.mittwald.de/v2/stacks/${this.projectId}`,
         {
           method: "PATCH",
@@ -224,6 +229,9 @@ class ReviewDeployer {
             volumes: {},
           }),
         },
+        // The body is the stack's desired state, so a replay lands on the same
+        // state rather than adding anything.
+        { label: "updating services", idempotent: true },
       );
 
       if (!response.ok) {
@@ -244,12 +252,14 @@ class ReviewDeployer {
     console.log("🔄 Pulling latest image...");
 
     try {
-      const response = await fetch(
+      const response = await apiFetch(
         `https://api.mittwald.de/v2/stacks/${this.projectId}/services/${serviceId}/actions/pull`,
         {
           method: "POST",
           headers: getApiHeaders(),
         },
+        // Pulling the same tag twice is a no-op, so a replay costs nothing.
+        { label: "pulling the image", idempotent: true },
       );
 
       if (!response.ok) {
@@ -273,25 +283,31 @@ class ReviewDeployer {
     console.log(`🌐 Creating ingress for ${hostname}...`);
 
     try {
-      const response = await fetch("https://api.mittwald.de/v2/ingresses", {
-        method: "POST",
-        headers: getApiHeaders(),
-        body: JSON.stringify({
-          projectId: this.projectId,
-          hostname,
-          paths: [
-            {
-              path: "/",
-              target: {
-                container: {
-                  id: containerId,
-                  portProtocol: "80/tcp",
+      const response = await apiFetch(
+        "https://api.mittwald.de/v2/ingresses",
+        {
+          method: "POST",
+          headers: getApiHeaders(),
+          body: JSON.stringify({
+            projectId: this.projectId,
+            hostname,
+            paths: [
+              {
+                path: "/",
+                target: {
+                  container: {
+                    id: containerId,
+                    portProtocol: "80/tcp",
+                  },
                 },
               },
-            },
-          ],
-        }),
-      });
+            ],
+          }),
+        },
+        // Creates a resource: only a failure from before the server saw the
+        // request may be replayed, never a 5xx.
+        { label: `creating the ingress for ${hostname}`, idempotent: false },
+      );
 
       if (!response.ok) {
         const error = await response.text();
@@ -330,7 +346,7 @@ class ReviewDeployer {
     console.log(`🔒 Connecting TLS certificate to ingress ${ingressId}...`);
 
     try {
-      const response = await fetch(
+      const response = await apiFetch(
         `https://api.mittwald.de/v2/ingresses/${ingressId}/tls`,
         {
           method: "PATCH",
@@ -339,6 +355,7 @@ class ReviewDeployer {
             certificateId,
           }),
         },
+        { label: "connecting the TLS certificate", idempotent: true },
       );
 
       if (!response.ok) {
@@ -446,7 +463,7 @@ ${this.images.map((img) => `- ${img.imageType}: \`${img.name}\``).join("\n")}
 `;
 
     try {
-      const response = await fetch(
+      const response = await apiFetch(
         `https://api.github.com/repos/${owner}/${repoName}/issues/${this.prNumber}/comments`,
         {
           method: "POST",
@@ -458,6 +475,8 @@ ${this.images.map((img) => `- ${img.imageType}: \`${img.name}\``).join("\n")}
             body: comment,
           }),
         },
+        // A replay would post a second comment.
+        { label: "posting the PR comment", idempotent: false },
       );
       if (!response.ok) {
         console.warn(


### PR DESCRIPTION
`dev/deploy-review.ts` and `dev/cleanup-review.ts` talk to the mittwald API with
bare `fetch` calls: one attempt each, no explicit timeout, so undici's 10 s
connect default applies. A single stalled TCP handshake on the runner fails the
whole preview deploy.

On 2026-09-08, while 20 open PRs were brought onto main, that took out five
deploys. One PR lost four reruns in a row on the same call — `Fetching existing
ingresses` — while the 19 others went green on an identical script and workflow.
`deploy` is not a required check, so nothing was blocked, but every failure
costs a rerun and a log dig to classify as infra.

## What this changes

`dev/apiFetch.ts` wraps the calls: four attempts, 0.5/1/2 s backoff, and a 30 s
per-attempt timeout so a hung response can no longer sit until the job timeout.

What it replays is deliberately narrow, because replaying a write is not free:

| Failure | Replayed |
| --- | --- |
| Connect-phase (`UND_ERR_CONNECT_TIMEOUT`, `ECONNREFUSED`, `ENOTFOUND`, `EAI_AGAIN`) | every request — the server cannot have seen it |
| Socket died mid-flight, per-attempt timeout, HTTP 429, HTTP 5xx | only where the call site declares `idempotent: true` |
| HTTP 4xx | never — the server judged the request, it goes back to the caller |

Creating an ingress and posting the PR comment are the two non-idempotent call
sites, so a replay can never produce a second ingress or a second comment. The
reads, the declarative stack PATCHes, the TLS PATCH, the image pull and the
ingress DELETE are all safe to repeat.

One behaviour change comes with the DELETE: a replayed delete whose first
attempt did reach the server finds the ingress already gone, so a 404 now counts
as the goal state instead of failing the cleanup.

## Verification

The policy keys entirely on `cause.code`, so the tests pin the shape undici
really produces (a closed loopback port) next to hand-built errors, and cover
the classification, the per-method retry decisions, giving up after four
attempts, and the backoff — 11 tests.

Checked by hand against real undici errors: a closed port (`ECONNREFUSED`), a
bad hostname (`ENOTFOUND`) and a blackholed address (`UND_ERR_CONNECT_TIMEOUT`,
after the real 10 s wait) all classify as connect-phase, and a non-idempotent
POST against a closed port is replayed exactly four times.

`dev/*.test.ts` now runs in the existing "Test the CI guard scripts" step, which
already covers the `.github/scripts` node:test files; the TypeScript ones need
the tsx loader.

CI- and tooling-only, so this publishes nothing.

Related: #3112 (the PR that lost four deploy reruns to this)
