### PR TITLE
fix(ci): render every commit type in the changelog

### DIFF
--- a/.github/scripts/changelog-preset.test.mjs
+++ b/.github/scripts/changelog-preset.test.mjs
@@ -1,0 +1,87 @@
+// @ts-check
+/**
+ * `lerna.json`'s `changelogPreset` renders EVERY commit type (#3023).
+ *
+ * Release relevance is decided by PATH, the changelog by TYPE, and the two can
+ * never agree: the `conventionalcommits` preset hides `docs`, `style`, `chore`,
+ * `refactor`, `test`, `build` and `ci` by default, so a release those types
+ * triggered had nothing to write and lerna emitted "Version bump only" — four
+ * of the first fourteen post-1.0 releases. `chore(deps):` bumps are the
+ * sharpest case: they change what consumers resolve and must stay releases, so
+ * the changelog is what has to admit them.
+ *
+ * The gate is `writer.transform`, which returns `undefined` for a hidden type.
+ * Asserting on it needs no git history and no rendering.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import createPreset from "conventional-changelog-conventionalcommits";
+
+const { changelogPreset } = JSON.parse(
+  readFileSync(join(import.meta.dirname, "..", "..", "lerna.json"), "utf8"),
+);
+
+/** Every Conventional Commit type the repo's commit guard accepts. */
+const EXPECTED_SECTIONS = {
+  feat: "Features",
+  fix: "Bug Fixes",
+  perf: "Performance Improvements",
+  revert: "Reverts",
+  docs: "Documentation",
+  style: "Styles",
+  chore: "Miscellaneous Chores",
+  refactor: "Code Refactoring",
+  test: "Tests",
+  build: "Build System",
+  ci: "Continuous Integration",
+};
+
+test("changelogPreset: the preset is configured, not just named", () => {
+  // A bare string means the preset's defaults — which hide seven of the eleven
+  // types. The object form is what carries `types`.
+  assert.equal(typeof changelogPreset, "object");
+  assert.equal(changelogPreset.name, "conventionalcommits");
+  assert.ok(Array.isArray(changelogPreset.types));
+});
+
+test("changelogPreset: no configured type is hidden", () => {
+  for (const entry of changelogPreset.types) {
+    assert.notEqual(entry.hidden, true, entry.type);
+    assert.ok(entry.section, `${entry.type} has no section`);
+  }
+});
+
+test("changelogPreset: every commit type reaches the changelog", async () => {
+  const preset = await createPreset(changelogPreset);
+  const context = {
+    host: "https://github.com",
+    owner: "mittwald",
+    repository: "flow",
+  };
+
+  for (const [type, section] of Object.entries(EXPECTED_SECTIONS)) {
+    const commit = {
+      type,
+      scope: "components",
+      subject: "a subject",
+      hash: "0".repeat(40),
+      notes: [],
+      references: [],
+    };
+    const transformed = preset.writer.transform(commit, context);
+    assert.ok(transformed, `${type} is dropped from the changelog`);
+    assert.equal(transformed.type, section, type);
+  }
+});
+
+test("changelogPreset: a chore(deps) bump renders", () => {
+  // The case problem 2 of #3023 is about: it changes what consumers resolve,
+  // so it must publish AND say so.
+  assert.ok(
+    changelogPreset.types.some(
+      (entry) => entry.type === "chore" && entry.hidden !== true,
+    ),
+  );
+});

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -70,6 +70,27 @@ flowchart LR
   guard that Lerna-Lite 5's changelog config trips over (it recompiles the
   preset's template itself), and the guard then aborts `lerna version`. Re-check
   on the next Lerna-Lite major.
