### PR TITLE
ci(publish): assert every package reached npm before calling a release done

### DIFF
--- a/.github/scripts/publish-completeness-guard.mjs
+++ b/.github/scripts/publish-completeness-guard.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+// @ts-check
+/**
+ * Publish-completeness guard — fs/network shell around
+ * publish-completeness-lib.mjs.
+ *
+ * Fails (exit 1) when a publishable package does NOT resolve on the registry at
+ * the version this release shipped. Runs as the last step of `publish.yml`,
+ * after the push, the tag and the GitHub release — deliberately: `only_publish`
+ * (the remedy) publishes whatever the checked-out branch's manifests say, so
+ * failing before the push would leave the branch at N-1 while npm carries N,
+ * and the remedy would republish the wrong version.
+ *
+ * Exit codes: 0 complete · 1 hole, unverifiable or out of lockstep · 2 the
+ * guard could not run (bad `lerna.json`, no packages matched).
+ */
+import { appendFileSync, readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { dirname } from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+import { isLernaPackageDir } from "./version-consistency-lib.mjs";
+import {
+  backoffDelays,
+  classifyStatus,
+  collectOutOfLockstep,
+  collectPublishable,
+  renderReport,
+  verdict,
+} from "./publish-completeness-lib.mjs";
+
+const registry = (
+  process.env.NPM_REGISTRY ?? "https://registry.npmjs.org"
+).replace(/\/+$/, "");
+
+const lerna = JSON.parse(readFileSync("lerna.json", "utf8"));
+const patterns = lerna.packages ?? ["packages/*"];
+
+if (typeof lerna.version !== "string") {
+  console.error("::error::lerna.json has no top-level `version`.");
+  process.exit(2);
+}
+
+// Same pathspec trick as version-consistency-guard.mjs: a git wildcard matches
+// across `/`, so `*package.json` finds every manifest at any depth; `endsWith`
+// then drops the root manifest, which is not a package.
+const entries = execFileSync("git", ["ls-files", "*package.json"], {
+  encoding: "utf8",
+  maxBuffer: 64 * 1024 * 1024,
+})
+  .split("\n")
+  .map((line) => line.trim())
+  .filter((path) => path.endsWith("/package.json"))
+  .filter((path) => isLernaPackageDir(dirname(path), patterns))
+  .map((path) => ({ path, manifest: JSON.parse(readFileSync(path, "utf8")) }));
+
+const publishable = collectPublishable(entries);
+
+if (publishable.length === 0) {
+  console.error(
+    `::error::No publishable package matched the lerna.json globs (${patterns.join(", ")}).`,
+  );
+  process.exit(2);
+}
+
+/**
+ * One registry lookup against the exact-version endpoint: 200 the version
+ * exists, 404 it does not. Anything else says nothing — see `classifyStatus`.
+ *
+ * @param {{ name: string; version: string }} pkg
+ */
+async function probe(pkg) {
+  const url = `${registry}/${encodeURIComponent(pkg.name)}/${encodeURIComponent(pkg.version)}`;
+  try {
+    const response = await fetch(url, {
+      headers: { accept: "application/json" },
+      signal: AbortSignal.timeout(10_000),
+    });
+    return {
+      presence: classifyStatus(response.status),
+      detail: `HTTP ${response.status}`,
+    };
+  } catch (error) {
+    return {
+      presence: classifyStatus(0),
+      detail: error instanceof Error ? error.message : "request failed",
+    };
+  }
+}
+
+const outOfLockstep = collectOutOfLockstep(lerna.version, publishable);
+for (const pkg of outOfLockstep) {
+  console.log(
+    `::error file=${pkg.path}::${pkg.name} is at ${pkg.version} — lerna.json says ${lerna.version}`,
+  );
+}
+
+/** @type {Map<string, import("./publish-completeness-lib.mjs").Result>} */
+const seen = new Map();
+const delays = backoffDelays();
+let outstanding = publishable;
+
+for (let attempt = 0; ; attempt++) {
+  const probed = await Promise.all(
+    outstanding.map(async (pkg) => ({ pkg, ...(await probe(pkg)) })),
+  );
+
+  for (const { pkg, presence, detail } of probed) {
+    seen.set(pkg.name, {
+      name: pkg.name,
+      version: pkg.version,
+      presence,
+      detail,
+    });
+  }
+
+  outstanding = probed
+    .filter(({ presence }) => presence !== "present")
+    .map(({ pkg }) => pkg);
+
+  if (outstanding.length === 0 || attempt >= delays.length) break;
+
+  const names = outstanding.map((pkg) => pkg.name).join(", ");
+  console.log(
+    `${outstanding.length} package(s) not visible yet, re-checking in ${delays[attempt] / 1000}s: ${names}`,
+  );
+  await sleep(delays[attempt]);
+}
+
+const results = publishable.map(
+  (pkg) =>
+    /** @type {import("./publish-completeness-lib.mjs").Result} */ (
+      seen.get(pkg.name)
+    ),
+);
+const report = renderReport(lerna.version, results);
+
+console.log(report);
+
+if (process.env.GITHUB_STEP_SUMMARY) {
+  appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${report}\n`);
+}
+
+const { ok, missing, unknown } = verdict(results);
+
+for (const result of missing) {
+  console.log(
+    `::error::${result.name}@${result.version} is not on the registry — the publish reported success without shipping it.`,
+  );
+}
+
+for (const result of unknown) {
+  console.log(
+    `::warning::${result.name}@${result.version} could not be verified (${result.detail}).`,
+  );
+}
+
+if (ok && outOfLockstep.length === 0) {
+  console.log(
+    `Publish completeness OK — all ${results.length} package(s) resolve at ${lerna.version}.`,
+  );
+  process.exit(0);
+}
+
+if (missing.length > 0) {
+  console.error(
+    "::error::Incomplete release: a package was versioned, tagged and released but never reached npm. " +
+      "`workspace:*` packs as an EXACT pin, so the packages that DID publish can now demand a version " +
+      "that does not exist. Heal it by dispatching this workflow on the affected line with " +
+      "`only_publish: true` — it republishes exactly the missing packages, with no version bump.",
+  );
+}
+
+if (unknown.length > 0 && missing.length === 0) {
+  console.error(
+    "::error::Could not verify the release against the registry after the full retry budget. " +
+      "This is not proof of a hole — re-run this job before republishing anything.",
+  );
+}
+
+process.exit(1);

--- a/.github/scripts/publish-completeness-lib.mjs
+++ b/.github/scripts/publish-completeness-lib.mjs
@@ -1,0 +1,161 @@
+// @ts-check
+/**
+ * Publish-completeness classification — pure functions, no fs / no network.
+ *
+ * Fixed versioning ships all publishable packages as one release. A release
+ * that lands only some of them is not a smaller release: `workspace:*` becomes
+ * an EXACT pin at pack time, so a package that did publish can demand a version
+ * that does not exist. `@mittwald/flow-remote-react-components@1.1.31` pins
+ * `@mittwald/flow-remote-elements@1.1.31`, which the 1.1.31 run dropped —
+ * installing it fails with `ETARGET` (#2887).
+ *
+ * Such a hole is silent by construction. `lerna publish` treats npm's `409
+ * Failed to save packument` — the answer to a CONCURRENT write on the same
+ * package document — as "already published", warns, and exits 0 (lerna-lite
+ * `is-npm-js-publish-version-conflict.js`). The run is green, the tag and the
+ * GitHub release are cut, and the hole surfaces months later in a consumer's
+ * install. This module classifies what the registry answers so the run can go
+ * red instead.
+ *
+ * @typedef {{ name: unknown; version: unknown; private?: unknown }} Manifest
+ *
+ * @typedef {{ path: string; name: string; version: string }} Publishable
+ *
+ * @typedef {"present" | "missing" | "unknown"} Presence
+ *
+ * @typedef {{
+ *   name: string;
+ *   version: string;
+ *   presence: Presence;
+ *   detail?: string;
+ * }} Result
+ */
+
+/**
+ * The packages a publish is expected to land: every manifest Lerna-Lite manages
+ * that is not `private`. Mirrors lerna's own selection, so the guard can never
+ * check a different set than the publish shipped.
+ *
+ * `private` is read for TRUTHINESS, not for `=== true`, because that is what
+ * lerna-lite does (`Package.private` is `Boolean(manifest.private)`) — and the
+ * difference is live in this repo: `packages/core` declares the STRING
+ * `"private": "true"`. Comparing against the boolean makes the guard demand
+ * `@mittwald/flow-core` on npm, where it has never been published.
+ *
+ * @param {{ path: string; manifest: Manifest }[]} entries
+ * @returns {Publishable[]}
+ */
+export function collectPublishable(entries) {
+  /** @type {Publishable[]} */
+  const publishable = [];
+  for (const { path, manifest } of entries) {
+    if (manifest.private) continue;
+    if (
+      typeof manifest.name !== "string" ||
+      typeof manifest.version !== "string"
+    )
+      continue;
+    publishable.push({ path, name: manifest.name, version: manifest.version });
+  }
+  return publishable;
+}
+
+/**
+ * Packages whose manifest fell out of lockstep with `lerna.json`. Fixed
+ * versioning means they agree; when they do not, `lerna publish from-package`
+ * has already shipped what the MANIFEST says, so the release is split across
+ * two versions and the registry check below would be aimed at the wrong one.
+ *
+ * @param {string} lernaVersion
+ * @param {Publishable[]} publishable
+ * @returns {Publishable[]}
+ */
+export function collectOutOfLockstep(lernaVersion, publishable) {
+  return publishable.filter((pkg) => pkg.version !== lernaVersion);
+}
+
+/**
+ * What one registry answer says about a version's existence.
+ *
+ * `unknown` is deliberately NOT "missing": a 5xx, a rate limit or a dropped
+ * connection says nothing about the version, and reporting it as a hole would
+ * send someone republishing over a release that is already complete.
+ *
+ * @param {number} status HTTP status, or 0 when the request never completed.
+ * @returns {Presence}
+ */
+export function classifyStatus(status) {
+  if (status === 200) return "present";
+  if (status === 404) return "missing";
+  return "unknown";
+}
+
+/**
+ * Delays (ms) between re-checks of a package that did not answer `present`.
+ *
+ * The budget is load-bearing, not politeness. npm's registry is not immediately
+ * consistent across its CDN, so the version this very job just published can
+ * still 404. Only a package that is still not `present` after the whole
+ * schedule counts — a guard that fires false reds after a good publish gets
+ * ignored, and an ignored guard is worse than none.
+ *
+ * Five minutes, because seconds are not enough: on the 1.1.31 backfill (run
+ * 34577464400) `flow-remote-elements` and `flow-remote-react-renderer` were
+ * readable within seconds of the publish, while `flow-stylesheet` — published
+ * in the same command, between the two — kept answering 404 for minutes.
+ *
+ * Spent only on packages that look missing, so a complete release pays nothing.
+ *
+ * @returns {number[]} Eight delays, ~305s total.
+ */
+export function backoffDelays() {
+  return [5000, 10_000, 20_000, 30_000, 60_000, 60_000, 60_000, 60_000];
+}
+
+/**
+ * The run's verdict. `missing` fails it — that is the hole the guard exists
+ * for. `unknown` fails it too, but as a distinct outcome: the release may well
+ * be complete, and the remedy is to re-run the check, not to republish.
+ *
+ * @param {Result[]} results
+ */
+export function verdict(results) {
+  const missing = results.filter((r) => r.presence === "missing");
+  const unknown = results.filter((r) => r.presence === "unknown");
+  return { ok: missing.length === 0 && unknown.length === 0, missing, unknown };
+}
+
+/**
+ * Markdown table for the job summary — one row per package, so a red run shows
+ * WHICH packages are missing without anyone opening the raw log.
+ *
+ * @param {string} lernaVersion
+ * @param {Result[]} results
+ * @returns {string}
+ */
+export function renderReport(lernaVersion, results) {
+  const icon = { present: "✅", missing: "❌", unknown: "⚠️" };
+  const rows = results.map(
+    (r) =>
+      `| ${icon[r.presence]} | \`${r.name}\` | ${r.version} | ${r.detail ?? r.presence} |`,
+  );
+  const { ok, missing, unknown } = verdict(results);
+  // The headline claims no version: each row was checked at the MANIFEST's own
+  // version, which equals `lernaVersion` only while lockstep holds — and a
+  // report that says "all resolve at 1.1.31" over a row reading 1.1.30 is
+  // exactly the kind of false assurance this guard exists to remove.
+  const headline = ok
+    ? `All ${results.length} publishable package(s) resolve on the registry.`
+    : `${missing.length} missing, ${unknown.length} unverifiable of ${results.length} publishable package(s).`;
+
+  return [
+    `### Publish completeness — ${lernaVersion}`,
+    "",
+    headline,
+    "",
+    "|  | Package | Version | Registry |",
+    "| --- | --- | --- | --- |",
+    ...rows,
+    "",
+  ].join("\n");
+}

