### PR TITLE
ci: reject a pull request that mixes release classes

### DIFF
--- a/.github/scripts/commit-mixture-guard.mjs
+++ b/.github/scripts/commit-mixture-guard.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+// @ts-check
+/**
+ * Commit-mixture guard — the IO shell around `commit-mixture-lib.mjs`.
+ *
+ * Reads the PR's commits on stdin as NUL-separated records, subject on the
+ * first line and body on the rest:
+ *
+ *     git log -z --reverse --format=%s%n%b <base>..<head>
+ *
+ * `-z` rather than a textual delimiter, because a commit body can contain any
+ * text but not a NUL. The PR title comes from `PR_TITLE`.
+ *
+ * Exits non-zero when the PR mixes release classes, or when its title does not
+ * match the class its commits carry.
+ */
+import { readFileSync } from "node:fs";
+import {
+  classifyMixture,
+  classifyTitleRelease,
+} from "./commit-mixture-lib.mjs";
+
+/** Read all of stdin; an unreadable stdin is an empty list. */
+function readStdin() {
+  try {
+    return readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+const commits = readStdin()
+  .split("\u0000")
+  .filter((record) => record.trim() !== "")
+  .map((record) => {
+    const newline = record.indexOf("\n");
+    return newline === -1
+      ? { subject: record.trim(), body: "" }
+      : {
+          subject: record.slice(0, newline).trim(),
+          body: record.slice(newline + 1),
+        };
+  });
+
+const title = process.env.PR_TITLE ?? "";
+const result = classifyMixture(commits, title);
+
+// `PATHS_PUBLISH` comes from `release-relevance-guard.mjs`, run by the same job.
+// Missing means the step could not answer, and then this half is skipped.
+const pathsPublish =
+  process.env.PATHS_PUBLISH === "true"
+    ? true
+    : process.env.PATHS_PUBLISH === "false"
+      ? false
+      : undefined;
+const release =
+  pathsPublish === undefined
+    ? { ok: true, reason: "the changed paths were not classified" }
+    : classifyTitleRelease(title, pathsPublish);
+
+console.log(
+  `Title: ${title || "(empty)"} -> ${result.titleClass ?? "not conventional"}`,
+);
+console.log(`Commits (${commits.length}):`);
+for (const commit of commits.slice(0, 30)) console.log(`  ${commit.subject}`);
+if (commits.length > 30) console.log(`  ... and ${commits.length - 30} more`);
+
+if (!result.ok) {
+  for (const offender of result.offenders) {
+    console.log(`::error::${offender.class}: ${offender.subject}`);
+  }
+  console.log(
+    `::error::Invalid commit mixture - ${result.reason}. ` +
+      "Split the pull request, or retitle it to the class its commits carry. " +
+      "The squash merge keeps only the title.",
+  );
+}
+
+if (!release.ok) {
+  console.log(`::error::The title hides a release - ${release.reason}`);
+}
+
+if (result.ok && release.ok) {
+  console.log(
+    `::notice::Commit mixture is fine - ${result.reason}; ${release.reason}.`,
+  );
+  process.exit(0);
+}
+
+process.exit(1);

--- a/.github/scripts/commit-mixture-lib.mjs
+++ b/.github/scripts/commit-mixture-lib.mjs
@@ -1,0 +1,284 @@
+// @ts-check
+/**
+ * Commit-mixture classification — pure functions, no git / no IO.
+ *
+ * The repo squash-merges, so only the PR TITLE survives the merge: it becomes
+ * the release commit Lerna-Lite reads, and `commit-guard.yml`'s routing job
+ * checks that title against the target branch. A PR whose commits carry a
+ * higher release class than its title therefore smuggles that class past
+ * routing — a `feat:` commit under a `fix:` title lands a feature on `main`,
+ * and a breaking commit under either lands it on a standing line.
+ *
+ * Two rules, both about the classes a PR mixes:
+ *
+ * 1. At most ONE releasing class per PR. `feat` + `fix` cannot both be told in one
+ *    squash subject, and they route to different branches.
+ * 2. The title's class equals the commits' class. Anything else is either
+ *    smuggling (title lower) or mislabelling (title higher).
+ *
+ * Non-releasing commits mix freely: a feature with its docs, a fix with its
+ * test. And a commit whose subject is not a Conventional Commit is IGNORED —
+ * `wip`, `review feedback` and `fixup!` are normal on a branch, and failing on
+ * them would make the guard a nuisance rather than a gate.
+ */
+
+/** Release classes, ordered. `none` never conflicts with anything. */
+const CLASS_ORDER = ["none", "patch", "feature", "breaking"];
+
+/** Types that produce a patch release. */
+const PATCH_TYPES = new Set(["fix", "perf", "revert"]);
+
+/** Types that produce a feature release. */
+const FEATURE_TYPES = new Set(["feat", "feature"]);
+
+/** Types that release nothing. Keep in step with `commit-guard.yml`. */
+const NONE_TYPES = new Set([
+  "docs",
+  "style",
+  "chore",
+  "refactor",
+  "test",
+  "build",
+  "ci",
+]);
+
+/**
+ * Parse a Conventional Commit header.
+ *
+ * @param {string} subject
+ * @returns {{ type: string; scope?: string; breaking: boolean } | undefined}
+ */
+export function parseConventionalHeader(subject) {
+  const match = /^([a-z]+)(?:\(([^)]*)\))?(!)?:\s*(.+)$/.exec(
+    (subject ?? "").trim(),
+  );
+  if (!match) return undefined;
+  return { type: match[1], scope: match[2], breaking: match[3] === "!" };
+}
+
+/**
+ * The release class a commit belongs to.
+ *
+ * `undefined` means "cannot tell" — an unparsable subject or a type this
+ * repository does not know. Those are ignored rather than rejected.
+ *
+ * @param {{ subject: string; body?: string }} commit
+ * @returns {"none" | "patch" | "feature" | "breaking" | undefined}
+ */
+export function classifyCommit(commit) {
+  const header = parseConventionalHeader(commit.subject);
+  if (!header) return undefined;
+
+  // A footer marks a breaking change as loudly as the `!` does.
+  const declaresBreaking = /^BREAKING[ -]CHANGE:/m.test(commit.body ?? "");
+  if (header.breaking || declaresBreaking) return "breaking";
+
+  if (FEATURE_TYPES.has(header.type)) return "feature";
+  if (PATCH_TYPES.has(header.type)) return "patch";
+  if (NONE_TYPES.has(header.type)) return "none";
+  return undefined;
+}
+
+/**
+ * Does this PR mix classes it cannot express in one squash subject?
+ *
+ * @param {{ subject: string; body?: string }[]} commits
+ * @param {string} title The PR title — the future squash subject.
+ * @returns {{
+ *   ok: boolean;
+ *   reason: string;
+ *   titleClass: string | undefined;
+ *   commitClasses: string[];
+ *   offenders: { subject: string; class: string }[];
+ * }}
+ */
+export function classifyMixture(commits, title) {
+  const classified = commits
+    .map((commit) => ({ ...commit, class: classifyCommit(commit) }))
+    .filter((commit) => commit.class !== undefined);
+
+  const releasing = classified.filter((commit) => commit.class !== "none");
+  const commitClasses = [...new Set(releasing.map((commit) => commit.class))]
+    .filter((value) => typeof value === "string")
+    .sort((a, b) => CLASS_ORDER.indexOf(a) - CLASS_ORDER.indexOf(b));
+
+  const titleClass = classifyCommit({ subject: title });
+  const titleClassType = parseConventionalHeader(title)?.type ?? "that type";
+
+  if (commitClasses.length > 1) {
+    return {
+      ok: false,
+      reason:
+        `the commits mix ${commitClasses.join(" and ")} changes, and one squash ` +
+        "subject can only tell one of them",
+      titleClass,
+      commitClasses,
+      offenders: releasing.map((commit) => ({
+        subject: commit.subject,
+        class: /** @type {string} */ (commit.class),
+      })),
+    };
+  }
+
+  // One class, but several scopes: the squash keeps one subject, so every
+  // releasing commit outside the title's scope loses its description. Same
+  // information loss as a class mixture, one level down. Repeats WITHIN a scope
+  // are fine — `fix(List): a` plus `fix(List): b` is one logical change.
+  if (commitClasses.length === 1) {
+    const scopes = [
+      ...new Set(
+        releasing.map(
+          (commit) => parseConventionalHeader(commit.subject)?.scope ?? "",
+        ),
+      ),
+    ];
+    if (scopes.length > 1) {
+      return {
+        ok: false,
+        reason:
+          `the commits carry ${commitClasses[0]} changes in ${scopes.length} ` +
+          `different scopes (${scopes.map((scope) => scope || "none").join(", ")}) ` +
+          "and the squash merge keeps only one subject, so the others reach no " +
+          "changelog",
+        titleClass,
+        commitClasses,
+        offenders: releasing.map((commit) => ({
+          subject: commit.subject,
+          class: /** @type {string} */ (commit.class),
+        })),
+      };
+    }
+  }
+
+  // Nothing releasing, or nothing parsable: the title stands on its own.
+  if (commitClasses.length === 0) {
+    return {
+      ok: true,
+      reason:
+        classified.length === 0
+          ? "no commit carries a Conventional Commit subject — nothing to compare"
+          : "no commit carries a releasing type",
+      titleClass,
+      commitClasses,
+      offenders: [],
+    };
+  }
+
+  const commitClass = commitClasses[0];
+
+  if (titleClass === undefined) {
+    return {
+      ok: true,
+      reason: `the title is not a Conventional Commit — \`conventional-title\` reports that`,
+      titleClass,
+      commitClasses,
+      offenders: [],
+    };
+  }
+
+  if (titleClass === commitClass) {
+    return {
+      ok: true,
+      reason: `title and commits agree on \`${commitClass}\``,
+      titleClass,
+      commitClasses,
+      offenders: [],
+    };
+  }
+
+  const smuggling =
+    CLASS_ORDER.indexOf(commitClass) > CLASS_ORDER.indexOf(titleClass);
+
+  // Three different consequences, so three different messages. The one that
+  // bites most often is the first: a `fix:` commit under a `docs:` title is not
+  // routed wrongly, it is not released AT ALL.
+  let reason;
+  if (!smuggling) {
+    reason =
+      `the title claims ${titleClass} but no commit carries more than a ` +
+      `${commitClass} change`;
+  } else if (titleClass === "none") {
+    reason =
+      `the commits carry a ${commitClass} change but the title does not — the ` +
+      "squash merge keeps only the title, so the change ships (relevance is " +
+      `decided by the changed paths) while the changelog announces it as ` +
+      `\`${titleClassType}\` and its own description is discarded`;
+  } else {
+    reason =
+      `the commits carry a ${commitClass} change but the title claims ` +
+      `${titleClass} — routing reads the title, so it would land on the wrong line`;
+  }
+
+  return {
+    ok: false,
+    reason,
+    titleClass,
+    commitClasses,
+    offenders: releasing.map((commit) => ({
+      subject: commit.subject,
+      class: /** @type {string} */ (commit.class),
+    })),
+  };
+}
+
+/**
+ * Scopes whose titles are machine-generated, so no human chose the type.
+ *
+ * Dependabot writes `build(deps-dev): bump the dev-minor group …`, and a group
+ * is not homogeneous in effect: Rollup moves every `dist`, Prettier moves
+ * nothing. `commit-message.prefix` is configured per ecosystem, not per group,
+ * so no title Dependabot can produce would be true for all of them.
+ */
+const GENERATED_SCOPES = new Set(["deps", "deps-dev"]);
+
+/**
+ * Does the title admit that this pull request reaches a consumer?
+ *
+ * Checked in ONE direction only. A non-releasing type over shipping paths is
+ * the expensive mistake: the change ships — relevance is decided by the paths —
+ * while the changelog announces it as `docs`/`chore` and the commit's own
+ * description is discarded. The other direction (a `fix:` title over paths that
+ * reach nobody) costs nothing: the paths decide, so no release happens, and
+ * `fix(docs): …` for a docs-app fix is an honest title.
+ *
+ * The fix is a releasing type, not a tag: `fix(docs): add a migration entry`
+ * says both things at once — it ships, and it is documentation.
+ *
+ * @param {string} title
+ * @param {boolean} pathsPublish
+ * @returns {{ ok: boolean; reason: string }}
+ */
+export function classifyTitleRelease(title, pathsPublish) {
+  const header = parseConventionalHeader(title);
+
+  if (!header) {
+    return {
+      ok: true,
+      reason:
+        "the title is not a Conventional Commit — the title linter reports that",
+    };
+  }
+  if (header.scope !== undefined && GENERATED_SCOPES.has(header.scope)) {
+    return {
+      ok: true,
+      reason: `${header.type}(${header.scope}): is generated`,
+    };
+  }
+  if (!pathsPublish) {
+    return { ok: true, reason: "the changed paths reach no consumer" };
+  }
+
+  const titleClass = classifyCommit({ subject: title });
+  if (titleClass !== "none") {
+    return { ok: true, reason: `\`${header.type}\` admits that this releases` };
+  }
+
+  return {
+    ok: false,
+    reason:
+      `the changed paths reach a consumer but the title says \`${header.type}\`, ` +
+      "which does not — the change would ship while the changelog announces it " +
+      `as \`${header.type}\`. Use a releasing type and keep the scope: ` +
+      `\`fix(${header.scope ?? "scope"}): …\``,
+  };
+}

--- a/.github/scripts/commit-mixture-lib.test.mjs
+++ b/.github/scripts/commit-mixture-lib.test.mjs
@@ -1,0 +1,217 @@
+// @ts-check
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  classifyCommit,
+  classifyMixture,
+  classifyTitleRelease,
+} from "./commit-mixture-lib.mjs";
+
+const c = (subject, body) => ({ subject, body });
+
+test("classifyCommit: the type decides the class", () => {
+  assert.equal(classifyCommit(c("feat(List): add a prop")), "feature");
+  assert.equal(classifyCommit(c("fix(List): stop the crash")), "patch");
+  assert.equal(classifyCommit(c("perf(components): drop metadata")), "patch");
+  assert.equal(classifyCommit(c("revert(List): undo the prop")), "patch");
+  assert.equal(classifyCommit(c("docs: explain the prop")), "none");
+  assert.equal(classifyCommit(c("ci: shard the suite")), "none");
+});
+
+test("classifyCommit: both breaking markers count", () => {
+  assert.equal(classifyCommit(c("feat(List)!: drop the old prop")), "breaking");
+  assert.equal(
+    classifyCommit(
+      c("fix(List): tidy up", "BREAKING CHANGE: the prop is gone"),
+    ),
+    "breaking",
+  );
+  assert.equal(
+    classifyCommit(
+      c("fix(List): tidy up", "BREAKING-CHANGE: the prop is gone"),
+    ),
+    "breaking",
+  );
+});
+
+test("classifyCommit: a branch commit that is not conventional is ignored", () => {
+  for (const subject of [
+    "wip",
+    "review feedback",
+    "fixup! fix(List): stop the crash",
+    "Merge branch 'main' into feature",
+    "",
+  ]) {
+    assert.equal(classifyCommit(c(subject)), undefined, subject);
+  }
+  // An unknown type is unknown, not "none".
+  assert.equal(classifyCommit(c("wip(List): something")), undefined);
+});
+
+test("classifyMixture: one releasing class plus non-releasing ones is fine", () => {
+  const result = classifyMixture(
+    [
+      c("feat(List): add a prop"),
+      c("docs(List): document the prop"),
+      c("test(List): cover the prop"),
+      c("wip"),
+    ],
+    "feat(List): add a prop",
+  );
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.commitClasses, ["feature"]);
+});
+
+test("classifyMixture: feat and fix together cannot be squashed", () => {
+  const result = classifyMixture(
+    [c("fix(List): stop the crash"), c("feat(List): add a prop")],
+    "fix(List): stop the crash",
+  );
+  assert.equal(result.ok, false);
+  assert.match(result.reason, /mix patch and feature/);
+  assert.equal(result.offenders.length, 2);
+});
+
+test("classifyMixture: a breaking commit under a fix title is smuggling", () => {
+  const result = classifyMixture(
+    [c("fix(List): tidy up", "BREAKING CHANGE: the prop is gone")],
+    "fix(List): tidy up",
+  );
+  assert.equal(result.ok, false);
+  assert.match(result.reason, /routing reads the title/);
+});
+
+test("classifyMixture: a feat commit under a fix title is smuggling", () => {
+  // The dangerous direction: routing sends `fix:` to main, so the feature
+  // would land on the stable line.
+  const result = classifyMixture(
+    [c("feat(List): add a prop"), c("docs: mention it")],
+    "fix(List): add a prop",
+  );
+  assert.equal(result.ok, false);
+  assert.equal(result.titleClass, "patch");
+  assert.deepEqual(result.commitClasses, ["feature"]);
+});
+
+test("classifyMixture: a docs title announces a fix as documentation", () => {
+  // The common shape: the docs work is the headline and the fix rides along.
+  // Relevance is decided by the changed paths, so the fix DOES ship — but the
+  // squash keeps only the title, so the changelog files it under docs and the
+  // fix's own description is gone.
+  const result = classifyMixture(
+    [c("docs(List): document the states"), c("fix(List): stop the crash")],
+    "docs(List): document the states",
+  );
+  assert.equal(result.ok, false);
+  assert.equal(result.titleClass, "none");
+  assert.match(result.reason, /the changelog announces it as `docs`/);
+  assert.deepEqual(result.offenders, [
+    { subject: "fix(List): stop the crash", class: "patch" },
+  ]);
+});
+
+test("classifyMixture: releasing commits across scopes lose their descriptions", () => {
+  const result = classifyMixture(
+    [c("fix(List): stop the crash"), c("fix(Button): keep the label")],
+    "fix(List): stop the crash",
+  );
+  assert.equal(result.ok, false);
+  assert.match(result.reason, /2 different scopes \(List, Button\)/);
+
+  // Repeats within one scope are one logical change.
+  const sameScope = classifyMixture(
+    [c("fix(List): stop the crash"), c("fix(List): keep the selection")],
+    "fix(List): stop the crash",
+  );
+  assert.equal(sameScope.ok, true);
+
+  // And a scopeless pair is one scope, not two.
+  const scopeless = classifyMixture(
+    [c("fix: one thing"), c("fix: another thing")],
+    "fix: one thing",
+  );
+  assert.equal(scopeless.ok, true);
+});
+
+test("classifyMixture: a title claiming more than the commits is mislabelling", () => {
+  const result = classifyMixture(
+    [c("fix(List): stop the crash")],
+    "feat(List): stop the crash",
+  );
+  assert.equal(result.ok, false);
+  assert.match(result.reason, /no commit carries more than a patch change/);
+});
+
+test("classifyMixture: nothing releasing leaves the title alone", () => {
+  const docsOnly = classifyMixture(
+    [c("docs: a page"), c("ci: a workflow")],
+    "docs: a page",
+  );
+  assert.equal(docsOnly.ok, true);
+
+  // A docs-only branch may still be titled `fix:` — whether that releases is
+  // the release-intent guard's question, not this one's.
+  const titledFix = classifyMixture([c("docs: a page")], "fix(docs): a page");
+  assert.equal(titledFix.ok, true);
+
+  const nothingParsable = classifyMixture(
+    [c("wip"), c("more wip")],
+    "fix(x): y",
+  );
+  assert.equal(nothingParsable.ok, true);
+  assert.match(nothingParsable.reason, /nothing to compare/);
+});
+
+test("classifyMixture: an unconventional title is left to the title linter", () => {
+  const result = classifyMixture([c("feat(List): add a prop")], "add a prop");
+  assert.equal(result.ok, true);
+  assert.equal(result.titleClass, undefined);
+});
+
+test("classifyTitleRelease: a non-releasing title over shipping paths fails", () => {
+  // #2902 changed two `.module.scss` files under a `docs:` title.
+  const result = classifyTitleRelease("docs: set max text width", true);
+  assert.equal(result.ok, false);
+  assert.match(result.reason, /Use a releasing type and keep the scope/);
+
+  // #3062 — the fix is `fix(codemods):`, which says both things at once.
+  const scoped = classifyTitleRelease(
+    "docs(codemods): add a migration entry",
+    true,
+  );
+  assert.equal(scoped.ok, false);
+  assert.match(scoped.reason, /fix\(codemods\)/);
+});
+
+test("classifyTitleRelease: a releasing title admits it", () => {
+  for (const title of [
+    "fix(List): stop the crash",
+    "fix(docs): add a migration entry",
+    "feat(List): add a prop",
+    "perf(components): drop metadata",
+  ]) {
+    assert.equal(classifyTitleRelease(title, true).ok, true, title);
+  }
+});
+
+test("classifyTitleRelease: the other direction never fails", () => {
+  // A `fix(docs):` over the docs app reaches nobody, and the paths decide that
+  // — nothing to report. #3020 and #2993 are exactly this shape.
+  assert.equal(
+    classifyTitleRelease("fix(docs): stop the footer overflowing", false).ok,
+    true,
+  );
+  assert.equal(classifyTitleRelease("docs: a page", false).ok, true);
+});
+
+test("classifyTitleRelease: generated and unparsable titles are exempt", () => {
+  assert.equal(
+    classifyTitleRelease("build(deps-dev): bump the dev-minor group", true).ok,
+    true,
+  );
+  assert.equal(
+    classifyTitleRelease("build(deps): bump the production group", true).ok,
+    true,
+  );
+  assert.equal(classifyTitleRelease("add a prop", true).ok, true);
+});

