### PR TITLE
feat(List): let items declare the state they depend on

### DIFF
--- a/apps/docs/src/content/components/list/list/index.mdx
+++ b/apps/docs/src/content/components/list/list/index.mdx
@@ -259,6 +259,27 @@ vermieden. Zeigt deine Anwendung durchgängig eigene Ladezustände, kannst du
 
 ---
 
+# Item-Inhalte und externer State
+
+Ein Item wird neu gerendert, wenn sich seine Daten ändern oder wenn eine der
+Render-Funktionen an seinem `<List.Item />` ihre Identität wechselt. Eine inline
+im JSX geschriebene Funktion tut das bei jedem Render ihrer Elternkomponente –
+State aus der umgebenden Komponente erreicht das Item damit von allein.
+
+Hat die Render-Funktion eine stabile Identität – aus der Komponente
+herausgezogen, in `useCallback` gewrappt, oder sie liest aus einem externen
+Store –, fehlt dem Item dieses Signal und es behält die Werte, mit denen es
+zuerst gerendert wurde. Liste dann über `dependencies` auf, was die Funktion
+liest:
+
+```tsx
+<List.Item textValue={itemTextValue} dependencies={[selected]}>
+  {renderItem}
+</List.Item>
+```
+
+---
+
 # Daten laden
 
 Die List kann ihre Daten statisch oder asynchron laden.

--- a/packages/components/src/components/List/List.browser.test.tsx
+++ b/packages/components/src/components/List/List.browser.test.tsx
@@ -9,7 +9,7 @@ import {
   ListStaticData,
 } from "@/components/List";
 import type { AsyncDataLoader } from "@/components/List/model/loading/types";
-import { use, useState, type ReactNode } from "react";
+import { use, useState, useSyncExternalStore, type ReactNode } from "react";
 import { test, type Mock } from "vitest";
 import { page, userEvent } from "vitest/browser";
 import { RouterProvider } from "react-aria-components";