+- **No type is hidden from the changelog** (#3023). The preset hides `docs`,
+  `style`, `chore`, `refactor`, `test`, `build` and `ci` by default, so a
+  release those types triggered had nothing to write and Lerna emitted
+  "**Note:** Version bump only" — four of the first fourteen post-1.0 releases.
+  `lerna.json` therefore configures `changelogPreset` as an object and respells
+  the full `types` list with every `hidden` dropped. Relevance is decided by
+  path, so a release exists only because something can reach a consumer; if a
+  commit was worth a release it is worth a line. That covers the cases a path
+  gate must not suppress — `chore(deps): bump …` changes what consumers resolve,
+  and a `docs:` commit on a shipped `AGENTS.md` really does change the tarball
+  (#2954 cut 1.0.11). `.github/scripts/changelog-preset.test.mjs` asserts every
+  type still renders. Unhiding changes nothing about the bump: without
+  `bumpStrict` the preset's `whatBump` returns patch for any non-empty commit
+  range regardless.
+
+  What stays unrenderable: a release whose cause lies outside every package —
+  `pnpm-lock.yaml`, the root manifest, `lerna.json`. Lerna attributes commits
+  per package, so with no package changed every changelog honestly reads
+  "Version bump only" (1.1.11, a lock-only Rollup bump). An entry's scope is
+  always the commit's, never the changelog's package.
+
 - **Not every merge releases.** A push to a release line only publishes when it
   carries a change that can reach a **published package**. Docs-, CI- and
   repo-tooling-only merges (`apps/**`, `docs/**`, `.github/**`, `dev/**`, root

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,22 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "changelogPreset": "conventionalcommits",
+  "changelogPreset": {
+    "name": "conventionalcommits",
+    "types": [
+      { "type": "feat", "section": "Features" },
+      { "type": "feature", "section": "Features" },
+      { "type": "fix", "section": "Bug Fixes" },
+      { "type": "perf", "section": "Performance Improvements" },
+      { "type": "revert", "section": "Reverts" },
+      { "type": "docs", "section": "Documentation" },
+      { "type": "style", "section": "Styles" },
+      { "type": "chore", "section": "Miscellaneous Chores" },
+      { "type": "refactor", "section": "Code Refactoring" },
+      { "type": "test", "section": "Tests" },
+      { "type": "build", "section": "Build System" },
+      { "type": "ci", "section": "Continuous Integration" }
+    ]
+  },
   "npmClient": "pnpm",
   "packages": [
     "packages/*"


### PR DESCRIPTION
`changelogPreset` was the bare string `conventionalcommits`, and that preset **hides** `docs`, `style`, `chore`, `refactor`, `test`, `build` and `ci`. A release one of those types triggered therefore had nothing to write, and Lerna emitted "**Note:** Version bump only" — four of the first fourteen post-1.0 releases.

Release relevance is decided by **path**, the changelog by **type**, so the two could never agree (#3023). A type gate on relevance is not the answer either: `chore(deps): bump …` changes what consumers resolve, and a `docs:` commit on a shipped `AGENTS.md` really does change the tarball (#2954 cut 1.0.11). If a commit was worth a release, it is worth a line.

`lerna.json` now configures `changelogPreset` as an object and respells the full `types` list with every `hidden` dropped. Unhiding changes nothing about the bump: without `bumpStrict` the preset's `whatBump` returns patch for any non-empty commit range regardless.

`.github/scripts/changelog-preset.test.mjs` asserts every type renders — against the preset's own `writer.transform`, which needs no git history and no rendering. It runs in `test.yml` with the other `.github/scripts` suites.

## What stays unrenderable

Documented rather than fixed: a release whose cause lies **outside every package** — `pnpm-lock.yaml`, the root manifest, `lerna.json`. Lerna attributes commits per package; with no package changed, every changelog honestly reads "Version bump only". 1.1.11 is the live example, a lock-only Rollup bump.

This PR is itself such a case: it touches `lerna.json`, which is publish-relevant by path, so it will cut a version whose changelogs say exactly that.

## The #3083 anomaly, resolved

1.1.6 shows a `fix(codemods):` entry in the **components** changelog because #3041 regenerated `packages/components/MIGRATION.md` — components genuinely changed. #3040 (1.1.1) touched no package but `codemods` and correctly reads "Version bump only". The per-package attribution is consistent; only the rendered **scope** is the commit's, never the changelog's package.

## Split out of #3098

That PR carried three changes. This is the changelog half — orthogonal to the path classifier in #3098, which decides *whether* a release happens rather than what it says.

Fixes #3083. Part of #3023 — the type half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