--- a/.github/workflows/commit-guard.yml
+++ b/.github/workflows/commit-guard.yml
@@ -11,6 +11,11 @@ name: Commit guard
 #      - a breaking change (`feat!:` / `BREAKING CHANGE`) belongs on the major
 #        line, not on any standing line (`main` *or* `next`).
 #    This makes the dangerous directions mechanically hard.
+# 3. Commit mixture — the squash merge keeps only the TITLE, so the title has to
+#    be the whole truth about the branch. A PR that mixes a `feat:` and a `fix:`
+#    commit cannot be told in one subject; a `feat:` or breaking commit under a
+#    `fix:` title walks straight past routing onto `main`; and a non-releasing
+#    title over shipping paths announces a released change as documentation.
 
 on:
   pull_request:
@@ -156,3 +161,88 @@ jobs:
       - name: Enforce the version contract
         if: steps.gate.outputs.active == 'true'
         run: node .github/scripts/version-contract-guard.mjs
+
+  commit-mixture:
+    name: Commit mixture (one release class per PR)
+    # Same standing-line scope as routing: only PRs targeting a release line.
+    if: >-
+      github.event.pull_request.base.ref == 'main' ||
+      github.event.pull_request.base.ref == 'next'
+    runs-on: ubuntu-latest
+    env:
+      PR_TITLE: ${{ github.event.pull_request.title }}
+      HEAD_REF: ${{ github.event.pull_request.head.ref }}
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+    steps:
+      - name: Gate (promotion/sync exemptions)
+        id: gate
+        run: |
+          set -euo pipefail
+
+          # A promotion or sync source carries every class by design — that is
+          # what it is for (ADR 0004 §8) — so it is exempt, same as routing and
+          # the version contract.
+          if [ "$HEAD_REF" = "next" ] \
+             || printf '%s' "$HEAD_REF" | grep -qE '^([0-9]+\.(x|[0-9]+)|next-major)$' \
+             || printf '%s' "$HEAD_REF" | grep -qE '^(sync|release)/'; then
+            echo "::notice::head='${HEAD_REF}' is a promotion/sync source — commit-mixture guard exempt."
+            echo "active=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "active=true" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout (full history so the merge base is reachable)
+        if: steps.gate.outputs.active == 'true'
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
+
+      - name: Self-test the classifiers
+        if: steps.gate.outputs.active == 'true'
+        run: |
+          node --test .github/scripts/commit-mixture-lib.test.mjs
+          node --test .github/scripts/release-relevance-lib.test.mjs
+
+      # The same classifier the release gate runs, so both answer alike. It
+      # writes `publish=` to this step's outputs; the snapshots come out of git
+      # rather than the compare API, because this checkout has history.
+      - name: Classify the changed paths
+        id: relevance
+        if: steps.gate.outputs.active == 'true'
+        run: |
+          set -euo pipefail
+
+          base="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"
+          echo "base=${base}" >> "$GITHUB_OUTPUT"
+          files="$(git diff --name-only "${base}" "$HEAD_SHA")"
+
+          export MANIFEST_SNAPSHOT_DIR="${RUNNER_TEMP}/manifests"
+          mkdir -p "${MANIFEST_SNAPSHOT_DIR}/before" "${MANIFEST_SNAPSHOT_DIR}/after"
+          while IFS= read -r manifest; do
+            [ -n "$manifest" ] || continue
+            slug="$(printf '%s' "$manifest" | sed 's|/|__|g')"
+            git show "${base}:${manifest}" \
+              > "${MANIFEST_SNAPSHOT_DIR}/before/${slug}.json" 2>/dev/null \
+              || rm -f "${MANIFEST_SNAPSHOT_DIR}/before/${slug}.json"
+            git show "${HEAD_SHA}:${manifest}" \
+              > "${MANIFEST_SNAPSHOT_DIR}/after/${slug}.json" 2>/dev/null \
+              || rm -f "${MANIFEST_SNAPSHOT_DIR}/after/${slug}.json"
+          done <<< "$(printf '%s\n' "$files" \
+            | grep -E '^(package\.json|packages/[^/]+/package\.json)$' || true)"
+
+          printf '%s\n' "$files" \
+            | node .github/scripts/release-relevance-guard.mjs
+
+      - name: Check the commit mixture
+        if: steps.gate.outputs.active == 'true'
+        env:
+          # Empty when the step above could not answer — then that half is
+          # skipped rather than guessed.
+          PATHS_PUBLISH: ${{ steps.relevance.outputs.publish }}
+        run: |
+          set -euo pipefail
+          git log -z --reverse --format=%s%n%b \
+            "${{ steps.relevance.outputs.base }}..${HEAD_SHA}" \
+            | node .github/scripts/commit-mixture-guard.mjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,22 @@ and commit the results.
 
 - **Conventional Commits** with component/package scope — `fix(Button): …`,
   `feat(components): …`. Releases and changelogs are generated from them.