@@ -643,6 +643,70 @@ describe("Item rendering", () => {
 
   test("items follow state the consumer renders them from", async () => {
     await render(<SelectableList />);
+
+    await userEvent.click(page.getByText("Item: 42 unselected"));
+    await expect
+      .element(page.getByText("Item: 42 selected"))
+      .toBeInTheDocument();
+
+    await userEvent.click(page.getByText("Item: 42 selected"));
+    await expect
+      .element(page.getByText("Item: 42 unselected"))
+      .toBeInTheDocument();
+  });
+
+  // A render function whose identity never changes leaves the memoized item no
+  // signal to follow — `dependencies` is the consumer's way to give it one.
+  const store = {
+    selected: [] as number[],
+    version: 0,
+    listeners: new Set<() => void>(),
+    toggle(num: number) {
+      store.selected = store.selected.includes(num)
+        ? store.selected.filter((n) => n !== num)
+        : [...store.selected, num];
+      store.version++;
+      store.listeners.forEach((listener) => listener());
+    },
+  };
+
+  const subscribeToStore = (listener: () => void) => {
+    store.listeners.add(listener);
+    return () => {
+      store.listeners.delete(listener);
+    };
+  };
+
+  const renderStoreItem = ({ num }: Data) => (
+    <span>
+      Item: {num} {store.selected.includes(num) ? "selected" : "unselected"}
+    </span>
+  );
+
+  const storeItemTextValue = ({ num }: Data) => String(num);
+
+  const toggleStoreItem = ({ num }: Data) => {
+    store.toggle(num);
+  };
+
+  const StoreList = () => {
+    const version = useSyncExternalStore(subscribeToStore, () => store.version);
+
+    return (
+      <List aria-label="Test" onAction={toggleStoreItem}>
+        <ListStaticData<Data> data={selectableData} />
+        <ListItem<Data> textValue={storeItemTextValue} dependencies={[version]}>
+          {renderStoreItem}
+        </ListItem>
+      </List>
+    );
+  };
+
+  test("items follow the dependencies a stable render function declares", async () => {
+    store.selected = [];
+    store.version = 0;
+
+    await render(<StoreList />);
 
     await userEvent.click(page.getByText("Item: 42 unselected"));
     await expect

--- a/packages/components/src/components/List/model/item/ItemView.ts
+++ b/packages/components/src/components/List/model/item/ItemView.ts
@@ -1,4 +1,9 @@
-import type { HTMLAttributeAnchorTarget, ReactElement, ReactNode } from "react";
+import type {
+  DependencyList,
+  HTMLAttributeAnchorTarget,
+  ReactElement,
+  ReactNode,
+} from "react";
 import { createElement } from "react";
 import type { RenderItemFn } from "@/components/List/model/item/types";
 import type List from "@/components/List/model/List";
@@ -15,7 +20,25 @@ export interface ItemViewShape<T> {
   showList?: boolean;
   showTiles?: boolean;
   tileMaxWidth?: number;
+  /**
+   * Values this item's content depends on besides its own data.
+   *
+   * An item re-renders when its data changes, or when one of the render
+   * functions on its `List.Item` changes identity — which a function written
+   * inline in JSX does on every render of its parent. A render function with a
+   * stable identity (hoisted out of the component, wrapped in `useCallback`, or
+   * reading from an external store) has to list what it reads here, or the item
+   * keeps the values it first saw.
+   */
+  dependencies?: DependencyList;
 }
+
+const dependenciesAreEqual = (a?: DependencyList, b?: DependencyList) =>
+  a === b ||
+  (!!a &&
+    !!b &&
+    a.length === b.length &&
+    a.every((dependency, index) => Object.is(dependency, b[index])));
 
 export class ItemView<T> {
   public readonly list: List<T>;
@@ -27,6 +50,7 @@ export class ItemView<T> {
   public readonly showTiles?: boolean;
   public readonly showList?: boolean;
   public readonly tileMaxWidth: number;
+  public readonly dependencies?: DependencyList;
   private readonly renderFn?: RenderItemFn<T>;
 
   public constructor(list: List<T>, shape: ItemViewShape<T> = {}) {
@@ -41,6 +65,7 @@ export class ItemView<T> {
       showTiles,
       showList = true,
       tileMaxWidth = 230,
+      dependencies,
     } = shape;
     this.list = list;
     this.textValue = textValue;
@@ -52,6 +77,7 @@ export class ItemView<T> {
     this.showTiles = showTiles;
     this.showList = showList;
     this.tileMaxWidth = tileMaxWidth;
+    this.dependencies = dependencies;
   }
 
   private static fallbackRenderItemFn: RenderItemFn<never> = (item) =>
@@ -59,11 +85,13 @@ export class ItemView<T> {
 
   /**
    * Whether `other` would render this item identically — i.e. all render
-   * functions taken from the consumer's `ListItem` element are still the same.
+   * functions taken from the consumer's `ListItem` element are still the same,
+   * and the dependencies it declared have not changed.
    */
   public rendersSameAs(other?: ItemView<T>): boolean {
     return (
       !!other &&
+      dependenciesAreEqual(this.dependencies, other.dependencies) &&
       this.renderFn === other.renderFn &&
       this.textValue === other.textValue &&
       this.href === other.href &&


### PR DESCRIPTION
## What

`List.Item` takes a new optional `dependencies` prop, mirroring react-aria's `CollectionProps.dependencies`. Values listed there are compared alongside the item's render functions, so an item re-renders when they change.

## Why

#2777 reported that item content stays frozen on the values it first saw. [#3065](https://github.com/mittwald/flow/pull/3065) fixed the common half: items re-render when one of the render functions on their `List.Item` changes identity, which a function written inline in JSX does on every render of its parent. State from the surrounding component now reaches items on its own — verified against the issue's repro (`List.LoaderHooks` + a `Checkbox` reading `isSelected` from outside state) in both the local and the remote environment.

What remained is the case the issue's own notes point at: a render function with a **stable** identity — hoisted out of the component, wrapped in `useCallback`, or reading from an external store — gives the memoized item no signal to follow, and there was no way to supply one from the consumer side.

```tsx
<List.Item textValue={itemTextValue} dependencies={[selected]}>
  {renderItem}
</List.Item>
```

## How

`dependencies` lands on `ItemViewShape` and is compared in `ItemView.rendersSameAs` (length + `Object.is` per element) before the render-function identities. Additive and opt-in: omitting it keeps today's behaviour, including the memoization that stops existing items from re-rendering while loading more.

## Tests

`List.browser.test.tsx` → *Item rendering* gains a scenario whose render function, `textValue` and `onAction` all have stable identities and whose state lives in an external store. It fails on `next` without this change and passes with it — the pre-existing memoization test (infinite scroll) stays green.

fixes #2777

🤖 Generated with [Claude Code](https://claude.com/claude-code)