--- a/.github/scripts/publish-completeness-lib.test.mjs
+++ b/.github/scripts/publish-completeness-lib.test.mjs
@@ -1,0 +1,173 @@
+// @ts-check
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  backoffDelays,
+  classifyStatus,
+  collectOutOfLockstep,
+  collectPublishable,
+  renderReport,
+  verdict,
+} from "./publish-completeness-lib.mjs";
+
+/**
+ * @param {string} name
+ * @param {string} version
+ * @param {import("./publish-completeness-lib.mjs").Presence} presence
+ * @returns {import("./publish-completeness-lib.mjs").Result}
+ */
+const result = (name, version, presence) => ({ name, version, presence });
+
+test("collectPublishable: private packages are not expected on npm", () => {
+  assert.deepEqual(
+    collectPublishable([
+      {
+        path: "packages/a/package.json",
+        manifest: { name: "@scope/a", version: "1.0.0" },
+      },
+      {
+        path: "packages/core/package.json",
+        manifest: { name: "core", version: "1.0.0", private: true },
+      },
+    ]),
+    [{ path: "packages/a/package.json", name: "@scope/a", version: "1.0.0" }],
+  );
+});
+
+test("collectPublishable: `private` is truthy, as lerna reads it", () => {
+  // packages/core declares the STRING "true". lerna-lite's `Package.private` is
+  // `Boolean(manifest.private)`, so it never publishes it — and neither may the
+  // guard expect it on npm.
+  const publishable = collectPublishable([
+    {
+      path: "packages/core/package.json",
+      manifest: {
+        name: "@mittwald/flow-core",
+        version: "1.1.31",
+        private: "true",
+      },
+    },
+    {
+      path: "packages/a/package.json",
+      manifest: { name: "@scope/a", version: "1.1.31", private: false },
+    },
+  ]);
+  assert.deepEqual(
+    publishable.map((pkg) => pkg.name),
+    ["@scope/a"],
+  );
+});
+
+test("collectPublishable: a manifest without name or version is skipped", () => {
+  const publishable = collectPublishable([
+    {
+      path: "packages/a/package.json",
+      manifest: { name: "@scope/a", version: "1.0.0" },
+    },
+    { path: "packages/b/package.json", manifest: { name: "@scope/b" } },
+    { path: "packages/c/package.json", manifest: { version: "1.0.0" } },
+  ]);
+  assert.deepEqual(
+    publishable.map((pkg) => pkg.name),
+    ["@scope/a"],
+  );
+});
+
+test("collectOutOfLockstep: fixed versioning means every manifest matches lerna.json", () => {
+  const publishable = [
+    { path: "packages/a/package.json", name: "@scope/a", version: "1.1.31" },
+    { path: "packages/b/package.json", name: "@scope/b", version: "1.1.30" },
+  ];
+  assert.deepEqual(collectOutOfLockstep("1.1.31", publishable), [
+    publishable[1],
+  ]);
+  assert.deepEqual(collectOutOfLockstep("1.1.30", [publishable[1]]), []);
+});
+
+test("classifyStatus: only 404 proves absence", () => {
+  assert.equal(classifyStatus(200), "present");
+  assert.equal(classifyStatus(404), "missing");
+  // A registry that errors, rate-limits or never answers says NOTHING about the
+  // version — reporting that as a hole sends someone republishing a complete
+  // release.
+  assert.equal(classifyStatus(500), "unknown");
+  assert.equal(classifyStatus(429), "unknown");
+  assert.equal(classifyStatus(0), "unknown");
+});
+
+test("backoffDelays: the budget outlasts registry propagation", () => {
+  const delays = backoffDelays();
+  assert.ok(delays.length >= 5, "too few attempts to ride out a slow CDN");
+  // Measured: a package can stay 404 for minutes after its own publish.
+  const total = delays.reduce((sum, delay) => sum + delay, 0);
+  assert.ok(total >= 300_000, `budget is only ${total}ms`);
+  assert.deepEqual(
+    [...delays].sort((a, b) => a - b),
+    delays,
+    "delays must grow, not thrash the registry",
+  );
+});
+
+test("verdict: a complete release is ok", () => {
+  const results = [
+    result("@scope/a", "1.1.31", "present"),
+    result("@scope/b", "1.1.31", "present"),
+  ];
+  assert.deepEqual(verdict(results), { ok: true, missing: [], unknown: [] });
+});
+
+test("verdict: one missing package fails the run", () => {
+  // The 1.1.31 shape: 10 of 13 published, the run green (#2887).
+  const results = [
+    result("@scope/a", "1.1.31", "present"),
+    result("@scope/b", "1.1.31", "missing"),
+  ];
+  const { ok, missing, unknown } = verdict(results);
+  assert.equal(ok, false);
+  assert.deepEqual(
+    missing.map((r) => r.name),
+    ["@scope/b"],
+  );
+  assert.deepEqual(unknown, []);
+});
+
+test("verdict: unverifiable is its own outcome, not a hole", () => {
+  const results = [result("@scope/a", "1.1.31", "unknown")];
+  const { ok, missing, unknown } = verdict(results);
+  assert.equal(ok, false);
+  assert.deepEqual(missing, []);
+  assert.deepEqual(
+    unknown.map((r) => r.name),
+    ["@scope/a"],
+  );
+});
+
+test("renderReport: names the missing package and the version asked for", () => {
+  const report = renderReport("1.1.31", [
+    result("@mittwald/flow-react-components", "1.1.31", "present"),
+    result("@mittwald/flow-remote-elements", "1.1.31", "missing"),
+  ]);
+  assert.match(report, /1 missing, 0 unverifiable of 2 publishable/);
+  assert.match(report, /`@mittwald\/flow-remote-elements` \| 1\.1\.31/);
+  assert.match(report, /^\| --- \| --- \| --- \| --- \|$/m);
+});
+
+test("renderReport: a complete release says so, under the release's heading", () => {
+  const report = renderReport("1.1.31", [
+    result("@scope/a", "1.1.31", "present"),
+  ]);
+  assert.match(report, /^### Publish completeness — 1\.1\.31$/m);
+  assert.match(
+    report,
+    /All 1 publishable package\(s\) resolve on the registry\./,
+  );
+});
+
+test("renderReport: the headline never claims a version the rows contradict", () => {
+  // A manifest out of lockstep is checked at ITS version, not lerna.json's.
+  const report = renderReport("1.1.31", [
+    result("@scope/a", "1.1.30", "present"),
+  ]);
+  assert.doesNotMatch(report, /resolve at 1\.1\.31/);
+  assert.match(report, /\| 1\.1\.30 \|/);
+});

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -489,6 +489,12 @@ jobs:
           grep -qE "packageVersion *= *\"${v}\"" "${pkg}/dist/js/version.mjs" \
             || { echo "::error::${pkg}/dist/js/version.mjs does not stamp ${v} — the build ran against a stale manifest."; exit 1; }
 
+      # Before the publish, so a guard that cannot classify its own fixtures
+      # stops the release instead of waving it through — same precedent as the
+      # classifier self-test in `decide`. Sub-second; no network.
+      - name: Self-test the completeness guard
+        run: node --test .github/scripts/publish-completeness-lib.test.mjs
+
       # Provenance stays enabled (npm Trusted Publisher OIDC). A Rekor 409
       # ("equivalent entry already exists") is no longer fatal: @sigstore/sign is
       # patched (patches/@sigstore__sign@4.1.1.patch) to default fetchOnConflict
@@ -608,3 +614,27 @@ jobs:
           # `feat` PRs merge straight into `next`, so the window between the
           # release commit and this push is just as open here.
           node .github/scripts/push-release.mjs next "${tag}"
+
+      # LAST, after the push, the tag and the GitHub release — the assert that
+      # every publishable package actually reached npm at this version (#2887).
+      #
+      # `lerna publish` cannot be trusted to report this itself: it treats npm's
+      # `409 Failed to save packument` — the answer to a CONCURRENT write on the
+      # same package document — as "already published", warns, and exits 0
+      # (lerna-lite `is-npm-js-publish-version-conflict.js`). That is how 1.1.31
+      # shipped 10 of 13 packages from a green run, with the tag and the Release
+      # cut: the stable and the `next` line publish the SAME npm packages, their
+      # concurrency groups (`mutate-main` / `mutate-next`) do not serialize them
+      # against each other, and a forward-merge starts the second run seconds
+      # after the first. Both walked the same toposort at the same pace and
+      # collided on three packages. `flow-remote-react-components@1.1.31` then
+      # pinned a `flow-remote-elements@1.1.31` that did not exist — `workspace:*`
+      # packs as an EXACT pin, so the packages that DID publish were
+      # uninstallable.
+      #
+      # It runs last because the remedy is a dispatch with `only_publish`, which
+      # publishes whatever the branch's manifests say. Failing before the push
+      # would leave the branch at N-1 while npm carries N — and the remedy would
+      # then republish N-1, healing nothing.
+      - name: Assert the release is complete on npm 🔍
+        run: node .github/scripts/publish-completeness-guard.mjs

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -126,6 +126,9 @@ export default tseslint.config(
       globals: {
         process: "readonly",
         console: "readonly",
+        // Node >=24 — global since 18 (fetch) and 15 (AbortSignal).
+        fetch: "readonly",
+        AbortSignal: "readonly",
       },
     },
   },


