### PR TITLE
fix(Option): stop every option landing in the collection twice

### DIFF
--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -393,6 +393,20 @@ Easy-to-miss conventions not spelled out above. Full details and examples in
   icon-only padding silently do not apply. Wrap it — `<Icon><IconFoo /></Icon>`
   — as the [Icon page](https://flow.mittwald.de/components/content/icon)
   documents. Nothing errors: types, lint and the console stay clean.
+- **A collection child is rendered twice** — react-aria renders the children of
+  a collection (`Select`, `ComboBox`, `Autocomplete`, `Menu`, `ListBox`, `Tree`,
+  …) once into its hidden collection document and once for real. Both renders
+  are full component instances, so anything derived per instance happens twice
+  for one logical element: `useId` returns two ids, effects run twice, and every
+  registration into shared state lands twice. Whatever such a child registers
+  therefore needs an id derived from the element itself, not a generated one —
+  options pass their collection key as the tunnel's `staticEntryId`
+  (`Option/optionsTunnel.ts`), and a new tunnelled collection child must do the
+  same. Without it the tunnel exit renders each child twice: the keys stay
+  unique, so the DOM and the tests look right, but the collection holds two
+  nodes per key and its `prevKey`/`nextKey` chain closes into a ring — `ArrowUp`
+  on the first item wraps to the last, and react-stately's focus restoration
+  walks `getKeyBefore` forever and freezes the tab (#3146).
 - **Universal exports are deliberately explicit** — remote-safe values and their
   types are curated in `flr-universal.ts` independently of the main public
   surface; adding to `public.ts` does not add them there.

--- a/packages/components/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/components/Autocomplete/Autocomplete.tsx
@@ -1,3 +1,4 @@
+import { getOptionsTunnelProps } from "@/components/Option/optionsTunnel";
 import { useRef, type PropsWithChildren } from "react";
 import type { PropsWithClassName } from "@/lib/types/props";
 import { type PropsContext, PropsContextProvider } from "@/lib/propsContext";
@@ -102,10 +103,7 @@ export const Autocomplete = flowComponent("Autocomplete", (props) => {
     SearchField: inputProps,
     TextField: inputProps,
     Option: {
-      tunnel: {
-        id: "options",
-        component: "Autocomplete",
-      },
+      tunnel: getOptionsTunnelProps("Autocomplete"),
     },
     Popover: {
       className: styles.popover,

--- a/packages/components/src/components/ComboBox/ComboBox.tsx
+++ b/packages/components/src/components/ComboBox/ComboBox.tsx
@@ -12,6 +12,7 @@ import locales from "./locales/*.locale.json";
 import { useLocalizedStringFormatter } from "@/components/TranslationProvider/useLocalizedStringFormatter";
 import type { FlowComponentProps } from "@/lib/componentFactory/flowComponent";
 import { flowComponent } from "@/lib/componentFactory/flowComponent";
+import { getOptionsTunnelProps } from "@/components/Option/optionsTunnel";
 import { useOverlayController } from "@/lib/controller";
 import type { OptionsProps } from "@/components/Options/Options";
 import { useFieldComponent } from "@/lib/hooks/useFieldComponent";
@@ -55,10 +56,7 @@ export const ComboBox = flowComponent("ComboBox", (props) => {
 
   const propsContext: PropsContext = {
     Option: {
-      tunnel: {
-        id: "options",
-        component: "ComboBox",
-      },
+      tunnel: getOptionsTunnelProps("ComboBox"),
     },
     ...fieldPropsContext,
   };

--- a/packages/components/src/components/Option/Option.browser.test.tsx
+++ b/packages/components/src/components/Option/Option.browser.test.tsx
@@ -5,7 +5,7 @@ import { Select } from "@/components/Select";
 import { Text } from "@/components/Text";
 import type { ReactNode } from "react";
 import { expect, test, vi } from "vitest";
-import { page } from "vitest/browser";
+import { page, userEvent } from "vitest/browser";
 import { render } from "vitest-browser-react";
 
 /*
@@ -120,4 +120,41 @@ test("an explicit value silences the warning and wins over the children", async 
   expect(error.mock.calls.flat().join("\n")).not.toMatch(/Option.*no 'value'/s);
 
   error.mockRestore();
+});
+
+/*
+ * Flow routes options through a tunnel, and react-aria renders collection
+ * children twice — once into its hidden collection document, once for real.
+ * With a generated tunnel entry id both renders registered their own entry, so
+ * the exit rendered every option twice and the collection held two element
+ * nodes per key. The keys stayed unique, but the `prevKey`/`nextKey` links
+ * derived from that doubled sibling chain formed a ring: the first option's
+ * `prevKey` pointed at the last one.
+ *
+ * Visible as a wrapping `ArrowUp`; the expensive half is that react-stately's
+ * focus restoration walks `getKeyBefore` until it returns null, which in a ring
+ * never happens and blocks the main thread for good (#3028 is about the keys
+ * themselves, this is about the options being in the collection twice).
+ */
+const focusedOptionText = () =>
+  document
+    .querySelector("[role='option'][data-focused='true']")
+    ?.textContent?.trim();
+
+test("the option collection is a list, not a ring", async () => {
+  renderSelect();
+  await openOptions();
+
+  await userEvent.keyboard("{Home}");
+  await expect.poll(focusedOptionText).toMatch(/^Millennium Falcon/);
+
+  // In a ring this lands on the last option instead of staying put.
+  await userEvent.keyboard("{ArrowUp}");
+  await expect.poll(focusedOptionText).toMatch(/^Millennium Falcon/);
+
+  await userEvent.keyboard("{End}");
+  await expect.poll(focusedOptionText).toBe("TIE Fighter");
+
+  await userEvent.keyboard("{ArrowDown}");
+  await expect.poll(focusedOptionText).toBe("TIE Fighter");
 });

--- a/packages/components/src/components/Option/Option.tsx
+++ b/packages/components/src/components/Option/Option.tsx
@@ -26,16 +26,31 @@ export interface OptionProps
   value?: string | number;
 }
 
+/**
+ * The key an option contributes to its collection: an explicit `value`, else
+ * the `textValue`, else the text among the children. Shared with the props
+ * context that routes options through a field's tunnel, so both derive the same
+ * identity for one option.
+ */
+export const getOptionValue = (
+  props: Pick<OptionProps, "value" | "textValue" | "children">,
+): string | number | undefined =>
+  props.value ?? props.textValue ?? extractTextFromChildren(props.children);
+
 /** @flr-generate all */
 export const Option = flowComponent("Option", (props) => {
   const {
     className,
     children,
     textValue = extractTextFromChildren(children),
-    value = textValue,
+    // Derived through `getOptionValue` below; destructured only to keep it out
+    // of the props spread onto the react-aria item.
+    value: valueIgnored,
     ref,
     ...rest
   } = props;
+
+  const value = getOptionValue(props);
 
   useWarnMissingValue(value === undefined);
 

--- a/packages/components/src/components/Option/optionsTunnel.ts
+++ b/packages/components/src/components/Option/optionsTunnel.ts
@@ -1,0 +1,34 @@
+import type { FlowComponentName } from "@/components/propTypes";
+import { dynamic } from "@/lib/propsContext";
+import { getOptionValue } from "./Option";
+
+export const optionsTunnelId = "options";
+
+/**
+ * Props context entry that routes a field's `Option` children through its
+ * "options" tunnel.
+ *
+ * The entry id is the option's own collection key rather than a generated one.
+ * react-aria renders collection children twice — once into its hidden
+ * collection document, once for real — and both renders register a tunnel
+ * entry. With a generated id each render becomes its own entry, so the tunnel
+ * exit renders every option twice: the collection then holds two element nodes
+ * per key, and the `prevKey`/`nextKey` links derived from that doubled sibling
+ * chain form a ring. That ring makes `ArrowUp` on the first option wrap to the
+ * last one, and lets react-stately's focus restoration walk `getKeyBefore`
+ * forever, which freezes the tab.
+ *
+ * An option without a value keeps a generated id. Its collection key is a
+ * react-aria render counter in that case, which is unstable for other reasons
+ * already — `Option` warns about it.
+ */
+export const getOptionsTunnelProps = (component: FlowComponentName) =>
+  dynamic<"Option", "tunnel">((optionProps) => {
+    const value = getOptionValue(optionProps);
+
+    return {
+      id: optionsTunnelId,
+      component,
+      staticEntryId: value === undefined ? undefined : String(value),
+    };
+  });

--- a/packages/components/src/components/Select/Select.tsx
+++ b/packages/components/src/components/Select/Select.tsx
@@ -10,6 +10,7 @@ import { IconChevronDown } from "@/components/Icon/components/icons";
 import type { FlowComponentProps } from "@/lib/componentFactory/flowComponent";
 import { flowComponent } from "@/lib/componentFactory/flowComponent";
 import { Options } from "@/components/Options";
+import { getOptionsTunnelProps } from "@/components/Option/optionsTunnel";
 import type { PropsWithClassName } from "@/lib/types/props";
 import { useOverlayController } from "@/lib/controller";
 import { useFieldComponent } from "@/lib/hooks/useFieldComponent";
@@ -68,10 +69,7 @@ export const Select = flowComponent("Select", (props) => {
 
   const propsContext: PropsContext = {
     Option: {
-      tunnel: {
-        id: "options",
-        component: "Select",
-      },
+      tunnel: getOptionsTunnelProps("Select"),
     },
     ...fieldPropsContext,
   };

--- a/packages/components/src/components/Select/stories/EdgeCases.stories.tsx
+++ b/packages/components/src/components/Select/stories/EdgeCases.stories.tsx
@@ -1,7 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { Suspense, useState, type FC } from "react";
 import { Option } from "@/components/Option";
 import Select from "../index";
 import { Label } from "@/components/Label";
+import { LoadingSpinner } from "@/components/LoadingSpinner";
 import defaultMeta from "./Default.stories";
 import { dummyText } from "@/lib/dev/dummyText";
 
@@ -39,4 +41,79 @@ export const LongTexts: Story = {
         ))}
     </Select>
   ),
+};
+
+/*
+ * A resource that suspends once per version, so pressing the button makes a
+ * component *above* the Select suspend during an update — what a mutation plus
+ * cache invalidation produces in a real application. React swaps in the
+ * fallback and reveals the Select again once the resource resolves.
+ */
+const resolvedVersions = new Set<number>();
+const pendingVersions = new Map<number, Promise<void>>();
+
+const suspendUntilResolved = (version: number): void => {
+  if (version === 0 || resolvedVersions.has(version)) {
+    return;
+  }
+
+  let pending = pendingVersions.get(version);
+
+  if (!pending) {
+    pending = new Promise<void>((resolve) => {
+      setTimeout(() => {
+        resolvedVersions.add(version);
+        resolve();
+      }, 400);
+    });
+    pendingVersions.set(version, pending);
+  }
+
+  throw pending;
+};
+
+interface SuspendedContentProps {
+  version: number;
+  onReload: () => void;
+}
+
+const SuspendedContent: FC<SuspendedContentProps> = (props) => {
+  suspendUntilResolved(props.version);
+
+  return (
+    <>
+      <Select>
+        <Label>Starship</Label>
+        <Option value="falcon">Millennium Falcon</Option>
+        <Option value="x-wing">X-Wing</Option>
+        <Option value="tie">TIE Fighter</Option>
+      </Select>
+      <button type="button" onClick={props.onReload}>
+        Reload (suspends)
+      </button>
+    </>
+  );
+};
+
+const SuspendedSelect: FC = () => {
+  const [version, setVersion] = useState(0);
+
+  return (
+    <Suspense fallback={<LoadingSpinner />}>
+      <SuspendedContent
+        version={version}
+        onReload={() => setVersion((v) => v + 1)}
+      />
+    </Suspense>
+  );
+};
+
+/**
+ * The Select survives a component above it suspending: React swaps in the
+ * fallback and reveals the same Select again once the resource resolves. Used
+ * to leave the option collection with a ring-shaped `prevKey`/`nextKey` chain,
+ * which froze the tab — see `Option.browser.test.tsx`.
+ */
+export const Suspended: Story = {
+  render: () => <SuspendedSelect />,
 };

--- a/packages/components/src/lib/componentFactory/flowComponent.tsx
+++ b/packages/components/src/lib/componentFactory/flowComponent.tsx
@@ -142,7 +142,11 @@ export function flowComponent<C extends FlowComponentName>(
 
     if (tunnel) {
       element = (
-        <UiComponentTunnelEntry id={tunnel.id} component={tunnel.component}>
+        <UiComponentTunnelEntry
+          id={tunnel.id}
+          component={tunnel.component}
+          staticEntryId={tunnel.staticEntryId}
+        >
           {element}
         </UiComponentTunnelEntry>
       );

--- a/packages/components/src/lib/types/props.ts
+++ b/packages/components/src/lib/types/props.ts
@@ -21,6 +21,15 @@ export interface PropsWithTunnel {
   tunnel?: {
     id: string;
     component: FlowComponentName;
+    /**
+     * A stable entry id instead of a generated one. Needed wherever the same
+     * component is rendered more than once for a single logical element:
+     * react-aria renders collection children twice — once into its hidden
+     * collection document, once for real — and a generated id would register
+     * each render as its own entry, so the tunnel exit renders every element
+     * twice. Must be unique among the siblings of one tunnel.
+     */
+    staticEntryId?: string;
   } | null;
 }
 

--- a/packages/react-tunnel/src/Tunnel.browser.test.tsx
+++ b/packages/react-tunnel/src/Tunnel.browser.test.tsx
@@ -383,6 +383,70 @@ test("Order of multiple children is changed when entries are changing", async ()
   expect(dom.getByTestId("exit")).toHaveTextContent("ACB");
 });
 
+describe("Static entry id", () => {
+  /*
+   * A `staticEntryId` is shared on purpose: react-aria renders collection
+   * children twice — once into its hidden collection document, once for real —
+   * and both renders register the same entry. With a generated id each render
+   * became its own entry and the exit rendered every element twice.
+   */
+  test("Entries sharing a static entry id are rendered once", async () => {
+    const dom = await render(
+      <TunnelProvider>
+        <div data-testid="exit">
+          <TunnelExit />
+        </div>
+        <TunnelEntry staticEntryId="shared">A</TunnelEntry>
+        <TunnelEntry staticEntryId="shared">A</TunnelEntry>
+      </TunnelProvider>,
+    );
+
+    expect(dom.getByTestId("exit")).toHaveTextContent(/^A$/);
+  });
+
+  test("Content stays while one of the entries sharing a static entry id unmounts", async () => {
+    const Test: FC<{ renderSecondEntry: boolean }> = (props) => (
+      <TunnelProvider>
+        <div data-testid="exit">
+          <TunnelExit />
+        </div>
+        <TunnelEntry staticEntryId="shared">A</TunnelEntry>
+        {props.renderSecondEntry && (
+          <TunnelEntry staticEntryId="shared">A</TunnelEntry>
+        )}
+      </TunnelProvider>
+    );
+
+    const dom = await render(<Test renderSecondEntry />);
+    expect(dom.getByTestId("exit")).toHaveTextContent(/^A$/);
+
+    await dom.rerender(<Test renderSecondEntry={false} />);
+    expect(dom.getByTestId("exit")).toHaveTextContent(/^A$/);
+  });
+
+  test("Content is removed once the last entry sharing a static entry id unmounts", async () => {
+    const Test: FC<{ renderEntries: boolean }> = (props) => (
+      <TunnelProvider>
+        <div data-testid="exit">
+          <TunnelExit />
+        </div>
+        {props.renderEntries && (
+          <>
+            <TunnelEntry staticEntryId="shared">A</TunnelEntry>
+            <TunnelEntry staticEntryId="shared">A</TunnelEntry>
+          </>
+        )}
+      </TunnelProvider>
+    );
+
+    const dom = await render(<Test renderEntries />);
+    expect(dom.getByTestId("exit")).toHaveTextContent(/^A$/);
+
+    await dom.rerender(<Test renderEntries={false} />);
+    expect(dom.getByTestId("exit")).toHaveTextContent("");
+  });
+});
+
 vitest.useFakeTimers();
 
 test("Content is not rendered if removing previously suspended tunnel entry", async () => {
@@ -512,7 +576,7 @@ describe("Nested tunnel provider", () => {
 describe("SSR hydration", () => {
   test("getEntries is a pure read, idempotent across repeated render invocations", () => {
     const state = new TunnelState();
-    state.setRenderPhaseChildren("default", "entry-1", 0, "Hello!");
+    state.setRenderPhaseChildren("default", "entry-1", "owner-1", 0, "Hello!");
 
     // Read render-phase children (as the exit does during SSR / first render).
     const first = state.getEntries("default", true);

--- a/packages/react-tunnel/src/TunnelState.ts
+++ b/packages/react-tunnel/src/TunnelState.ts
@@ -14,6 +14,15 @@ interface TunnelEntryState {
   index: number;
   id: string;
   children: TunnelChildren;
+  /**
+   * The `TunnelEntry` instances currently registered under this entry id.
+   * Usually exactly one, but a `staticEntryId` is shared on purpose: react-aria
+   * renders collection children twice (once into its hidden collection
+   * document, once for real), and both renders register the same entry. The
+   * entry is only removed once the last of them unmounts — deleting it when the
+   * first one goes would drop content that is still being rendered.
+   */
+  owners: Set<string>;
 }
 
 interface TunnelEntries {
@@ -76,64 +85,120 @@ export class TunnelState {
     return thisIndex.current;
   }
 
-  public setChildren(
-    tunnelId: string = defaultId,
+  private buildEntryState(
+    previous: TunnelEntryState | undefined,
     entryId: string,
+    ownerId: string,
     index: number,
     children: TunnelChildren,
-  ): void {
-    const entryState: TunnelEntryState = {
+  ): TunnelEntryState {
+    const owners = new Set(previous?.owners);
+    owners.add(ownerId);
+
+    return {
       id: entryId,
       index,
       children,
+      owners,
     };
+  }
 
+  public setChildren(
+    tunnelId: string = defaultId,
+    entryId: string,
+    ownerId: string,
+    index: number,
+    children: TunnelChildren,
+  ): void {
     const tunnelEntries =
       this.committedChildren.get(tunnelId) ??
       observable.map<string, TunnelEntryState>({}, { deep: false });
 
-    tunnelEntries.set(entryId, entryState);
+    tunnelEntries.set(
+      entryId,
+      this.buildEntryState(
+        tunnelEntries.get(entryId),
+        entryId,
+        ownerId,
+        index,
+        children,
+      ),
+    );
 
-    this.renderPhaseChildren.get(tunnelId)?.delete(entryId);
+    this.deleteOwnerFromMap(
+      this.renderPhaseChildren,
+      tunnelId,
+      entryId,
+      ownerId,
+    );
     this.committedChildren.set(tunnelId, tunnelEntries);
   }
 
   public setRenderPhaseChildren(
     tunnelId: string = defaultId,
     entryId: string,
+    ownerId: string,
     index: number,
     children: TunnelChildren,
   ): void {
-    const entryState: TunnelEntryState = {
-      id: entryId,
-      index,
-      children,
-    };
-
     const tunnelEntries =
       this.renderPhaseChildren.get(tunnelId) ??
       new Map<string, TunnelEntryState>();
 
-    tunnelEntries.set(entryId, entryState);
+    tunnelEntries.set(
+      entryId,
+      this.buildEntryState(
+        tunnelEntries.get(entryId),
+        entryId,
+        ownerId,
+        index,
+        children,
+      ),
+    );
 
     this.renderPhaseChildren.set(tunnelId, tunnelEntries);
   }
 
-  private deleteChildrenFromMap(
+  private deleteOwnerFromMap(
     map: Map<string, Map<string, TunnelEntryState>>,
     tunnelId: string,
     entryId: string,
+    ownerId: string,
   ): void {
     const mapEntries = map.get(tunnelId);
-    mapEntries?.delete(entryId);
-    if (mapEntries?.size === 0) {
+    const entry = mapEntries?.get(entryId);
+
+    if (!mapEntries || !entry) {
+      return;
+    }
+
+    const owners = new Set(entry.owners);
+    owners.delete(ownerId);
+
+    if (owners.size > 0) {
+      mapEntries.set(entryId, { ...entry, owners });
+      return;
+    }
+
+    mapEntries.delete(entryId);
+
+    if (mapEntries.size === 0) {
       map.delete(tunnelId);
     }
   }
 
-  public deleteChildren(tunnelId: string = defaultId, entryId: string): void {
-    this.deleteChildrenFromMap(this.committedChildren, tunnelId, entryId);
-    this.deleteChildrenFromMap(this.renderPhaseChildren, tunnelId, entryId);
+  public deleteChildren(
+    tunnelId: string = defaultId,
+    entryId: string,
+    ownerId: string,
+  ): void {
+    this.deleteOwnerFromMap(this.committedChildren, tunnelId, entryId, ownerId);
+    this.deleteOwnerFromMap(
+      this.renderPhaseChildren,
+      tunnelId,
+      entryId,
+      ownerId,
+    );
   }
 
   // Pure read — never mutate during render. `getEntries` runs inside the

--- a/packages/react-tunnel/src/components/TunnelEntry.tsx
+++ b/packages/react-tunnel/src/components/TunnelEntry.tsx
@@ -17,20 +17,24 @@ export interface TunnelEntryProps {
 export const TunnelEntry: FC<TunnelEntryProps> = (props) => {
   const { children, id, staticEntryId, providerId } = props;
   const tunnel = useTunnelState(providerId);
-  const usedId = useId();
-  const entryId = staticEntryId ?? usedId;
+  /**
+   * Identifies this entry instance, as opposed to `entryId`, which a
+   * `staticEntryId` deliberately shares between several instances.
+   */
+  const ownerId = useId();
+  const entryId = staticEntryId ?? ownerId;
   const index = tunnel.useEntryIndex();
 
   const mounted = useRef(false);
 
   if (!mounted.current) {
-    tunnel.setRenderPhaseChildren(id, entryId, index, children);
+    tunnel.setRenderPhaseChildren(id, entryId, ownerId, index, children);
   }
 
   useLayoutEffect(() => {
     mounted.current = true;
-    tunnel.setChildren(id, entryId, index, children);
-  }, [children, id, entryId, index, providerId]);
+    tunnel.setChildren(id, entryId, ownerId, index, children);
+  }, [children, id, entryId, ownerId, index, providerId]);
 
   useEffect(() => {
     /**
@@ -40,9 +44,9 @@ export const TunnelEntry: FC<TunnelEntryProps> = (props) => {
      * in the TunnelExit may be disrupted as well.
      */
     return () => {
-      tunnel.deleteChildren(id, entryId);
+      tunnel.deleteChildren(id, entryId, ownerId);
     };
-  }, [id, entryId, providerId]);
+  }, [id, entryId, ownerId, providerId]);
 
   return null;
 };

--- a/packages/react-tunnel/src/components/TunnelEntry.tsx
+++ b/packages/react-tunnel/src/components/TunnelEntry.tsx
@@ -8,7 +8,20 @@ export type TunnelEntryChildren =
 export interface TunnelEntryProps {
   id?: string;
   children?: TunnelEntryChildren;
-  /** Static entry ID instead of generated ID by `useId` */
+  /**
+   * Static entry ID instead of generated ID by `useId`.
+   *
+   * Needed wherever one logical element is rendered by more than one component
+   * instance — react-aria, for example, renders the children of a collection
+   * twice: once into its hidden collection document, once for real. Each
+   * instance generates its own `useId`, so with a generated entry id the exit
+   * renders the element once per instance. A static id derived from the element
+   * itself collapses them into one entry; the entry is kept until the last of
+   * the instances unmounts.
+   *
+   * Must be unique among the siblings of one tunnel — two unrelated entries
+   * sharing an id overwrite each other.
+   */
   staticEntryId?: string;
   /** Select a dedicated tunnel provider by ID. */
   providerId?: string;


### PR DESCRIPTION
## Problem

react-aria renders collection children twice — once into its hidden collection document, once for real. Flow's option tunnel registered an entry in **both** renders, so every option ended up in the collection twice.

The keys stayed unique, but the "previous/next" links the collection derives from that doubled list formed a **ring**: the first option's previous pointed at the last one. Every Flow `Select` was in that state from the first render on.

Two effects:

- `ArrowUp` on the first option jumps to the last one instead of staying put.
- react-stately's focus handling walks "previous" until it hits the start. In a ring it never does — the loop never ends and the browser tab freezes for good. That is how this surfaced: saving in a modal froze the tab.

## Fix

The tunnel entry now uses the option's own key instead of a generated id, so both renders share one entry.

That makes one entry id shared on purpose, so the tunnel now tracks which instances registered an entry and only drops it once the last one is gone. Dropping it when the first one unmounts would take content that is still on screen.

An option without a value keeps a generated id — its collection key is already unstable for other reasons, and `Option` warns about that.

Affects `Select`, `ComboBox` and `Autocomplete`; all three route options through the tunnel.

## Tests

- `Option.browser.test.tsx` — "the option collection is a list, not a ring": `Home`/`ArrowUp`/`End`/`ArrowDown`. Verified it actually catches the bug: with the fix disabled, the `ArrowUp` assertion fails and nothing else does.
- `Tunnel.browser.test.tsx` — three tests for a shared entry id: rendered once, content survives one registrant unmounting, content goes when the last one does.
- New `Suspended` story on Select, the situation this was found in.

Full suite green: 284 browser tests (components), 26 (react-tunnel), 344 unit tests, compile, links, lint, format. `pnpm build` produces no generated diff.

Worth adding the `run-visual-tests` label — the rendered output should be unchanged, the duplicates never reached the real DOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)