+- **One releasing change per pull request.** The squash merge keeps only the
+  title, and routing reads that title, so a branch may not
+  - mix a `feat:` and a `fix:` commit, nor hide a `feat:` or breaking commit
+    under a `fix:` title — that lands a feature or a breaking change on the
+    wrong line;
+  - carry a releasing commit under a non-releasing title — the change still
+    ships (the changed paths decide that) but the changelog announces it as
+    `docs`/`chore` and the commit's own description is discarded;
+  - spread releasing commits over several scopes — only one subject survives, so
+    the others reach no changelog. Repeats within one scope are fine.
+
+  A CI guard fails the PR on each, naming the offending commits. Non-releasing
+  commits (`docs`, `test`, `chore`, …) mix with anything, and a commit whose
+  subject is not a Conventional Commit (`wip`, `fixup!`) is ignored. Split the
+  PR, or retitle it to what its commits actually carry.
+
 - Merged PRs trigger the publish workflow (lerna-lite, fixed versioning across
   packages) — **unless the merge is docs-, CI- or tooling-only**, which
   publishes nothing at all (no npm release, no version bump commit, no tag, no


### PR DESCRIPTION
Routing only ever sees the PR **title**. The repo squash-merges, so that title becomes the release commit — which means a branch whose commits carry a higher release class than its title walks straight past the routing guard.

## What it catches

Everything below is information the squash merge destroys, because only the title survives.

| Case | What is lost |
| --- | --- |
| `feat:` and `fix:` commits in one PR | one subject cannot tell both; whichever the title omits disappears |
| a `feat:` commit under a `fix:` title | routing sends `fix:` to `main`, so the feature lands on the stable line |
| a breaking commit (`!` or a `BREAKING CHANGE:` footer) under a `fix:`/`feat:` title | routing sends it to a standing line instead of the major line |
| a releasing commit under a non-releasing title | the change still **ships** — relevance is decided by the changed paths — but the changelog announces it as `docs`/`chore`, and the commit's own description is discarded |
| releasing commits across **different scopes** | `fix(List):` plus `fix(Button):` keeps one subject, so the other fix reaches no changelog |
| a `feat:` title over nothing but `fix:` commits | the branch is mislabelled in the other direction — a minor for a patch |
| a **non-releasing title over shipping paths** | the fix folded *into* a `docs:` commit, where no commit subject says `fix` at all — #2902 changed two `.module.scss` files under `docs: set max text width` |

Repeats within one scope are fine: `fix(List): a` plus `fix(List): b` is one logical change, and the surviving subject still names it.

## What it deliberately allows

- **Non-releasing commits mix with anything** — a feature with its docs, a fix with its test, `chore`/`ci`/`refactor`/`style` alongside either.
- **A commit whose subject is not a Conventional Commit is ignored.** `wip`, `review feedback`, `fixup! …` and merge commits are normal on a branch; failing on them would make this a nuisance rather than a gate. An unknown type (`wip(List): …`) counts as unparsable, not as non-releasing.
- **A docs-only branch may still be titled `fix:`.** Whether that releases anything is a different question — the path-based release gate answers it.
- **Promotion and sync sources are exempt**, the same heads routing and the version contract already exempt (`next`, `x.x`, `sync/*`, `release/*`): they carry every class by design (ADR 0004 §8).

## The paths, in one direction

The last row needs more than the commit subjects, so the job runs the release gate's own classifier and fails when the changed paths reach a consumer while the title's type does not. **The remedy is a releasing type with the same scope** — `fix(docs): add a migration entry` says both things at once: it ships, and it is documentation. No tag, no second vocabulary.

Checked in one direction only. A `fix(docs):` title over paths that reach nobody costs nothing — the paths decide whether anything publishes, and `fix(docs):` for a docs-app fix is honest (#3020, #2993). Dependabot's generated `*(deps)` titles are exempt: a group is not homogeneous in effect and `commit-message.prefix` is per ecosystem, so no title it can produce would be true for all of it.

Over `main` since #2933 this half fires on **7 of 81** conventional merges — #2902, #3016 and #3062 (genuinely mislabelled), #3000 (a build config plus a dependency patch under `test:`), #2954 (honest docs that ships `components/AGENTS.md`, so it wants `fix(docs):`), and #2929 and #3013 where the classifier stays deliberately fail-safe.

## Shape

Follows the existing guard pattern in this repo — a pure lib, an IO shell, and a self-test the job runs before it:

- `.github/scripts/commit-mixture-lib.mjs` — `classifyCommit` and `classifyMixture`, no git, no IO
- `.github/scripts/commit-mixture-guard.mjs` — reads `git log -z --format=%s%n%b`, writes `::error::` per offending commit
- `.github/scripts/commit-mixture-lib.test.mjs` — 16 tests
- a `commit-mixture` job in `commit-guard.yml`, gated to PRs against `main`/`next`

`-z` rather than a textual record delimiter, because a commit body can contain any text but not a NUL.

## Verified

All 16 lib tests plus the real shapes through the guard end to end: `feat`+`fix` mixed fails naming both commits, a `feat` under a `fix` title fails as smuggling, a `BREAKING CHANGE:` footer under a `fix` title fails, a `fix` under a `docs` title fails naming the changelog consequence, two fixes in different scopes fail naming the scopes, two fixes in the same scope pass, `feat` + `docs` + `wip` passes, and a docs-only branch titled `fix(docs):` passes.

## Merge after #3098

This was reviewed as **#3102** and merged into the #3098 *branch* rather than into `main`; #3098 has now been pulled apart, and this is its own line, rebased onto current `main`.

It still **depends on #3098**, which sharpens the path classifier this guard runs:

- a package's root Markdown judged against its `files`, and `Dockerfile`/`.dockerignore` in the package-local denylist — without those, the path half would fire on #3009 and #3008, which reach nobody;
- the `MANIFEST_SNAPSHOT_DIR` protocol the `Classify the changed paths` step uses. Today's classifier reads `ROOT_MANIFEST_*` instead and ignores the snapshot dir, so until #3098 lands the manifest key-diff refinement is inert here and the classification stays conservative.

Independent of #3137 (the changelog preset) — no shared files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