### PR DESCRIPTION
## What & why

A green publish run is not proof that a release reached npm. `lerna publish`
maps npm's `409 Failed to save packument` — the answer to a **concurrent write
on the same package document** — to "already published": it warns and exits 0.

That is how **1.1.31 shipped 10 of 13 packages** ([run 34473093304][run]) with
the tag and the GitHub Release cut, and nobody noticed for a day:

```
lerna-lite WARN publish Package is already published: @mittwald/flow-stylesheet@1.1.31
lerna-lite WARN publish Package is already published: @mittwald/flow-remote-elements@1.1.31
lerna-lite WARN publish Package is already published: @mittwald/flow-remote-react-renderer@1.1.31
lerna-lite success published 10 packages
```

None of the three was published. `flow-remote-react-components@1.1.31` — the
`latest` an extension developer installs — pinned
`flow-remote-elements@1.1.31` (`workspace:*` packs as an **exact** pin), so:

```
npm error code ETARGET
npm error notarget No matching version found for @mittwald/flow-remote-elements@1.1.31.
```

The three were backfilled by a dispatch with `only_publish` ([run
34577464400][fix]); 1.1.31 is complete again.

**The collision needs no bad luck.** `main` and `next` publish the *same* npm
packages; their concurrency groups (`mutate-main` / `mutate-next`) serialize
each line against itself but not against the other, and `forward-merge.yml`
starts the `next` run seconds after the `main` one. Both then walk the same
toposort with `--concurrency 1` at the same pace. The two runs drifted into
lockstep and collided on three packages, to the second:

