### PR TITLE
fix(Image): keep sizing from style when no size props are given

### DIFF
--- a/packages/components/src/components/Image/Image.browser.test.tsx
+++ b/packages/components/src/components/Image/Image.browser.test.tsx
@@ -1,0 +1,36 @@
+import { expect, test } from "vitest";
+import { render } from "vitest-browser-react";
+import { Image } from "@/components/Image";
+
+const src =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='10'%3E%3C/svg%3E";
+
+const imageOf = (container: Element): HTMLImageElement =>
+  container.querySelector("img") as HTMLImageElement;
+
+test("keeps sizing from style when no size props are given", async () => {
+  const screen = await render(
+    <Image alt="" src={src} style={{ width: "100%", height: "50%" }} />,
+  );
+
+  const image = imageOf(screen.container);
+
+  expect(image.style.width).toBe("100%");
+  expect(image.style.height).toBe("50%");
+});
+
+test("prefers the size props over style", async () => {
+  const screen = await render(
+    <Image alt="" src={src} style={{ width: "100%" }} width={120} />,
+  );
+
+  expect(imageOf(screen.container).style.width).toBe("120px");
+});
+
+test("keeps aspectRatio from style when no aspectRatio prop is given", async () => {
+  const screen = await render(
+    <Image alt="" src={src} style={{ aspectRatio: "16 / 9" }} />,
+  );
+
+  expect(imageOf(screen.container).style.aspectRatio).toBe("16 / 9");
+});

--- a/packages/components/src/components/Image/Image.tsx
+++ b/packages/components/src/components/Image/Image.tsx
@@ -41,7 +41,12 @@ export const Image = flowComponent("Image", (props) => {
     <img
       ref={ref}
       className={rootClassName}
-      style={{ ...style, aspectRatio, width, height }}
+      style={{
+        ...style,
+        ...(aspectRatio !== undefined && { aspectRatio }),
+        ...(width !== undefined && { width }),
+        ...(height !== undefined && { height }),
+      }}
       {...rest}
     />
   );


### PR DESCRIPTION
## What & why

`Image` destructures `width`, `height` and `aspectRatio` out of props and then writes them into the style object **after** spreading the caller's `style`:

```tsx
style={{ ...style, aspectRatio, width, height }}
```

When those props are absent they are `undefined`, and that `undefined` overwrites whatever the caller passed in `style`. So this silently does nothing:

```tsx
<Image src={logo} style={{ width: "100%", maxWidth: "260px" }} />
```

The image falls back to its intrinsic width instead. `maxWidth` survives (it is not one of the destructured props), which makes the failure mode confusing: the size looks capped correctly as long as the asset happens to be wider than the cap, and silently changes the moment the asset is swapped for a narrower one. That is how we hit it in mStudio — replacing a logo with a narrower export shrank it, with no change to the consuming code.

Fix: only write the props that are actually defined. Props still win over `style` when both are given, so this is not a precedence change.

Added `Image.browser.test.tsx` covering the three cases: sizing from `style` survives, the props still take precedence, and the same for `aspectRatio`.

## Base branch & title

`fix:` → base `main`.

## Checklist

- [x] PR title is a Conventional Commit and matches the base branch above
- [x] `pnpm lint` is clean (0 errors) and `pnpm affected:test` passes; the new browser tests pass
- [x] **Generated code is committed** — no public API change, `git diff` is empty
- [x] User-facing strings — none added
- [x] Docs — no public API change

> Note: a full `components:test:browser` run showed one unrelated failure in `Option.browser.test.tsx` ("the option collection is a list, not a ring", Firefox). It passes in isolation (7/7) and does not touch `Image`, so it looks like an ordering-dependent flake rather than something this change caused.