| Time (UTC) | `next` → 1.2.0-next.37 | `main` → 1.1.31 |
| --- | --- | --- |
| 11:51:05 | ✅ `flow-stylesheet` | ⚠️ "already published" |
| 11:51:12 | ✅ `flow-remote-elements` | ⚠️ "already published" |
| 11:51:19 | ✅ `flow-remote-react-renderer` | ⚠️ "already published" |

## What this adds

`publish.yml` now asserts, as its **last** step, that every publishable package
resolves on the registry at its manifest version — and fails the run naming the
packages and the remedy when one does not.

- `publish-completeness-lib.mjs` — pure classification (package selection
  mirroring lerna's rule, lockstep check against `lerna.json`, presence
  classification, retry budget, verdict, report)
- `publish-completeness-guard.mjs` — fs/network shell; writes a per-package
  table to the job summary
- `publish-completeness-lib.test.mjs` — 12 `node:test` cases, run by `test.yml`
  and self-tested in the publish job before the publish
- `eslint.config.js` — `fetch` / `AbortSignal` added to the globals for
  `.github/scripts/**/*.mjs`

Three decisions worth recording:

**It runs last, after push/tag/release.** The remedy is a dispatch with
`only_publish`, which publishes whatever the branch's manifests say. Failing
before the push would leave the branch at N-1 while npm carries N — and the
remedy would then republish N-1, healing nothing.

**A 404 is a hole; anything else is not.** A 5xx, a rate limit or a timeout says
nothing about the version. It fails the run too, but as a distinct outcome whose
remedy is "re-run this job", never "republish".

**The retry budget is ~305s, not seconds.** Measured on the backfill above:
`flow-stylesheet` kept answering 404 for minutes after its own publish, while
the two packages published beside it in the same command were readable within
seconds. A guard that fires false reds gets ignored.

## Verified

- `node --test .github/scripts/publish-completeness-lib.test.mjs` — 12/12
- Green path, live against npm: all 13 packages at 1.1.31, exit 0, 1.0s
- Red path, end-to-end in a scratch repo: exit 1, `::error::` per missing
  package plus the remedy, private package correctly excluded
- Lockstep path: a manifest off `lerna.json` fails the run and is checked at
  **its own** version, not `lerna.json`'s
- `pnpm format:check` clean; `eslint` clean on every file this PR touches

## Deliberately not in scope

- **The race itself.** Serializing the npm publish across both lines needs a
  shared job-level concurrency group, and GitHub keeps only one pending run per
  group — a queued publish could be dropped. Worth its own issue.
- **The upstream misclassification.** `E409 Failed to save packument` belongs in
  a retry, not in "already published" (lerna-lite
  `is-npm-js-publish-version-conflict.js`).
- **Dist-tag verification.** The guard checks that a version exists, not that
  `latest` / `next` point at it.

Proposed in #2887, closed 2026-08-25 with an implementation that is in no branch
of this repository — hence a fresh one, with the reasoning re-derived from the
1.1.31 evidence.

[run]: https://github.com/mittwald/flow/actions/runs/34473093304
[fix]: https://github.com/mittwald/flow/actions/runs/34577464400

## Checklist

- [x] PR title is a Conventional Commit and matches the base branch (`ci:` →
      `main`)
- [x] `eslint` / `prettier` clean on the files this PR touches
- [x] No generated code affected; no user-facing strings; no visual changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
